### PR TITLE
Refactor shared cluster strategy utilities

### DIFF
--- a/src/Clusterer/BeachOverYearsClusterStrategy.php
+++ b/src/Clusterer/BeachOverYearsClusterStrategy.php
@@ -6,7 +6,7 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +15,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
 final class BeachOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ClusterBuildHelperTrait;
+
+    /** @var list<string> */
+    private const KEYWORDS = ['strand', 'beach', 'meer', 'ocean', 'küste', 'kueste', 'coast', 'seaside', 'baltic', 'ostsee', 'nordsee', 'adriatic'];
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 6,
@@ -36,78 +41,20 @@ final class BeachOverYearsClusterStrategy implements ClusterStrategyInterface
     {
         $tz = new DateTimeZone($this->timezone);
 
-        /** @var array<int, array<string, list<Media>>> $byYearDay */
-        $byYearDay = [];
+        $byYearDay = $this->buildYearDayIndex(
+            $items,
+            $tz,
+            fn (Media $media, DateTimeImmutable $local): bool => $this->mediaPathContains($media, self::KEYWORDS)
+        );
 
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksBeach($path)) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $y = (int) $local->format('Y');
-            $d = $local->format('Y-m-d');
-            $byYearDay[$y] ??= [];
-            $byYearDay[$y][$d] ??= [];
-            $byYearDay[$y][$d][] = $m;
-        }
+        $best = $this->pickBestDayPerYear($byYearDay, $this->minItemsPerDay);
 
-        /** @var list<Media> $picked */
-        $picked = [];
-        /** @var array<int,bool> $years */
-        $years = [];
-
-        foreach ($byYearDay as $year => $days) {
-            // pick day with most items
-            $bestDay = null;
-            $bestCnt = 0;
-            foreach ($days as $d => $list) {
-                $c = \count($list);
-                if ($c >= $this->minItemsPerDay && $c > $bestCnt) {
-                    $bestCnt = $c;
-                    $bestDay = $d;
-                }
-            }
-            if ($bestDay === null) {
-                continue;
-            }
-            foreach ($days[$bestDay] as $m) {
-                $picked[] = $m;
-            }
-            $years[$year] = true;
-        }
-
-        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
-            return [];
-        }
-
-        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
-
-        return [
-            new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
-            ),
-        ];
-    }
-
-    private function looksBeach(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['strand', 'beach', 'meer', 'ocean', 'küste', 'kueste', 'coast', 'seaside', 'baltic', 'ostsee', 'nordsee', 'adriatic'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return $this->buildOverYearsDrafts(
+            $best['members'],
+            $best['years'],
+            $this->minYears,
+            $this->minItemsTotal,
+            $this->name()
+        );
     }
 }

--- a/src/Clusterer/MuseumOverYearsClusterStrategy.php
+++ b/src/Clusterer/MuseumOverYearsClusterStrategy.php
@@ -6,7 +6,7 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +15,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class MuseumOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ClusterBuildHelperTrait;
+
+    /** @var list<string> */
+    private const KEYWORDS = ['museum', 'galerie', 'gallery', 'ausstellung', 'exhibit', 'exhibition', 'kunsthalle'];
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 5,
@@ -36,77 +41,20 @@ final class MuseumOverYearsClusterStrategy implements ClusterStrategyInterface
     {
         $tz = new DateTimeZone($this->timezone);
 
-        /** @var array<int, array<string, list<Media>>> $byYearDay */
-        $byYearDay = [];
+        $byYearDay = $this->buildYearDayIndex(
+            $items,
+            $tz,
+            fn (Media $media, DateTimeImmutable $local): bool => $this->mediaPathContains($media, self::KEYWORDS)
+        );
 
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksMuseum($path)) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $y = (int) $local->format('Y');
-            $d = $local->format('Y-m-d');
-            $byYearDay[$y] ??= [];
-            $byYearDay[$y][$d] ??= [];
-            $byYearDay[$y][$d][] = $m;
-        }
+        $best = $this->pickBestDayPerYear($byYearDay, $this->minItemsPerDay);
 
-        /** @var list<Media> $picked */
-        $picked = [];
-        /** @var array<int,bool> $years */
-        $years = [];
-
-        foreach ($byYearDay as $year => $days) {
-            $bestDay = null;
-            $bestCnt = 0;
-            foreach ($days as $d => $list) {
-                $c = \count($list);
-                if ($c >= $this->minItemsPerDay && $c > $bestCnt) {
-                    $bestCnt = $c;
-                    $bestDay = $d;
-                }
-            }
-            if ($bestDay === null) {
-                continue;
-            }
-            foreach ($days[$bestDay] as $m) {
-                $picked[] = $m;
-            }
-            $years[$year] = true;
-        }
-
-        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
-            return [];
-        }
-
-        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
-
-        return [
-            new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
-            ),
-        ];
-    }
-
-    private function looksMuseum(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['museum', 'galerie', 'gallery', 'ausstellung', 'exhibit', 'exhibition', 'kunsthalle'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return $this->buildOverYearsDrafts(
+            $best['members'],
+            $best['years'],
+            $this->minYears,
+            $this->minItemsTotal,
+            $this->name()
+        );
     }
 }

--- a/src/Clusterer/SeasonOverYearsClusterStrategy.php
+++ b/src/Clusterer/SeasonOverYearsClusterStrategy.php
@@ -5,7 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class SeasonOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ClusterBuildHelperTrait;
+
     public function __construct(
         private readonly int $minYears = 3,
         private readonly int $minItems = 30
@@ -67,19 +69,13 @@ final class SeasonOverYearsClusterStrategy implements ClusterStrategyInterface
                 continue;
             }
 
-            \usort($list, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-            $centroid = MediaMath::centroid($list);
-            $time     = MediaMath::timeRange($list);
-
-            $out[] = new ClusterDraft(
+            $out[] = $this->buildClusterDraft(
                 algorithm: $this->name(),
+                members: $list,
                 params: [
-                    'label'      => $season . ' im Laufe der Jahre',
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $list)
+                    'label' => $season . ' im Laufe der Jahre',
+                    'years' => \array_values(\array_keys($years)),
+                ]
             );
         }
 

--- a/src/Clusterer/Support/ClusterBuildHelperTrait.php
+++ b/src/Clusterer/Support/ClusterBuildHelperTrait.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer\Support;
 
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 
@@ -54,5 +57,196 @@ trait ClusterBuildHelperTrait
             $from = 0;
         }
         return ['from' => $from, 'to' => $to];
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    private function sortByTakenAt(array $members): array
+    {
+        \usort($members, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
+
+        return $members;
+    }
+
+    /**
+     * @param list<Media> $members
+     * @param array<string,mixed> $params
+     */
+    private function buildClusterDraft(string $algorithm, array $members, array $params): ClusterDraft
+    {
+        $members = $this->sortByTakenAt($members);
+
+        $params['time_range'] ??= $this->computeTimeRange($members);
+
+        return new ClusterDraft(
+            algorithm: $algorithm,
+            params: $params,
+            centroid: $this->computeCentroid($members),
+            members: $this->toMemberIds($members)
+        );
+    }
+
+    /**
+     * @param list<Media> $items
+     * @param callable(Media, DateTimeImmutable):bool|null $filter
+     * @return array<int, array<string, list<Media>>>
+     */
+    private function buildYearDayIndex(array $items, DateTimeZone $timezone, ?callable $filter = null): array
+    {
+        $byYearDay = [];
+
+        foreach ($items as $media) {
+            $takenAt = $media->getTakenAt();
+            if (!$takenAt instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            $local = $takenAt->setTimezone($timezone);
+            if ($filter !== null && !$filter($media, $local)) {
+                continue;
+            }
+
+            $year = (int) $local->format('Y');
+            $day  = $local->format('Y-m-d');
+
+            $byYearDay[$year] ??= [];
+            $byYearDay[$year][$day] ??= [];
+            $byYearDay[$year][$day][] = $media;
+        }
+
+        return $byYearDay;
+    }
+
+    /**
+     * @param array<int, array<string, list<Media>>> $byYearDay
+     * @return array{members:list<Media>, years:array<int,bool>}
+     */
+    private function pickBestDayPerYear(array $byYearDay, int $minItemsPerDay): array
+    {
+        $picked = [];
+        $years  = [];
+
+        foreach ($byYearDay as $year => $days) {
+            $bestDay   = null;
+            $bestCount = 0;
+
+            foreach ($days as $day => $list) {
+                $count = \count($list);
+                if ($count >= $minItemsPerDay && $count > $bestCount) {
+                    $bestCount = $count;
+                    $bestDay   = $day;
+                }
+            }
+
+            if ($bestDay === null) {
+                continue;
+            }
+
+            foreach ($days[$bestDay] as $media) {
+                $picked[] = $media;
+            }
+            $years[$year] = true;
+        }
+
+        return ['members' => $picked, 'years' => $years];
+    }
+
+    /**
+     * @param list<Media> $members
+     * @param array<int,bool> $years
+     * @param array<string,mixed> $params
+     * @return list<ClusterDraft>
+     */
+    private function buildOverYearsDrafts(
+        array $members,
+        array $years,
+        int $minYears,
+        int $minItemsTotal,
+        string $algorithm,
+        array $params = []
+    ): array {
+        if (\count($years) < $minYears || \count($members) < $minItemsTotal) {
+            return [];
+        }
+
+        $params['years'] = \array_values(\array_keys($years));
+
+        return [
+            $this->buildClusterDraft($algorithm, $members, $params),
+        ];
+    }
+
+    /**
+     * @param array<string, list<Media>> $daysMap
+     * @return list<array{days:list<string>, items:list<Media>}>
+     */
+    private function buildConsecutiveRuns(array $daysMap): array
+    {
+        $days = \array_keys($daysMap);
+        \sort($days, \SORT_STRING);
+
+        $runs = [];
+        $runDays = [];
+        $runItems = [];
+        $prev = null;
+
+        $flush = function () use (&$runs, &$runDays, &$runItems): void {
+            if ($runDays === []) {
+                return;
+            }
+
+            $runs[] = ['days' => $runDays, 'items' => $runItems];
+            $runDays = [];
+            $runItems = [];
+        };
+
+        foreach ($days as $day) {
+            if ($prev !== null && !$this->isNextDay($prev, $day)) {
+                $flush();
+            }
+
+            $runDays[] = $day;
+            foreach ($daysMap[$day] as $media) {
+                $runItems[] = $media;
+            }
+            $prev = $day;
+        }
+
+        $flush();
+
+        return $runs;
+    }
+
+    private function isNextDay(string $a, string $b): bool
+    {
+        $ta = \strtotime($a . ' 00:00:00');
+        $tb = \strtotime($b . ' 00:00:00');
+        if ($ta === false || $tb === false) {
+            return false;
+        }
+        return ($tb - $ta) === 86400;
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function pathContainsKeyword(string $pathLower, array $keywords): bool
+    {
+        foreach ($keywords as $keyword) {
+            if (\str_contains($pathLower, $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function mediaPathContains(Media $media, array $keywords): bool
+    {
+        return $this->pathContainsKeyword(\strtolower($media->getPath()), $keywords);
     }
 }

--- a/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
@@ -6,7 +6,7 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +15,11 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class ZooAquariumOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ClusterBuildHelperTrait;
+
+    /** @var list<string> */
+    private const KEYWORDS = ['zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark'];
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 5,
@@ -36,76 +41,20 @@ final class ZooAquariumOverYearsClusterStrategy implements ClusterStrategyInterf
     {
         $tz = new DateTimeZone($this->timezone);
 
-        /** @var array<int, array<string, list<Media>>> $byYearDay */
-        $byYearDay = [];
+        $byYearDay = $this->buildYearDayIndex(
+            $items,
+            $tz,
+            fn (Media $media, DateTimeImmutable $local): bool => $this->mediaPathContains($media, self::KEYWORDS)
+        );
 
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksZoo($path)) {
-                continue;
-            }
-            $y = (int) $t->format('Y');
-            $d = $t->setTimezone($tz)->format('Y-m-d');
-            $byYearDay[$y] ??= [];
-            $byYearDay[$y][$d] ??= [];
-            $byYearDay[$y][$d][] = $m;
-        }
+        $best = $this->pickBestDayPerYear($byYearDay, $this->minItemsPerDay);
 
-        /** @var list<Media> $picked */
-        $picked = [];
-        /** @var array<int,bool> $years */
-        $years = [];
-
-        foreach ($byYearDay as $year => $days) {
-            $bestDay = null;
-            $bestCnt = 0;
-            foreach ($days as $d => $list) {
-                $c = \count($list);
-                if ($c >= $this->minItemsPerDay && $c > $bestCnt) {
-                    $bestCnt = $c;
-                    $bestDay = $d;
-                }
-            }
-            if ($bestDay === null) {
-                continue;
-            }
-            foreach ($days[$bestDay] as $m) {
-                $picked[] = $m;
-            }
-            $years[$year] = true;
-        }
-
-        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
-            return [];
-        }
-
-        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
-
-        return [
-            new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
-            ),
-        ];
-    }
-
-    private function looksZoo(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return $this->buildOverYearsDrafts(
+            $best['members'],
+            $best['years'],
+            $this->minYears,
+            $this->minItemsTotal,
+            $this->name()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- extend `ClusterBuildHelperTrait` with helpers for sorting media, grouping per day, building consecutive runs and composing cluster drafts to replace bespoke implementations
- refactor the beach, museum, zoo, panorama, season, this-month, camping, snow-vacation and weekend-getaway over-years strategies to lean on the shared helpers and keyword constants, eliminating duplicated centroid/time range calculations

## Testing
- `for f in src/Clusterer/Support/ClusterBuildHelperTrait.php src/Clusterer/BeachOverYearsClusterStrategy.php src/Clusterer/MuseumOverYearsClusterStrategy.php src/Clusterer/ZooAquariumOverYearsClusterStrategy.php src/Clusterer/PanoramaOverYearsClusterStrategy.php src/Clusterer/SeasonOverYearsClusterStrategy.php src/Clusterer/ThisMonthOverYearsClusterStrategy.php src/Clusterer/CampingOverYearsClusterStrategy.php src/Clusterer/SnowVacationOverYearsClusterStrategy.php src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php; do php -l "$f" || break; done`
- `composer ci:test:php:lint` *(fails: missing `bin/php` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e5eaf6408323927e22819ada0e36