### PR TITLE
Refactor cluster strategies to share reusable base logic

### DIFF
--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\PlaceLabelHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -12,6 +13,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 64])]
 final class AnniversaryClusterStrategy extends AbstractGroupedClusterStrategy
 {
+    use PlaceLabelHelperTrait;
+
     public function __construct(
         private readonly LocationHelper $locHelper,
         private readonly int $minItems = 3
@@ -42,13 +45,6 @@ final class AnniversaryClusterStrategy extends AbstractGroupedClusterStrategy
             return null;
         }
 
-        $label = $this->locHelper->majorityLabel($members);
-
-        $params = [];
-        if ($label !== null) {
-            $params['place'] = $label;
-        }
-
-        return $params;
+        return $this->withMajorityPlace($members);
     }
 }

--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
+use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 64])]
-final class AnniversaryClusterStrategy implements ClusterStrategyInterface
+final class AnniversaryClusterStrategy extends AbstractGroupedClusterStrategy
 {
-    use ClusterBuildHelperTrait;
-
     public function __construct(
-        private readonly LocationHelper $locHelper
+        private readonly LocationHelper $locHelper,
+        private readonly int $minItems = 3
     ) {
     }
 
@@ -24,43 +23,32 @@ final class AnniversaryClusterStrategy implements ClusterStrategyInterface
         return 'anniversary';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function groupKey(Media $media): ?string
     {
-        /** @var array<string, list<Media>> $byMonthDay */
-        $byMonthDay = [];
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if ($t instanceof DateTimeImmutable) {
-                $byMonthDay[$t->format('m-d')][] = $m;
-            }
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
         }
 
-        $drafts = [];
-        foreach ($byMonthDay as $group) {
-            if (\count($group) < 3) {
-                continue;
-            }
-            $label = $this->locHelper->majorityLabel($group);
+        return $takenAt->format('m-d');
+    }
 
-            $params = [
-                'time_range' => $this->computeTimeRange($group),
-            ];
-            if ($label !== null) {
-                $params['place'] = $label;
-            }
-
-            $drafts[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: $params,
-                centroid: $this->computeCentroid($group),
-                members: $this->toMemberIds($group)
-            );
+    /**
+     * @param list<Media> $members
+     */
+    protected function groupParams(string $key, array $members): ?array
+    {
+        if (\count($members) < $this->minItems) {
+            return null;
         }
 
-        return $drafts;
+        $label = $this->locHelper->majorityLabel($members);
+
+        $params = [];
+        if ($label !== null) {
+            $params['place'] = $label;
+        }
+
+        return $params;
     }
 }

--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -4,21 +4,23 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Clusterer\Support\PlaceLabelHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 64])]
-final class AnniversaryClusterStrategy extends AbstractGroupedClusterStrategy
+final class AnniversaryClusterStrategy extends AbstractTimezoneAwareGroupedClusterStrategy
 {
     use PlaceLabelHelperTrait;
 
     public function __construct(
         private readonly LocationHelper $locHelper,
-        private readonly int $minItems = 3
+        private readonly int $minItems = 3,
+        string $timezone = 'Europe/Berlin'
     ) {
+        parent::__construct($timezone);
     }
 
     public function name(): string
@@ -26,14 +28,9 @@ final class AnniversaryClusterStrategy extends AbstractGroupedClusterStrategy
         return 'anniversary';
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $takenAt = $media->getTakenAt();
-        if (!$takenAt instanceof DateTimeImmutable) {
-            return null;
-        }
-
-        return $takenAt->format('m-d');
+        return $local->format('m-d');
     }
 
     /**

--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -28,6 +28,14 @@ final class AnniversaryClusterStrategy extends AbstractTimezoneAwareGroupedClust
         return 'anniversary';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         return $local->format('m-d');
@@ -38,10 +46,6 @@ final class AnniversaryClusterStrategy extends AbstractTimezoneAwareGroupedClust
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         return $this->withMajorityPlace($members);
     }
 }

--- a/src/Clusterer/AtHomeWeekdayClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekdayClusterStrategy.php
@@ -3,27 +3,25 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\AbstractAtHomeClusterStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters home-based weekday sessions (Mon–Fri) when most photos are within a home radius.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 43])]
-final class AtHomeWeekdayClusterStrategy implements ClusterStrategyInterface
+final class AtHomeWeekdayClusterStrategy extends AbstractAtHomeClusterStrategy
 {
     public function __construct(
-        private readonly ?float $homeLat = null,
-        private readonly ?float $homeLon = null,
-        private readonly float $homeRadiusMeters = 300.0,
-        private readonly float $minHomeShare = 0.7,   // >= 70% of day's photos within radius
-        private readonly int $minItemsPerDay = 4,
-        private readonly int $minItemsTotal = 8,
-        private readonly string $timezone = 'Europe/Berlin'
+        ?float $homeLat = null,
+        ?float $homeLon = null,
+        float $homeRadiusMeters = 300.0,
+        float $minHomeShare = 0.7,
+        int $minItemsPerDay = 4,
+        int $minItemsTotal = 8,
+        string $timezone = 'Europe/Berlin'
     ) {
+        parent::__construct($homeLat, $homeLon, $homeRadiusMeters, $minHomeShare, $minItemsPerDay, $minItemsTotal, $timezone);
     }
 
     public function name(): string
@@ -31,143 +29,8 @@ final class AtHomeWeekdayClusterStrategy implements ClusterStrategyInterface
         return 'at_home_weekday';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function isDesiredDay(int $dayOfWeek): bool
     {
-        if ($this->homeLat === null || $this->homeLon === null) {
-            return [];
-        }
-
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $dow = (int) $local->format('N'); // 1=Mon..7=Sun
-            if ($dow < 1 || $dow > 5) {      // weekdays only
-                continue;
-            }
-            $key = $local->format('Y-m-d');
-            $byDay[$key] ??= [];
-            $byDay[$key][] = $m;
-        }
-
-        if ($byDay === []) {
-            return [];
-        }
-
-        /** @var array<string, list<Media>> $homeOnly */
-        $homeOnly = [];
-        /** @var list<string> $keepDays */
-        $keepDays = [];
-
-        foreach ($byDay as $day => $list) {
-            if (\count($list) < $this->minItemsPerDay) {
-                continue;
-            }
-
-            $within = [];
-            foreach ($list as $m) {
-                $lat = $m->getGpsLat();
-                $lon = $m->getGpsLon();
-                if ($lat === null || $lon === null) {
-                    continue;
-                }
-                $dist = MediaMath::haversineDistanceInMeters(
-                    (float) $lat,
-                    (float) $lon,
-                    (float) $this->homeLat,
-                    (float) $this->homeLon
-                );
-                if ($dist <= $this->homeRadiusMeters) {
-                    $within[] = $m;
-                }
-            }
-
-            if ($within === []) {
-                continue;
-            }
-
-            $share = \count($within) / (float) \count($list);
-            if ($share >= $this->minHomeShare) {
-                $homeOnly[$day] = $within;
-                $keepDays[] = $day;
-            }
-        }
-
-        if ($keepDays === []) {
-            return [];
-        }
-
-        \sort($keepDays, \SORT_STRING);
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<string> $run */
-        $run = [];
-
-        $flush = function () use (&$run, &$out, $homeOnly): void {
-            if (\count($run) === 0) {
-                return;
-            }
-
-            /** @var list<Media> $members */
-            $members = [];
-            foreach ($run as $d) {
-                foreach ($homeOnly[$d] as $m) {
-                    $members[] = $m;
-                }
-            }
-
-            if (\count($members) < $this->minItemsTotal) {
-                $run = [];
-                return;
-            }
-
-            $centroid = MediaMath::centroid($members);
-            $time     = MediaMath::timeRange($members);
-
-            $out[] = new ClusterDraft(
-                algorithm: 'at_home_weekday',
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-            );
-
-            $run = [];
-        };
-
-        $prev = null;
-        foreach ($keepDays as $d) {
-            if ($prev !== null && !$this->isNextDay($prev, $d)) {
-                $flush();
-            }
-            $run[] = $d;
-            $prev  = $d;
-        }
-        $flush();
-
-        return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
+        return $dayOfWeek >= 1 && $dayOfWeek <= 5;
     }
 }

--- a/src/Clusterer/AtHomeWeekendClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekendClusterStrategy.php
@@ -3,27 +3,25 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\AbstractAtHomeClusterStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters home-based weekend sessions: Saturday/Sunday where most photos are within a home radius.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 44])]
-final class AtHomeWeekendClusterStrategy implements ClusterStrategyInterface
+final class AtHomeWeekendClusterStrategy extends AbstractAtHomeClusterStrategy
 {
     public function __construct(
-        private readonly ?float $homeLat = null,
-        private readonly ?float $homeLon = null,
-        private readonly float $homeRadiusMeters = 300.0,
-        private readonly float $minHomeShare = 0.7,   // >= 70% of day's photos within radius
-        private readonly int $minItemsPerDay = 4,
-        private readonly int $minItemsTotal = 6,
-        private readonly string $timezone = 'Europe/Berlin'
+        ?float $homeLat = null,
+        ?float $homeLon = null,
+        float $homeRadiusMeters = 300.0,
+        float $minHomeShare = 0.7,
+        int $minItemsPerDay = 4,
+        int $minItemsTotal = 6,
+        string $timezone = 'Europe/Berlin'
     ) {
+        parent::__construct($homeLat, $homeLon, $homeRadiusMeters, $minHomeShare, $minItemsPerDay, $minItemsTotal, $timezone);
     }
 
     public function name(): string
@@ -31,144 +29,8 @@ final class AtHomeWeekendClusterStrategy implements ClusterStrategyInterface
         return 'at_home_weekend';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function isDesiredDay(int $dayOfWeek): bool
     {
-        if ($this->homeLat === null || $this->homeLon === null) {
-            return [];
-        }
-
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            // weekend only
-            $dow = (int) $local->format('N'); // 1=Mon..7=Sun
-            if ($dow !== 6 && $dow !== 7) {
-                continue;
-            }
-            $key = $local->format('Y-m-d');
-            $byDay[$key] ??= [];
-            $byDay[$key][] = $m;
-        }
-
-        if ($byDay === []) {
-            return [];
-        }
-
-        /** @var array<string, list<Media>> $homeOnly */
-        $homeOnly = [];
-        /** @var list<string> $keepDays */
-        $keepDays = [];
-
-        foreach ($byDay as $day => $list) {
-            if (\count($list) < $this->minItemsPerDay) {
-                continue;
-            }
-
-            $within = [];
-            foreach ($list as $m) {
-                $lat = $m->getGpsLat();
-                $lon = $m->getGpsLon();
-                if ($lat === null || $lon === null) {
-                    continue;
-                }
-                $dist = MediaMath::haversineDistanceInMeters(
-                    (float) $lat,
-                    (float) $lon,
-                    (float) $this->homeLat,
-                    (float) $this->homeLon
-                );
-                if ($dist <= $this->homeRadiusMeters) {
-                    $within[] = $m;
-                }
-            }
-
-            if ($within === []) {
-                continue;
-            }
-
-            $share = \count($within) / (float) \count($list);
-            if ($share >= $this->minHomeShare) {
-                $homeOnly[$day] = $within;
-                $keepDays[] = $day;
-            }
-        }
-
-        if ($keepDays === []) {
-            return [];
-        }
-
-        \sort($keepDays, \SORT_STRING);
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<string> $run */
-        $run = [];
-
-        $flush = function () use (&$run, &$out, $homeOnly): void {
-            if (\count($run) === 0) {
-                return;
-            }
-
-            /** @var list<Media> $members */
-            $members = [];
-            foreach ($run as $d) {
-                foreach ($homeOnly[$d] as $m) {
-                    $members[] = $m;
-                }
-            }
-
-            if (\count($members) < $this->minItemsTotal) {
-                $run = [];
-                return;
-            }
-
-            $centroid = MediaMath::centroid($members);
-            $time     = MediaMath::timeRange($members);
-
-            $out[] = new ClusterDraft(
-                algorithm: 'at_home_weekend',
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-            );
-
-            $run = [];
-        };
-
-        $prev = null;
-        foreach ($keepDays as $d) {
-            if ($prev !== null && !$this->isNextDay($prev, $d)) {
-                $flush();
-            }
-            $run[] = $d;
-            $prev  = $d;
-        }
-        $flush();
-
-        return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
+        return $dayOfWeek === 6 || $dayOfWeek === 7;
     }
 }

--- a/src/Clusterer/BeachOverYearsClusterStrategy.php
+++ b/src/Clusterer/BeachOverYearsClusterStrategy.php
@@ -3,29 +3,25 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
+use MagicSunday\Memories\Clusterer\Support\AbstractKeywordBestDayOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best "beach day" per year (based on filename keywords) and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
-final class BeachOverYearsClusterStrategy implements ClusterStrategyInterface
+final class BeachOverYearsClusterStrategy extends AbstractKeywordBestDayOverYearsStrategy
 {
-    use ClusterBuildHelperTrait;
-
     /** @var list<string> */
     private const KEYWORDS = ['strand', 'beach', 'meer', 'ocean', 'küste', 'kueste', 'coast', 'seaside', 'baltic', 'ostsee', 'nordsee', 'adriatic'];
 
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 6,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 24
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 6,
+        int $minYears = 3,
+        int $minItemsTotal = 24
     ) {
+        parent::__construct($timezone, $minItemsPerDay, $minYears, $minItemsTotal);
     }
 
     public function name(): string
@@ -34,27 +30,10 @@ final class BeachOverYearsClusterStrategy implements ClusterStrategyInterface
     }
 
     /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
+     * @return list<string>
      */
-    public function cluster(array $items): array
+    protected function keywords(): array
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        $byYearDay = $this->buildYearDayIndex(
-            $items,
-            $tz,
-            fn (Media $media, DateTimeImmutable $local): bool => $this->mediaPathContains($media, self::KEYWORDS)
-        );
-
-        $best = $this->pickBestDayPerYear($byYearDay, $this->minItemsPerDay);
-
-        return $this->buildOverYearsDrafts(
-            $best['members'],
-            $best['years'],
-            $this->minYears,
-            $this->minItemsTotal,
-            $this->name()
-        );
+        return self::KEYWORDS;
     }
 }

--- a/src/Clusterer/CampingOverYearsClusterStrategy.php
+++ b/src/Clusterer/CampingOverYearsClusterStrategy.php
@@ -3,34 +3,27 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
+use MagicSunday\Memories\Clusterer\Support\AbstractKeywordConsecutiveRunOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best multi-day camping run per year and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
-final class CampingOverYearsClusterStrategy implements ClusterStrategyInterface
+final class CampingOverYearsClusterStrategy extends AbstractKeywordConsecutiveRunOverYearsStrategy
 {
-    use ClusterBuildHelperTrait;
-
     /** @var list<string> */
     private const KEYWORDS = ['camping', 'zelt', 'zelten', 'wohnmobil', 'caravan', 'wohnwagen', 'campground', 'camp site', 'campsite', 'stellplatz'];
 
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 3,
-        private readonly int $minNights = 2,
-        private readonly int $maxNights = 14,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 24
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 3,
+        int $minNights = 2,
+        int $maxNights = 14,
+        int $minYears = 3,
+        int $minItemsTotal = 24
     ) {
-        if ($this->maxNights < $this->minNights) {
-            throw new \InvalidArgumentException('maxNights must be >= minNights.');
-        }
+        parent::__construct($timezone, $minNights, $maxNights, $minItemsPerDay, $minYears, $minItemsTotal);
     }
 
     public function name(): string
@@ -39,75 +32,10 @@ final class CampingOverYearsClusterStrategy implements ClusterStrategyInterface
     }
 
     /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
+     * @return list<string>
      */
-    public function cluster(array $items): array
+    protected function keywords(): array
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        $byYearDay = $this->buildYearDayIndex(
-            $items,
-            $tz,
-            fn (Media $media, DateTimeImmutable $local): bool => $this->mediaPathContains($media, self::KEYWORDS)
-        );
-
-        $picked = [];
-        $years  = [];
-
-        foreach ($byYearDay as $year => $daysMap) {
-            foreach ($daysMap as $day => $list) {
-                if (\count($list) < $this->minItemsPerDay) {
-                    unset($daysMap[$day]);
-                }
-            }
-
-            if ($daysMap === []) {
-                continue;
-            }
-
-            $runs = $this->buildConsecutiveRuns($daysMap);
-
-            $candidates = [];
-            foreach ($runs as $run) {
-                $nights = \count($run['days']) - 1;
-                if ($nights < $this->minNights || $nights > $this->maxNights) {
-                    continue;
-                }
-                $candidates[] = $run;
-            }
-
-            if ($candidates === []) {
-                continue;
-            }
-
-            \usort($candidates, static function (array $a, array $b): int {
-                $na = \count($a['items']);
-                $nb = \count($b['items']);
-                if ($na !== $nb) {
-                    return $na < $nb ? 1 : -1;
-                }
-                $sa = \count($a['days']);
-                $sb = \count($b['days']);
-                if ($sa !== $sb) {
-                    return $sa < $sb ? 1 : -1;
-                }
-                return \strcmp($a['days'][0], $b['days'][0]);
-            });
-
-            $best = $candidates[0];
-            foreach ($best['items'] as $media) {
-                $picked[] = $media;
-            }
-            $years[$year] = true;
-        }
-
-        return $this->buildOverYearsDrafts(
-            $picked,
-            $years,
-            $this->minYears,
-            $this->minItemsTotal,
-            $this->name()
-        );
+        return self::KEYWORDS;
     }
 }

--- a/src/Clusterer/CampingTripClusterStrategy.php
+++ b/src/Clusterer/CampingTripClusterStrategy.php
@@ -4,27 +4,38 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractConsecutiveRunClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Multi-day camping runs (consecutive days) using keywords.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 83])]
-final class CampingTripClusterStrategy implements ClusterStrategyInterface
+final class CampingTripClusterStrategy extends AbstractConsecutiveRunClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'camping',
+        'zelt',
+        'zelten',
+        'wohnmobil',
+        'caravan',
+        'wohnwagen',
+        'campground',
+        'camp site',
+        'campsite',
+        'stellplatz',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 3,
-        private readonly int $minNights = 2,
-        private readonly int $maxNights = 14,
-        private readonly int $minItemsTotal = 20
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 3,
+        int $minNights = 2,
+        int $maxNights = 14,
+        int $minItemsTotal = 20
     ) {
-        if ($this->maxNights < $this->minNights) {
-            throw new \InvalidArgumentException('maxNights must be >= minNights.');
-        }
+        parent::__construct($timezone, $minItemsPerDay, $minItemsTotal, $minNights, $maxNights);
     }
 
     public function name(): string
@@ -32,114 +43,8 @@ final class CampingTripClusterStrategy implements ClusterStrategyInterface
         return 'camping_trip';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksCamping($path)) {
-                continue;
-            }
-            $d = $t->setTimezone($tz)->format('Y-m-d');
-            $byDay[$d] ??= [];
-            $byDay[$d][] = $m;
-        }
-
-        if ($byDay === []) {
-            return [];
-        }
-
-        $days = \array_keys($byDay);
-        \sort($days, \SORT_STRING);
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<string> $run */
-        $run = [];
-        $prev = null;
-
-        $flush = function () use (&$run, &$out, $byDay): void {
-            if (\count($run) === 0) {
-                return;
-            }
-            $nights = \count($run) - 1;
-            if ($nights < $this->minNights || $nights > $this->maxNights) {
-                $run = [];
-                return;
-            }
-            /** @var list<Media> $members */
-            $members = [];
-            foreach ($run as $d) {
-                if (\count($byDay[$d]) < $this->minItemsPerDay) {
-                    $members = [];
-                    break;
-                }
-                foreach ($byDay[$d] as $m) {
-                    $members[] = $m;
-                }
-            }
-            if (\count($members) < $this->minItemsTotal) {
-                $run = [];
-                return;
-            }
-
-            \usort($members, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-            $centroid = MediaMath::centroid($members);
-            $time     = MediaMath::timeRange($members);
-
-            $out[] = new ClusterDraft(
-                algorithm: 'camping_trip',
-                params: [
-                    'nights'     => $nights,
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-            );
-
-            $run = [];
-        };
-
-        foreach ($days as $d) {
-            if ($prev !== null && !$this->isNextDay($prev, $d)) {
-                $flush();
-            }
-            $run[] = $d;
-            $prev  = $d;
-        }
-        $flush();
-
-        return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
-    }
-
-    private function looksCamping(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['camping', 'zelt', 'zelten', 'wohnmobil', 'caravan', 'wohnwagen', 'campground', 'camp site', 'campsite', 'stellplatz'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 }

--- a/src/Clusterer/CityscapeNightClusterStrategy.php
+++ b/src/Clusterer/CityscapeNightClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * City night sessions: night hours & urban keywords, spatially compact.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 76])]
-final class CityscapeNightClusterStrategy extends AbstractTimeGapClusterStrategy
+final class CityscapeNightClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = [
@@ -33,22 +33,20 @@ final class CityscapeNightClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'cityscape_night';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
     {
-        $hour = (int) $local->format('G');
-        if ($hour < 20 && $hour > 2) {
-            return false;
-        }
-
-        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return self::KEYWORDS;
     }
 
-    /**
-     * @param list<Media> $members
-     */
-    protected function isSessionValid(array $members): bool
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
-        return parent::isSessionValid($members)
-            && $this->allWithinRadius($members, $this->radiusMeters);
+        $hour = (int) $local->format('G');
+
+        return $hour >= 20 || $hour <= 2;
+    }
+
+    protected function sessionRadiusMeters(): ?float
+    {
+        return $this->radiusMeters;
     }
 }

--- a/src/Clusterer/CityscapeNightClusterStrategy.php
+++ b/src/Clusterer/CityscapeNightClusterStrategy.php
@@ -4,23 +4,28 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * City night sessions: night hours & urban keywords, spatially compact.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 76])]
-final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
+final class CityscapeNightClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'city', 'urban', 'downtown', 'skyline', 'hochhaus', 'skyscraper', 'street', 'straße', 'strasse', 'platz',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 2 * 3600,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 2 * 3600,
         private readonly float $radiusMeters = 350.0,
-        private readonly int $minItems = 5
+        int $minItems = 5
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,110 +33,22 @@ final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
         return 'cityscape_night';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $h = (int) $t->setTimezone($tz)->format('G');
-            $night = ($h >= 20 || $h <= 2);
-            if ($night === false) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if (!$this->looksUrban($path)) {
-                continue;
-            }
-            $cand[] = $m;
+        $hour = (int) $local->format('G');
+        if ($hour < 20 && $hour > 2) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn(Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            // spatial compactness if GPS exists
-            $ok = true;
-            foreach ($gps as $m) {
-                $d = MediaMath::haversineDistanceInMeters(
-                    (float)$centroid['lat'], (float)$centroid['lon'],
-                    (float)$m->getGpsLat(), (float)$m->getGpsLon()
-                );
-                if ($d > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if ($ok === false) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-            $out[] = new ClusterDraft(
-                algorithm: 'cityscape_night',
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksUrban(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = ['city', 'urban', 'downtown', 'skyline', 'hochhaus', 'skyscraper', 'street', 'straße', 'strasse', 'platz'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/CrossDimensionClusterStrategy.php
+++ b/src/Clusterer/CrossDimensionClusterStrategy.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\GeoMath;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -14,13 +13,14 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Sliding-session approach with time gap and radius constraints.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 68])]
-final class CrossDimensionClusterStrategy implements ClusterStrategyInterface
+final class CrossDimensionClusterStrategy extends AbstractTimeGapClusterStrategy
 {
     public function __construct(
-        private readonly int $timeGapSeconds = 2 * 3600,   // 2h
+        int $timeGapSeconds = 2 * 3600,   // 2h
         private readonly float $radiusMeters = 150.0,      // 150 m
-        private readonly int $minItems = 6
+        int $minItems = 6
     ) {
+        parent::__construct('UTC', $timeGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,88 +28,17 @@ final class CrossDimensionClusterStrategy implements ClusterStrategyInterface
         return 'cross_dimension';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        // Filter: need time; prefer GPS (we allow some without GPS as long as cluster centroid is stable)
-        $withTime = \array_values(\array_filter(
-            $items,
-            static fn (Media $m): bool => $m->getTakenAt() instanceof DateTimeImmutable
-        ));
+        return true;
+    }
 
-        if (\count($withTime) < $this->minItems) {
-            return [];
-        }
-
-        \usort($withTime, static function (Media $a, Media $b): int {
-            return $a->getTakenAt() <=> $b->getTakenAt();
-        });
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-
-        /** @var list<Media> $buf */
-        $buf = [];
-        $lastTs = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-
-            // compute centroid from GPS-having items; if none, centroid (0,0)
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== []
-                ? MediaMath::centroid($gps)
-                : ['lat' => 0.0, 'lon' => 0.0];
-
-            // Validate spatial compactness: max distance to centroid <= radius
-            $ok = true;
-            foreach ($gps as $m) {
-                $dist = MediaMath::haversineDistanceInMeters(
-                    $centroid['lat'],
-                    $centroid['lon'],
-                    (float) $m->getGpsLat(),
-                    (float) $m->getGpsLon()
-                );
-
-                if ($dist > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-
-            if ($ok) {
-                $time = MediaMath::timeRange($buf);
-                $out[] = new ClusterDraft(
-                    algorithm: 'cross_dimension',
-                    params: [
-                        'time_range' => $time,
-                    ],
-                    centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                    members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-                );
-            }
-
-            $buf = [];
-        };
-
-        foreach ($withTime as $m) {
-            $ts = (int) $m->getTakenAt()->getTimestamp();
-
-            if ($lastTs !== null && ($ts - $lastTs) > $this->timeGapSeconds) {
-                $flush();
-            }
-
-            $buf[] = $m;
-            $lastTs = $ts;
-        }
-        $flush();
-
-        return $out;
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
+    {
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/DayAlbumClusterStrategy.php
+++ b/src/Clusterer/DayAlbumClusterStrategy.php
@@ -26,6 +26,14 @@ final class DayAlbumClusterStrategy extends AbstractTimezoneAwareGroupedClusterS
         return 'day_album';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         return $local->format('Y-m-d');
@@ -36,10 +44,6 @@ final class DayAlbumClusterStrategy extends AbstractTimezoneAwareGroupedClusterS
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         return [
             'year' => (int) \substr($key, 0, 4),
         ];

--- a/src/Clusterer/DayAlbumClusterStrategy.php
+++ b/src/Clusterer/DayAlbumClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -25,13 +26,8 @@ final class DayAlbumClusterStrategy extends AbstractTimezoneAwareGroupedClusterS
         return 'day_album';
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
-
         return $local->format('Y-m-d');
     }
 

--- a/src/Clusterer/DeviceSimilarityStrategy.php
+++ b/src/Clusterer/DeviceSimilarityStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\PlaceLabelHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -12,6 +13,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 30])]
 final class DeviceSimilarityStrategy extends AbstractGroupedClusterStrategy
 {
+    use PlaceLabelHelperTrait;
+
     public function __construct(
         private readonly LocationHelper $locHelper,
         private readonly int $minItems = 5,
@@ -41,12 +44,6 @@ final class DeviceSimilarityStrategy extends AbstractGroupedClusterStrategy
             return null;
         }
 
-        $label = $this->locHelper->majorityLabel($members);
-
-        if ($label === null) {
-            return [];
-        }
-
-        return ['place' => $label];
+        return $this->withMajorityPlace($members);
     }
 }

--- a/src/Clusterer/DeviceSimilarityStrategy.php
+++ b/src/Clusterer/DeviceSimilarityStrategy.php
@@ -26,6 +26,14 @@ final class DeviceSimilarityStrategy extends AbstractGroupedClusterStrategy
         return 'device_similarity';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function groupKey(Media $media): ?string
     {
         $date = $media->getTakenAt() instanceof DateTimeImmutable
@@ -40,10 +48,6 @@ final class DeviceSimilarityStrategy extends AbstractGroupedClusterStrategy
 
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         return $this->withMajorityPlace($members);
     }
 }

--- a/src/Clusterer/DiningOutClusterStrategy.php
+++ b/src/Clusterer/DiningOutClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Detects dining-out moments based on evening hours and food/venue keywords; spatially compact sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 52])]
-final class DiningOutClusterStrategy extends AbstractTimeGapClusterStrategy
+final class DiningOutClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = [
@@ -37,22 +37,20 @@ final class DiningOutClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'dining_out';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
     {
-        $hour = (int) $local->format('G');
-        if ($hour < 17 || $hour > 23) {
-            return false;
-        }
-
-        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return self::KEYWORDS;
     }
 
-    /**
-     * @param list<Media> $members
-     */
-    protected function isSessionValid(array $members): bool
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
-        return parent::isSessionValid($members)
-            && $this->allWithinRadius($members, $this->radiusMeters);
+        $hour = (int) $local->format('G');
+
+        return $hour >= 17 && $hour <= 23;
+    }
+
+    protected function sessionRadiusMeters(): ?float
+    {
+        return $this->radiusMeters;
     }
 }

--- a/src/Clusterer/DiningOutClusterStrategy.php
+++ b/src/Clusterer/DiningOutClusterStrategy.php
@@ -4,23 +4,32 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects dining-out moments based on evening hours and food/venue keywords; spatially compact sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 52])]
-final class DiningOutClusterStrategy implements ClusterStrategyInterface
+final class DiningOutClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'restaurant', 'ristorante', 'trattoria', 'osteria', 'bistro',
+        'cafe', 'café', 'bar', 'kneipe', 'brauhaus',
+        'dinner', 'lunch', 'brunch', 'food', 'essen', 'speise',
+        'sushi', 'pizza', 'burger', 'steak', 'pasta', 'tapas',
+        'weingut', 'wine', 'wein', 'biergarten',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 2 * 3600,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 2 * 3600,
         private readonly float $radiusMeters = 250.0,
-        private readonly int $minItems = 4
+        int $minItems = 4
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,118 +37,22 @@ final class DiningOutClusterStrategy implements ClusterStrategyInterface
         return 'dining_out';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $h = (int) $t->setTimezone($tz)->format('G'); // 0..23
-            if ($h < 17 || $h > 23) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if (!$this->looksLikeDining($path)) {
-                continue;
-            }
-            $cand[] = $m;
+        $hour = (int) $local->format('G');
+        if ($hour < 17 || $hour > 23) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            // centroid from GPS subset; require spatial compactness if GPS exists
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            $ok = true;
-            foreach ($gps as $m) {
-                $dist = MediaMath::haversineDistanceInMeters(
-                    (float) $centroid['lat'],
-                    (float) $centroid['lon'],
-                    (float) $m->getGpsLat(),
-                    (float) $m->getGpsLon()
-                );
-                if ($dist > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if (!$ok) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksLikeDining(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = [
-            'restaurant', 'ristorante', 'trattoria', 'osteria', 'bistro',
-            'cafe', 'café', 'bar', 'kneipe', 'brauhaus',
-            'dinner', 'lunch', 'brunch', 'food', 'essen', 'speise',
-            'sushi', 'pizza', 'burger', 'steak', 'pasta', 'tapas',
-            'weingut', 'wine', 'wein', 'biergarten'
-        ];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/FestivalSummerClusterStrategy.php
+++ b/src/Clusterer/FestivalSummerClusterStrategy.php
@@ -4,23 +4,30 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Outdoor festival/open-air sessions in summer months.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 77])]
-final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
+final class FestivalSummerClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'festival', 'open air', 'openair', 'rock am ring', 'wacken',
+        'lollapalooza', 'fusion festival', 'parookaville', 'deichbrand',
+        'bühne', 'buehne', 'stage', 'headliner',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 3 * 3600,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 3 * 3600,
         private readonly float $radiusMeters = 600.0,
-        private readonly int $minItems = 8
+        int $minItems = 8
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,120 +35,27 @@ final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
         return 'festival_summer';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $mon = (int) $local->format('n');
-            if ($mon < 6 || $mon > 9) {
-                continue;
-            }
-            $h = (int) $local->format('G');
-            if ($h < 14 && $h > 2) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if (!$this->looksFestival($path)) {
-                continue;
-            }
-            $cand[] = $m;
+        $month = (int) $local->format('n');
+        if ($month < 6 || $month > 9) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
+        $hour = (int) $local->format('G');
+        if ($hour > 2 && $hour < 14) {
+            return false;
         }
 
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            // compactness for open-air area
-            $ok = true;
-            foreach ($gps as $m) {
-                $d = MediaMath::haversineDistanceInMeters(
-                    (float) $centroid['lat'], (float) $centroid['lon'],
-                    (float) $m->getGpsLat(), (float) $m->getGpsLon()
-                );
-                if ($d > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if ($ok === false) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksFestival(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = [
-            'festival', 'open air', 'openair', 'rock am ring', 'wacken',
-            'lollapalooza', 'fusion festival', 'parookaville', 'deichbrand',
-            'bühne', 'buehne', 'stage', 'headliner'
-        ];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/GoldenHourClusterStrategy.php
+++ b/src/Clusterer/GoldenHourClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Heuristic "Golden Hour" clusters around morning/evening hours.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 57])]
-final class GoldenHourClusterStrategy extends AbstractTimeGapClusterStrategy
+final class GoldenHourClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /**
      * @param list<int> $morningHours
@@ -33,7 +33,7 @@ final class GoldenHourClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'golden_hour';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
         $hour = (int) $local->format('G');
 

--- a/src/Clusterer/GoldenHourClusterStrategy.php
+++ b/src/Clusterer/GoldenHourClusterStrategy.php
@@ -4,25 +4,28 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Heuristic "Golden Hour" clusters around morning/evening hours.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 57])]
-final class GoldenHourClusterStrategy implements ClusterStrategyInterface
+final class GoldenHourClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /**
+     * @param list<int> $morningHours
+     * @param list<int> $eveningHours
+     */
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        /** Inclusive local hours considered golden-hour candidates. */
+        string $timezone = 'Europe/Berlin',
         private readonly array $morningHours = [6, 7, 8],
         private readonly array $eveningHours = [18, 19, 20],
-        private readonly int $sessionGapSeconds = 90 * 60,
-        private readonly int $minItems = 5
+        int $sessionGapSeconds = 90 * 60,
+        int $minItems = 5
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -30,68 +33,11 @@ final class GoldenHourClusterStrategy implements ClusterStrategyInterface
         return 'golden_hour';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
+        $hour = (int) $local->format('G');
 
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $h = (int) $t->setTimezone($tz)->format('G'); // 0..23
-            if (\in_array($h, $this->morningHours, true) || \in_array($h, $this->eveningHours, true)) {
-                $cand[] = $m;
-            }
-        }
-
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $lastTs = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
-            $out[] = new ClusterDraft(
-                algorithm: 'golden_hour',
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = (int) $m->getTakenAt()->getTimestamp();
-            if ($lastTs !== null && ($ts - $lastTs) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $lastTs = $ts;
-        }
-        $flush();
-
-        return $out;
+        return \in_array($hour, $this->morningHours, true)
+            || \in_array($hour, $this->eveningHours, true);
     }
 }

--- a/src/Clusterer/HikeAdventureClusterStrategy.php
+++ b/src/Clusterer/HikeAdventureClusterStrategy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -11,14 +13,21 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Groups hiking/adventure sessions based on keywords; validates by traveled distance if GPS is available.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 74])]
-final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
+final class HikeAdventureClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'wander', 'wanderung', 'trail', 'hike', 'hiking', 'gipfel',
+        'alpen', 'dolomiten', 'pass', 'berg', 'berge', 'klettersteig',
+    ];
+
     public function __construct(
-        private readonly int $sessionGapSeconds = 3 * 3600,
-        private readonly float $minDistanceKm = 6.0, // require at least ~6km if GPS is present
-        private readonly int $minItems = 6,
-        private readonly int $minItemsNoGps = 12 // stricter if no GPS available
+        int $sessionGapSeconds = 3 * 3600,
+        private readonly float $minDistanceKm = 6.0,
+        int $minItems = 6,
+        private readonly int $minItemsNoGps = 12
     ) {
+        parent::__construct('UTC', $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -26,117 +35,46 @@ final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
         return 'hike_adventure';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        /** @var list<Media> $cand */
-        $cand = [];
-        foreach ($items as $m) {
-            $t  = $m->getTakenAt();
-            $pl = \strtolower($m->getPath());
-            if ($t !== null && $this->looksHike($pl)) {
-                $cand[] = $m;
-            }
-        }
-
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            $n = \count($buf);
-            if ($n < $this->minItems) {
-                $buf = [];
-                return;
-            }
-
-            // If GPS available, require minimum traveled distance
-            $withGps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-
-            if ($withGps !== []) {
-                \usort($withGps, static fn (Media $a, Media $b): int =>
-                    ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-                );
-                $km = 0.0;
-                for ($i = 1, $k = \count($withGps); $i < $k; $i++) {
-                    $p = $withGps[$i - 1];
-                    $q = $withGps[$i];
-                    $km += MediaMath::haversineDistanceInMeters(
-                            (float) $p->getGpsLat(),
-                            (float) $p->getGpsLon(),
-                            (float) $q->getGpsLat(),
-                            (float) $q->getGpsLon()
-                        ) / 1000.0;
-                }
-                if ($km < $this->minDistanceKm) {
-                    $buf = [];
-                    return;
-                }
-            } else {
-                // No GPS: require more items to reduce false positives
-                if ($n < $this->minItemsNoGps) {
-                    $buf = [];
-                    return;
-                }
-            }
-
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksHike(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = [
-            'wander', 'wanderung', 'trail', 'hike', 'hiking', 'gipfel',
-            'alpen', 'dolomiten', 'pass', 'berg', 'berge', 'klettersteig',
-        ];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
+        if (!parent::isSessionValid($members)) {
+            return false;
         }
-        return false;
+
+        $withGps = \array_values(\array_filter(
+            $members,
+            static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null
+        ));
+
+        if ($withGps === []) {
+            return \count($members) >= $this->minItemsNoGps;
+        }
+
+        \usort(
+            $withGps,
+            static fn (Media $a, Media $b): int => $a->getTakenAt()->getTimestamp() <=> $b->getTakenAt()->getTimestamp()
+        );
+
+        $distanceKm = 0.0;
+        for ($i = 1, $n = \count($withGps); $i < $n; $i++) {
+            $prev = $withGps[$i - 1];
+            $curr = $withGps[$i];
+            $distanceKm += MediaMath::haversineDistanceInMeters(
+                (float) $prev->getGpsLat(),
+                (float) $prev->getGpsLon(),
+                (float) $curr->getGpsLat(),
+                (float) $curr->getGpsLon()
+            ) / 1000.0;
+        }
+
+        return $distanceKm >= $this->minDistanceKm;
     }
 }

--- a/src/Clusterer/HikeAdventureClusterStrategy.php
+++ b/src/Clusterer/HikeAdventureClusterStrategy.php
@@ -3,8 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Groups hiking/adventure sessions based on keywords; validates by traveled distance if GPS is available.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 74])]
-final class HikeAdventureClusterStrategy extends AbstractTimeGapClusterStrategy
+final class HikeAdventureClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = [
@@ -35,9 +34,9 @@ final class HikeAdventureClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'hike_adventure';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
     {
-        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return self::KEYWORDS;
     }
 
     /**

--- a/src/Clusterer/HolidayEventClusterStrategy.php
+++ b/src/Clusterer/HolidayEventClusterStrategy.php
@@ -28,6 +28,14 @@ final class HolidayEventClusterStrategy extends AbstractTimezoneAwareGroupedClus
         return 'holiday_event';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         $name = Calendar::germanFederalHolidayName($local);
@@ -43,10 +51,6 @@ final class HolidayEventClusterStrategy extends AbstractTimezoneAwareGroupedClus
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         [$yearStr, ,] = \explode(':', $key, 3);
 
         return [

--- a/src/Clusterer/KidsBirthdayPartyClusterStrategy.php
+++ b/src/Clusterer/KidsBirthdayPartyClusterStrategy.php
@@ -4,23 +4,29 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects kids' birthday parties based on keywords; compact time sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 72])]
-final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
+final class KidsBirthdayPartyClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'geburtstag', 'birthday', 'party', 'kinder', 'kids', 'kerzen',
+        'torte', 'kuchen', 'luftballon', 'balloon', 'geschenke',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 3 * 3600,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 3 * 3600,
         private readonly float $radiusMeters = 250.0,
-        private readonly int $minItems = 6
+        int $minItems = 6
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,109 +34,22 @@ final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
         return 'kids_birthday_party';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $h = (int) $t->setTimezone($tz)->format('G'); // prefer 10–21
-            if ($h < 10 || $h > 21) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if ($this->looksBirthday($path)) {
-                $cand[] = $m;
-            }
+        $hour = (int) $local->format('G');
+        if ($hour < 10 || $hour > 21) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            // spatial compactness (if GPS exists)
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            $ok = true;
-            foreach ($gps as $m) {
-                $d = MediaMath::haversineDistanceInMeters(
-                    (float) $centroid['lat'], (float) $centroid['lon'],
-                    (float) $m->getGpsLat(), (float) $m->getGpsLon()
-                );
-                if ($d > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if (!$ok) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksBirthday(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = ['geburtstag', 'birthday', 'party', 'kinder', 'kids', 'kerzen', 'torte', 'kuchen', 'luftballon', 'balloon', 'geschenke'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/LongTripClusterStrategy.php
+++ b/src/Clusterer/LongTripClusterStrategy.php
@@ -3,8 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractConsecutiveRunClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Detects multi-night trips away from home based on per-day centroids and distance threshold.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 90])]
-final class LongTripClusterStrategy implements ClusterStrategyInterface
+final class LongTripClusterStrategy extends AbstractConsecutiveRunClusterStrategy
 {
     public function __construct(
         /** Home base; if null, strategy is effectively disabled. */
@@ -21,9 +20,10 @@ final class LongTripClusterStrategy implements ClusterStrategyInterface
         private readonly ?float $homeLon = null,
         private readonly float $minAwayKm = 150.0,
         private readonly int $minNights = 3,
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 3
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 3
     ) {
+        parent::__construct($timezone, $minItemsPerDay, 0, $minNights);
     }
 
     public function name(): string
@@ -31,124 +31,51 @@ final class LongTripClusterStrategy implements ClusterStrategyInterface
         return 'long_trip';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function isEnabled(): bool
     {
-        if ($this->homeLat === null || $this->homeLon === null) {
-            return [];
-        }
-
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $key = $local->format('Y-m-d');
-            $byDay[$key] ??= [];
-            $byDay[$key][] = $m;
-        }
-
-        /** @var array<string, bool> $isAway */
-        $isAway = [];
-        /** @var array<string, list<Media>> $usableDayItems */
-        $usableDayItems = [];
-
-        foreach ($byDay as $day => $list) {
-            if (\count($list) < $this->minItemsPerDay) {
-                continue;
-            }
-            $gps = \array_values(\array_filter($list, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            if ($gps === []) {
-                continue;
-            }
-            $centroid = MediaMath::centroid($gps);
-            $dist = MediaMath::haversineDistanceInMeters(
-                    (float) $centroid['lat'],
-                    (float) $centroid['lon'],
-                    (float) $this->homeLat,
-                    (float) $this->homeLon
-                ) / 1000.0;
-            $isAway[$day] = $dist >= $this->minAwayKm;
-            if ($isAway[$day] === true) {
-                $usableDayItems[$day] = $list;
-            }
-        }
-
-        if ($usableDayItems === []) {
-            return [];
-        }
-
-        // Sort days and find consecutive away sequences
-        $days = \array_keys($usableDayItems);
-        \sort($days, \SORT_STRING);
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<string> $run */
-        $run = [];
-
-        $flush = function () use (&$run, &$out, $usableDayItems): void {
-            if (\count($run) < 2) {
-                $run = [];
-                return;
-            }
-            /** @var list<Media> $all */
-            $all = [];
-            foreach ($run as $d) {
-                foreach ($usableDayItems[$d] as $m) {
-                    $all[] = $m;
-                }
-            }
-            $nights = \max(0, \count($run) - 1);
-            if ($nights < $this->minNights) {
-                $run = [];
-                return;
-            }
-            $centroid = MediaMath::centroid($all);
-            $time     = MediaMath::timeRange($all);
-
-            $out[] = new ClusterDraft(
-                algorithm: 'long_trip',
-                params: [
-                    'nights'      => $nights,
-                    'distance_km' => $this->minAwayKm,
-                    'time_range'  => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $all)
-            );
-
-            $run = [];
-        };
-
-        $prev = null;
-        foreach ($days as $d) {
-            if ($prev !== null && $this->isNextDay($prev, $d) === false) {
-                $flush();
-            }
-            $run[] = $d;
-            $prev = $d;
-        }
-        $flush();
-
-        return $out;
+        return $this->homeLat !== null && $this->homeLon !== null;
     }
 
-    private function isNextDay(string $a, string $b): bool
+    /**
+     * @param list<Media> $items
+     */
+    protected function isDayEligible(string $day, array $items): bool
     {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
+        if (!parent::isDayEligible($day, $items)) {
             return false;
         }
-        return ($tb - $ta) === 86400;
+
+        $gps = \array_values(\array_filter(
+            $items,
+            static fn (Media $media): bool => $media->getGpsLat() !== null && $media->getGpsLon() !== null
+        ));
+
+        if ($gps === []) {
+            return false;
+        }
+
+        $centroid = MediaMath::centroid($gps);
+        $distanceKm = MediaMath::haversineDistanceInMeters(
+            (float) $centroid['lat'],
+            (float) $centroid['lon'],
+            (float) $this->homeLat,
+            (float) $this->homeLon
+        ) / 1000.0;
+
+        return $distanceKm >= $this->minAwayKm;
+    }
+
+    /**
+     * @param array{days:list<string>, items:list<Media>} $run
+     * @param array<string, list<Media>> $daysMap
+     * @param list<Media> $members
+     * @return array<string, mixed>
+     */
+    protected function runParams(array $run, array $daysMap, int $nights, array $members): array
+    {
+        return [
+            'nights' => $nights,
+            'distance_km' => $this->minAwayKm,
+        ];
     }
 }

--- a/src/Clusterer/LongTripClusterStrategy.php
+++ b/src/Clusterer/LongTripClusterStrategy.php
@@ -39,9 +39,9 @@ final class LongTripClusterStrategy extends AbstractConsecutiveRunClusterStrateg
     /**
      * @param list<Media> $items
      */
-    protected function isDayEligible(string $day, array $items): bool
+    protected function isDayEligible(string $day, array $items, string $groupKey): bool
     {
-        if (!parent::isDayEligible($day, $items)) {
+        if (!parent::isDayEligible($day, $items, $groupKey)) {
             return false;
         }
 
@@ -71,7 +71,7 @@ final class LongTripClusterStrategy extends AbstractConsecutiveRunClusterStrateg
      * @param list<Media> $members
      * @return array<string, mixed>
      */
-    protected function runParams(array $run, array $daysMap, int $nights, array $members): array
+    protected function runParams(array $run, array $daysMap, int $nights, array $members, string $groupKey): array
     {
         return [
             'nights' => $nights,

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -13,16 +11,14 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Builds a highlight memory for each (year, month) with sufficient coverage.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 59])]
-final class MonthlyHighlightsClusterStrategy extends AbstractGroupedClusterStrategy
+final class MonthlyHighlightsClusterStrategy extends AbstractTimezoneAwareGroupedClusterStrategy
 {
-    private readonly DateTimeZone $timezone;
-
     public function __construct(
         string $timezone = 'Europe/Berlin',
         private readonly int $minItems = 40,
         private readonly int $minDistinctDays = 10
     ) {
-        $this->timezone = new DateTimeZone($timezone);
+        parent::__construct($timezone);
     }
 
     public function name(): string
@@ -32,12 +28,12 @@ final class MonthlyHighlightsClusterStrategy extends AbstractGroupedClusterStrat
 
     protected function groupKey(Media $media): ?string
     {
-        $takenAt = $media->getTakenAt();
-        if (!$takenAt instanceof DateTimeImmutable) {
+        $local = $this->localTakenAt($media);
+        if ($local === null) {
             return null;
         }
 
-        return $takenAt->setTimezone($this->timezone)->format('Y-m');
+        return $local->format('Y-m');
     }
 
     /**
@@ -49,7 +45,7 @@ final class MonthlyHighlightsClusterStrategy extends AbstractGroupedClusterStrat
             return null;
         }
 
-        $days = $this->uniqueDateParts($members, 'Y-m-d', $this->timezone);
+        $days = $this->uniqueDateParts($members, 'Y-m-d', $this->timezone());
         if (\count($days) < $this->minDistinctDays) {
             return null;
         }
@@ -60,13 +56,4 @@ final class MonthlyHighlightsClusterStrategy extends AbstractGroupedClusterStrat
         ];
     }
 
-    private static function germanMonthLabel(int $m): string
-    {
-        return match ($m) {
-            1 => 'Januar', 2 => 'Februar', 3 => 'März', 4 => 'April',
-            5 => 'Mai', 6 => 'Juni', 7 => 'Juli', 8 => 'August',
-            9 => 'September', 10 => 'Oktober', 11 => 'November', 12 => 'Dezember',
-            default => 'Monat',
-        };
-    }
 }

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -27,6 +27,14 @@ final class MonthlyHighlightsClusterStrategy extends AbstractTimezoneAwareGroupe
         return 'monthly_highlights';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         return $local->format('Y-m');
@@ -37,10 +45,6 @@ final class MonthlyHighlightsClusterStrategy extends AbstractTimezoneAwareGroupe
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         $days = $this->uniqueLocalDateParts($members, 'Y-m-d');
         if (\count($days) < $this->minDistinctDays) {
             return null;

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -49,15 +49,7 @@ final class MonthlyHighlightsClusterStrategy extends AbstractGroupedClusterStrat
             return null;
         }
 
-        /** @var array<string,bool> $days */
-        $days = [];
-        foreach ($members as $media) {
-            $takenAt = $media->getTakenAt();
-            if ($takenAt instanceof DateTimeImmutable) {
-                $days[$takenAt->setTimezone($this->timezone)->format('Y-m-d')] = true;
-            }
-        }
-
+        $days = $this->uniqueDateParts($members, 'Y-m-d', $this->timezone);
         if (\count($days) < $this->minDistinctDays) {
             return null;
         }

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -26,13 +27,8 @@ final class MonthlyHighlightsClusterStrategy extends AbstractTimezoneAwareGroupe
         return 'monthly_highlights';
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
-
         return $local->format('Y-m');
     }
 
@@ -45,7 +41,7 @@ final class MonthlyHighlightsClusterStrategy extends AbstractTimezoneAwareGroupe
             return null;
         }
 
-        $days = $this->uniqueDateParts($members, 'Y-m-d', $this->timezone());
+        $days = $this->uniqueLocalDateParts($members, 'Y-m-d');
         if (\count($days) < $this->minDistinctDays) {
             return null;
         }

--- a/src/Clusterer/MorningCoffeeClusterStrategy.php
+++ b/src/Clusterer/MorningCoffeeClusterStrategy.php
@@ -4,23 +4,29 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Morning café/breakfast moments based on time and keywords, spatially compact.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 51])]
-final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
+final class MorningCoffeeClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'cafe', 'café', 'coffee', 'kaffee', 'frühstück', 'fruehstueck',
+        'bakery', 'bäckerei', 'baeckerei', 'brunch', 'espresso', 'barista',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 90 * 60,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 90 * 60,
         private readonly float $radiusMeters = 200.0,
-        private readonly int $minItems = 3
+        int $minItems = 3
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,109 +34,22 @@ final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
         return 'morning_coffee';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $h = (int)$t->setTimezone($tz)->format('G'); // 0..23
-            if ($h < 7 || $h > 10) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if (!$this->looksLikeCafe($path)) {
-                continue;
-            }
-            $cand[] = $m;
+        $hour = (int) $local->format('G');
+        if ($hour < 7 || $hour > 10) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn(Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            // compactness
-            $ok = true;
-            foreach ($gps as $m) {
-                $d = MediaMath::haversineDistanceInMeters(
-                    (float)$centroid['lat'], (float)$centroid['lon'],
-                    (float)$m->getGpsLat(), (float)$m->getGpsLon()
-                );
-                if ($d > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if ($ok === false) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                   'time_range' => $time,
-                ],
-                centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksLikeCafe(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = ['cafe', 'café', 'coffee', 'kaffee', 'frühstück', 'fruehstueck', 'bakery', 'bäckerei', 'baeckerei', 'brunch', 'espresso', 'barista'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/MorningCoffeeClusterStrategy.php
+++ b/src/Clusterer/MorningCoffeeClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Morning café/breakfast moments based on time and keywords, spatially compact.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 51])]
-final class MorningCoffeeClusterStrategy extends AbstractTimeGapClusterStrategy
+final class MorningCoffeeClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = [
@@ -34,22 +34,20 @@ final class MorningCoffeeClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'morning_coffee';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
     {
-        $hour = (int) $local->format('G');
-        if ($hour < 7 || $hour > 10) {
-            return false;
-        }
-
-        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return self::KEYWORDS;
     }
 
-    /**
-     * @param list<Media> $members
-     */
-    protected function isSessionValid(array $members): bool
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
-        return parent::isSessionValid($members)
-            && $this->allWithinRadius($members, $this->radiusMeters);
+        $hour = (int) $local->format('G');
+
+        return $hour >= 7 && $hour <= 10;
+    }
+
+    protected function sessionRadiusMeters(): ?float
+    {
+        return $this->radiusMeters;
     }
 }

--- a/src/Clusterer/NewYearEveClusterStrategy.php
+++ b/src/Clusterer/NewYearEveClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -28,12 +29,8 @@ final class NewYearEveClusterStrategy extends AbstractTimezoneAwareGroupedCluste
         return 'new_year_eve';
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
         $monthDay = $local->format('m-d');
         $hour = (int) $local->format('G');
 

--- a/src/Clusterer/NewYearEveClusterStrategy.php
+++ b/src/Clusterer/NewYearEveClusterStrategy.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -13,10 +11,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Builds New Year's Eve clusters (local night around Dec 31 → Jan 1).
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 79])]
-final class NewYearEveClusterStrategy extends AbstractGroupedClusterStrategy
+final class NewYearEveClusterStrategy extends AbstractTimezoneAwareGroupedClusterStrategy
 {
-    private readonly DateTimeZone $timezone;
-
     public function __construct(
         string $timezone = 'Europe/Berlin',
         /** Hours considered NYE party window (local, 24h). */
@@ -24,7 +20,7 @@ final class NewYearEveClusterStrategy extends AbstractGroupedClusterStrategy
         private readonly int $endHour = 2,
         private readonly int $minItems = 6
     ) {
-        $this->timezone = new DateTimeZone($timezone);
+        parent::__construct($timezone);
     }
 
     public function name(): string
@@ -34,12 +30,10 @@ final class NewYearEveClusterStrategy extends AbstractGroupedClusterStrategy
 
     protected function groupKey(Media $media): ?string
     {
-        $takenAt = $media->getTakenAt();
-        if (!$takenAt instanceof DateTimeImmutable) {
+        $local = $this->localTakenAt($media);
+        if ($local === null) {
             return null;
         }
-
-        $local = $takenAt->setTimezone($this->timezone);
         $monthDay = $local->format('m-d');
         $hour = (int) $local->format('G');
 

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Clusters evening/night sessions (20:00–04:00 local time) with time gap and spatial compactness.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 75])]
-final class NightlifeEventClusterStrategy extends AbstractTimeGapClusterStrategy
+final class NightlifeEventClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     public function __construct(
         string $timezone = 'Europe/Berlin',
@@ -28,19 +28,15 @@ final class NightlifeEventClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'nightlife_event';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
         $hour = (int) $local->format('G');
 
         return $hour >= 20 || $hour <= 4;
     }
 
-    /**
-     * @param list<Media> $members
-     */
-    protected function isSessionValid(array $members): bool
+    protected function sessionRadiusMeters(): ?float
     {
-        return parent::isSessionValid($members)
-            && $this->allWithinRadius($members, $this->radiusMeters);
+        return $this->radiusMeters;
     }
 }

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\GeoMath;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters evening/night sessions (20:00–04:00 local time) with time gap and spatial compactness.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 75])]
-final class NightlifeEventClusterStrategy implements ClusterStrategyInterface
+final class NightlifeEventClusterStrategy extends AbstractTimeGapClusterStrategy
 {
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $timeGapSeconds = 3 * 3600, // 3h
+        string $timezone = 'Europe/Berlin',
+        int $timeGapSeconds = 3 * 3600, // 3h
         private readonly float $radiusMeters = 300.0,
-        private readonly int $minItems = 5
+        int $minItems = 5
     ) {
+        parent::__construct($timezone, $timeGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -29,87 +28,19 @@ final class NightlifeEventClusterStrategy implements ClusterStrategyInterface
         return 'nightlife_event';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
+        $hour = (int) $local->format('G');
 
-        $night = \array_values(\array_filter($items, function (Media $m) use ($tz): bool {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                return false;
-            }
-            $local = $t->setTimezone($tz);
-            $h = (int) $local->format('G'); // 0..23
-            return ($h >= 20) || ($h <= 4);
-        }));
+        return $hour >= 20 || $hour <= 4;
+    }
 
-        if (\count($night) < $this->minItems) {
-            return [];
-        }
-
-        \usort($night, static function (Media $a, Media $b): int {
-            return $a->getTakenAt() <=> $b->getTakenAt();
-        });
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $lastTs = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== []
-                ? MediaMath::centroid($gps)
-                : ['lat' => 0.0, 'lon' => 0.0];
-
-            // require spatial compactness if GPS present
-            $ok = true;
-            foreach ($gps as $m) {
-                $dist = MediaMath::haversineDistanceInMeters(
-                    $centroid['lat'],
-                    $centroid['lon'],
-                    (float) $m->getGpsLat(),
-                    (float) $m->getGpsLon()
-                );
-
-                if ($dist > 300.0) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if ($ok) {
-                $time = MediaMath::timeRange($buf);
-                $out[] = new ClusterDraft(
-                    algorithm: 'nightlife_event',
-                    params: [
-                        'time_range' => $time,
-                    ],
-                    centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                    members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-                );
-            }
-            $buf = [];
-        };
-
-        foreach ($night as $m) {
-            $ts = (int) $m->getTakenAt()->getTimestamp();
-            if ($lastTs !== null && ($ts - $lastTs) > $this->timeGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $lastTs = $ts;
-        }
-        $flush();
-
-        return $out;
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
+    {
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
+++ b/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
@@ -32,6 +32,14 @@ final class OnThisDayOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
         return 'on_this_day_over_years';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function beforeGrouping(): void
     {
         $now = new DateTimeImmutable('now', $this->timezone());
@@ -60,10 +68,6 @@ final class OnThisDayOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         $yearsMap = $this->uniqueLocalDateParts($members, 'Y');
         if (\count($yearsMap) < $this->minYears) {
             return null;

--- a/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
+++ b/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
@@ -39,12 +39,8 @@ final class OnThisDayOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
         $this->anchorDay = (int) $now->format('j');
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
         $monthDistance = $this->monthDayDistance(
             $this->anchorMonth,
             $this->anchorDay,
@@ -68,7 +64,7 @@ final class OnThisDayOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
             return null;
         }
 
-        $yearsMap = $this->uniqueDateParts($members, 'Y', $this->timezone());
+        $yearsMap = $this->uniqueLocalDateParts($members, 'Y');
         if (\count($yearsMap) < $this->minYears) {
             return null;
         }

--- a/src/Clusterer/OneYearAgoClusterStrategy.php
+++ b/src/Clusterer/OneYearAgoClusterStrategy.php
@@ -42,12 +42,8 @@ final class OneYearAgoClusterStrategy extends AbstractTimezoneAwareGroupedCluste
         $this->windowEnd = $anchor->modify('+' . $this->windowDays . ' days');
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
         if ($local < $this->windowStart || $local > $this->windowEnd) {
             return null;
         }

--- a/src/Clusterer/OneYearAgoClusterStrategy.php
+++ b/src/Clusterer/OneYearAgoClusterStrategy.php
@@ -34,6 +34,14 @@ final class OneYearAgoClusterStrategy extends AbstractTimezoneAwareGroupedCluste
         return 'one_year_ago';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function beforeGrouping(): void
     {
         $now = new DateTimeImmutable('now', $this->timezone());
@@ -56,10 +64,6 @@ final class OneYearAgoClusterStrategy extends AbstractTimezoneAwareGroupedCluste
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         return [];
     }
 }

--- a/src/Clusterer/PanoramaClusterStrategy.php
+++ b/src/Clusterer/PanoramaClusterStrategy.php
@@ -3,21 +3,23 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters panorama photos (very wide aspect ratio) into time sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 47])]
-final class PanoramaClusterStrategy implements ClusterStrategyInterface
+final class PanoramaClusterStrategy extends AbstractTimeGapClusterStrategy
 {
     public function __construct(
-        private readonly float $minAspect = 2.4,     // width / height threshold
-        private readonly int $sessionGapSeconds = 3 * 3600,
-        private readonly int $minItems = 3
+        private readonly float $minAspect = 2.4,
+        int $sessionGapSeconds = 3 * 3600,
+        int $minItems = 3
     ) {
+        parent::__construct('UTC', $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -25,75 +27,21 @@ final class PanoramaClusterStrategy implements ClusterStrategyInterface
         return 'panorama';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        /** @var list<Media> $cand */
-        $cand = [];
-        foreach ($items as $m) {
-            $w = $m->getWidth();
-            $h = $m->getHeight();
-            if ($w === null || $h === null || $w <= 0 || $h <= 0) {
-                continue;
-            }
-            if ($w <= $h) {
-                continue; // require landscape panoramas
-            }
-            $ratio = (float) $w / (float) $h;
-            if ($ratio >= $this->minAspect) {
-                $cand[] = $m;
-            }
-        }
-        if (\count($cand) < $this->minItems) {
-            return [];
+        $width = $media->getWidth();
+        $height = $media->getHeight();
+
+        if ($width === null || $height === null || $width <= 0 || $height <= 0) {
+            return false;
         }
 
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
+        if ($width <= $height) {
+            return false;
         }
-        $flush();
 
-        return $out;
+        $ratio = (float) $width / (float) $height;
+
+        return $ratio >= $this->minAspect;
     }
 }

--- a/src/Clusterer/PanoramaOverYearsClusterStrategy.php
+++ b/src/Clusterer/PanoramaOverYearsClusterStrategy.php
@@ -3,24 +3,25 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredOverYearsStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Aggregates panoramas across years; requires per-year minimum.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 46])]
-final class PanoramaOverYearsClusterStrategy implements ClusterStrategyInterface
+final class PanoramaOverYearsClusterStrategy extends AbstractFilteredOverYearsStrategy
 {
-    use ClusterBuildHelperTrait;
-
     public function __construct(
         private readonly float $minAspect = 2.4,
-        private readonly int $perYearMin = 3,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 15
+        int $perYearMin = 3,
+        int $minYears = 3,
+        int $minItemsTotal = 15,
+        string $timezone = 'UTC'
     ) {
+        parent::__construct($timezone, $perYearMin, $minYears, $minItemsTotal);
     }
 
     public function name(): string
@@ -28,50 +29,21 @@ final class PanoramaOverYearsClusterStrategy implements ClusterStrategyInterface
         return 'panorama_over_years';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldInclude(Media $media, DateTimeImmutable $local): bool
     {
-        /** @var array<int, list<Media>> $byYear */
-        $byYear = [];
+        $width = $media->getWidth();
+        $height = $media->getHeight();
 
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $w = $m->getWidth();
-            $h = $m->getHeight();
-            if ($t === null || $w === null || $h === null || $w <= 0 || $h <= 0 || $w <= $h) {
-                continue;
-            }
-            $ratio = (float) $w / (float) $h;
-            if ($ratio < $this->minAspect) {
-                continue;
-            }
-            $y = (int) $t->format('Y');
-            $byYear[$y] ??= [];
-            $byYear[$y][] = $m;
+        if ($width === null || $height === null || $width <= 0 || $height <= 0) {
+            return false;
         }
 
-        $picked = [];
-        $years  = [];
-
-        foreach ($byYear as $year => $list) {
-            if (\count($list) < $this->perYearMin) {
-                continue;
-            }
-            foreach ($list as $media) {
-                $picked[] = $media;
-            }
-            $years[$year] = true;
+        if ($width <= $height) {
+            return false;
         }
 
-        return $this->buildOverYearsDrafts(
-            $picked,
-            $years,
-            $this->minYears,
-            $this->minItemsTotal,
-            $this->name()
-        );
+        $ratio = (float) $width / (float) $height;
+
+        return $ratio >= $this->minAspect;
     }
 }

--- a/src/Clusterer/PersonCohortClusterStrategy.php
+++ b/src/Clusterer/PersonCohortClusterStrategy.php
@@ -3,8 +3,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractConsecutiveRunClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -12,13 +13,18 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Requires Media to expose person tags via getPersonIds() -> list<int>.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 80])]
-final class PersonCohortClusterStrategy implements ClusterStrategyInterface
+final class PersonCohortClusterStrategy extends AbstractConsecutiveRunClusterStrategy
 {
+    /** @var array<string, list<int>> */
+    private array $groupPersons = [];
+
     public function __construct(
         private readonly int $minPersons = 2,
-        private readonly int $minItems   = 5,
-        private readonly int $windowDays = 14
+        private readonly int $minItems = 5,
+        private readonly int $windowDays = 14,
+        string $timezone = 'UTC'
     ) {
+        parent::__construct($timezone, 1, $minItems, 0);
     }
 
     public function name(): string
@@ -26,107 +32,99 @@ final class PersonCohortClusterStrategy implements ClusterStrategyInterface
         return 'people_cohort';
     }
 
-    /**
-     * @param list<Media> $items
-     *
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function beforeGrouping(): void
     {
-        // If there is no person method, exit early
-        $hasMethod = \count(\array_filter(
-                $items,
-                static fn (Media $m): bool => \method_exists($m, 'getPersonIds')
-            )) > 0;
+        $this->groupPersons = [];
+    }
 
-        if (!$hasMethod) {
-            return [];
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        if (!\method_exists($media, 'getPersonIds')) {
+            return false;
         }
 
-        /** @var array<string, array<string, list<Media>>> $buckets sig => day => items */
-        $buckets = [];
-        $withTime = \array_values(\array_filter(
-            $items,
-            static fn (Media $m): bool => $m->getTakenAt() !== null
-        ));
+        /** @var list<int> $persons */
+        $persons = (array) $media->getPersonIds();
 
-        // Phase 1: bucket by persons signature per day
-        foreach ($withTime as $m) {
-            /** @var list<int> $persons */
-            $persons = \method_exists($m, 'getPersonIds') ? (array) $m->getPersonIds() : [];
-            if (\count($persons) < $this->minPersons) {
-                continue;
-            }
+        return \count($persons) >= $this->minPersons;
+    }
 
-            \sort($persons);
-            $sig = 'p:' . \implode('-', \array_map(static fn (int $id): string => (string) $id, $persons));
-            $day = $m->getTakenAt()?->format('Y-m-d') ?? '1970-01-01';
-
-            $buckets[$sig] ??= [];
-            $buckets[$sig][$day] ??= [];
-            $buckets[$sig][$day][] = $m;
+    protected function groupKey(Media $media, DateTimeImmutable $local): ?string
+    {
+        /** @var list<int> $persons */
+        $persons = (array) $media->getPersonIds();
+        if (\count($persons) < $this->minPersons) {
+            return null;
         }
 
-        if (\count($buckets) === 0) {
-            return [];
-        }
+        \sort($persons);
+        $key = 'p:' . \implode('-', \array_map(static fn (int $id): string => (string) $id, $persons));
+        $this->groupPersons[$key] = $persons;
 
-        $clusters = [];
-
-        // Phase 2: merge consecutive days within window for each signature
-        foreach ($buckets as $sig => $byDay) {
-            \ksort($byDay);
-
-            $current = [];
-            $lastDay = null;
-
-            foreach ($byDay as $day => $list) {
-                if ($lastDay === null) {
-                    $current = $list;
-                    $lastDay = $day;
-                    continue;
-                }
-
-                $gapDays = (new \DateTimeImmutable($day))->diff(new \DateTimeImmutable($lastDay))->days;
-                $gapDays = $gapDays === false || $gapDays === null ? 0 : (int) $gapDays;
-
-                if ($gapDays <= $this->windowDays) {
-                    /** @var list<Media> $current */
-                    $current = \array_merge($current, $list);
-                    $lastDay = $day;
-                    continue;
-                }
-
-                if (\count($current) >= $this->minItems) {
-                    $clusters[] = $this->makeDraft($current);
-                }
-
-                $current = $list;
-                $lastDay = $day;
-            }
-
-            if (\count($current) >= $this->minItems) {
-                $clusters[] = $this->makeDraft($current);
-            }
-        }
-
-        return $clusters;
+        return $key;
     }
 
     /**
-     * @param list<Media> $members
+     * @param array<string, list<Media>> $daysMap
+     * @return list<array{days:list<string>, items:list<Media>}>
      */
-    private function makeDraft(array $members): ClusterDraft
+    protected function buildRuns(array $daysMap, string $groupKey): array
     {
-        $centroid = MediaMath::centroid($members);
+        if ($this->windowDays <= 0) {
+            return parent::buildRuns($daysMap, $groupKey);
+        }
 
-        return new ClusterDraft(
-            algorithm: $this->name(),
-            params: [
-                'time_range' => MediaMath::timeRange($members),
-            ],
-            centroid: ['lat' => $centroid['lat'], 'lon' => $centroid['lon']],
-            members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-        );
+        $days = \array_keys($daysMap);
+        \sort($days, \SORT_STRING);
+
+        $runs = [];
+        $runDays = [];
+        $runItems = [];
+        $lastDay = null;
+
+        foreach ($days as $day) {
+            if ($lastDay !== null) {
+                $gap = $this->gapDays($lastDay, $day);
+                if ($gap > $this->windowDays) {
+                    if ($runDays !== []) {
+                        $runs[] = ['days' => $runDays, 'items' => $runItems];
+                        $runDays = [];
+                        $runItems = [];
+                    }
+                }
+            }
+
+            $runDays[] = $day;
+            foreach ($daysMap[$day] as $media) {
+                $runItems[] = $media;
+            }
+            $lastDay = $day;
+        }
+
+        if ($runDays !== []) {
+            $runs[] = ['days' => $runDays, 'items' => $runItems];
+        }
+
+        return $runs;
+    }
+
+    protected function runParams(array $run, array $daysMap, int $nights, array $members, string $groupKey): array
+    {
+        $params = [];
+
+        if (isset($this->groupPersons[$groupKey])) {
+            $params['person_ids'] = $this->groupPersons[$groupKey];
+        }
+
+        return $params;
+    }
+
+    private function gapDays(string $previousDay, string $currentDay): int
+    {
+        $previous = new DateTimeImmutable($previousDay);
+        $current = new DateTimeImmutable($currentDay);
+        $diff = $current->diff($previous);
+
+        return (int) ($diff->days ?? 0);
     }
 }

--- a/src/Clusterer/PetMomentsClusterStrategy.php
+++ b/src/Clusterer/PetMomentsClusterStrategy.php
@@ -3,16 +3,14 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
-use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Heuristic pet moments based on path keywords; grouped into time sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 49])]
-final class PetMomentsClusterStrategy extends AbstractTimeGapClusterStrategy
+final class PetMomentsClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = [
@@ -35,8 +33,8 @@ final class PetMomentsClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'pet_moments';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
     {
-        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return self::KEYWORDS;
     }
 }

--- a/src/Clusterer/PhashSimilarityStrategy.php
+++ b/src/Clusterer/PhashSimilarityStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
+use MagicSunday\Memories\Clusterer\Support\PlaceLabelHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -12,6 +13,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 final class PhashSimilarityStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;
+    use PlaceLabelHelperTrait;
 
     public function __construct(
         private readonly LocationHelper $locHelper,
@@ -58,20 +60,9 @@ final class PhashSimilarityStrategy implements ClusterStrategyInterface
                 if (\count($comp) < $this->minItems) {
                     continue;
                 }
-                $params = [
-                    'time_range' => $this->computeTimeRange($comp),
-                ];
-                $place = $this->locHelper->majorityLabel($comp);
-                if ($place !== null) {
-                    $params['place'] = $place;
-                }
+                $params = $this->withMajorityPlace($comp);
 
-                $drafts[] = new ClusterDraft(
-                    algorithm: $this->name(),
-                    params: $params,
-                    centroid: $this->computeCentroid($comp),
-                    members: $this->toMemberIds($comp)
-                );
+                $drafts[] = $this->buildClusterDraft($this->name(), $comp, $params);
             }
         }
 

--- a/src/Clusterer/PortraitOrientationClusterStrategy.php
+++ b/src/Clusterer/PortraitOrientationClusterStrategy.php
@@ -3,21 +3,23 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Portrait-oriented photos grouped into time sessions (no face detection).
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 45])]
-final class PortraitOrientationClusterStrategy implements ClusterStrategyInterface
+final class PortraitOrientationClusterStrategy extends AbstractTimeGapClusterStrategy
 {
     public function __construct(
-        private readonly float $minPortraitRatio = 1.2, // height / width
-        private readonly int $sessionGapSeconds = 2 * 3600,
-        private readonly int $minItems = 4
+        private readonly float $minPortraitRatio = 1.2,
+        int $sessionGapSeconds = 2 * 3600,
+        int $minItems = 4
     ) {
+        parent::__construct('UTC', $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -25,76 +27,21 @@ final class PortraitOrientationClusterStrategy implements ClusterStrategyInterfa
         return 'portrait_orientation';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        /** @var list<Media> $cand */
-        $cand = [];
-        foreach ($items as $m) {
-            $w = $m->getWidth();
-            $h = $m->getHeight();
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($w === null || $h === null || $w <= 0 || $h <= 0 || $ts === null) {
-                continue;
-            }
-            if ($h <= $w) {
-                continue;
-            }
-            $ratio = (float)$h / (float)$w;
-            if ($ratio >= $this->minPortraitRatio) {
-                $cand[] = $m;
-            }
+        $width = $media->getWidth();
+        $height = $media->getHeight();
+
+        if ($width === null || $height === null || $width <= 0 || $height <= 0) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
+        if ($height <= $width) {
+            return false;
         }
 
-        \usort($cand, static fn(Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
+        $ratio = (float) $height / (float) $width;
 
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $ratio >= $this->minPortraitRatio;
     }
 }

--- a/src/Clusterer/RainyDayClusterStrategy.php
+++ b/src/Clusterer/RainyDayClusterStrategy.php
@@ -3,10 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
-use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Clusterer\Support\AbstractWeatherDayClusterStrategy;
 use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -14,17 +11,15 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Builds "Rainy Day" clusters when weather hints indicate significant rain on a local day.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 54])]
-final class RainyDayClusterStrategy extends AbstractGroupedClusterStrategy
+final class RainyDayClusterStrategy extends AbstractWeatherDayClusterStrategy
 {
-    private readonly DateTimeZone $timezone;
-
     public function __construct(
-        private readonly WeatherHintProviderInterface $weather,
+        WeatherHintProviderInterface $weather,
         string $timezone = 'Europe/Berlin',
         private readonly float $minAvgRainProb = 0.6,  // 0..1
         private readonly int $minItemsPerDay = 6
     ) {
-        $this->timezone = new DateTimeZone($timezone);
+        parent::__construct($weather, $timezone);
     }
 
     public function name(): string
@@ -32,56 +27,29 @@ final class RainyDayClusterStrategy extends AbstractGroupedClusterStrategy
         return 'rainy_day';
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function scoreFromHint(array $hint): ?float
     {
-        $takenAt = $media->getTakenAt();
-        if (!$takenAt instanceof DateTimeImmutable) {
+        if (!\array_key_exists('rain_prob', $hint)) {
             return null;
         }
 
-        return $takenAt->setTimezone($this->timezone)->format('Y-m-d');
+        return (float) $hint['rain_prob'];
     }
 
-    /**
-     * @param list<Media> $members
-     */
-    protected function groupParams(string $key, array $members): ?array
+    protected function passesAverageThreshold(float $average): bool
     {
-        if (\count($members) < $this->minItemsPerDay) {
-            return null;
-        }
+        return $average >= $this->minAvgRainProb;
+    }
 
-        $sum = 0.0;
-        $count = 0;
-
-        foreach ($members as $media) {
-            $hint = $this->weather->getHint($media);
-            if ($hint === null) {
-                continue;
-            }
-
-            $probability = (float) ($hint['rain_prob'] ?? 0.0);
-            if ($probability < 0.0) {
-                $probability = 0.0;
-            } elseif ($probability > 1.0) {
-                $probability = 1.0;
-            }
-
-            $sum += $probability;
-            $count++;
-        }
-
-        if ($count === 0) {
-            return null;
-        }
-
-        $average = $sum / (float) $count;
-        if ($average < $this->minAvgRainProb) {
-            return null;
-        }
-
+    protected function buildParams(float $average, int $count): array
+    {
         return [
             'rain_prob' => $average,
         ];
+    }
+
+    protected function minItemsPerDay(): int
+    {
+        return $this->minItemsPerDay;
     }
 }

--- a/src/Clusterer/RainyDayClusterStrategy.php
+++ b/src/Clusterer/RainyDayClusterStrategy.php
@@ -5,23 +5,26 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds "Rainy Day" clusters when weather hints indicate significant rain on a local day.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 54])]
-final class RainyDayClusterStrategy implements ClusterStrategyInterface
+final class RainyDayClusterStrategy extends AbstractGroupedClusterStrategy
 {
+    private readonly DateTimeZone $timezone;
+
     public function __construct(
         private readonly WeatherHintProviderInterface $weather,
-        private readonly string $timezone = 'Europe/Berlin',
+        string $timezone = 'Europe/Berlin',
         private readonly float $minAvgRainProb = 0.6,  // 0..1
         private readonly int $minItemsPerDay = 6
     ) {
+        $this->timezone = new DateTimeZone($timezone);
     }
 
     public function name(): string
@@ -29,81 +32,56 @@ final class RainyDayClusterStrategy implements ClusterStrategyInterface
         return 'rainy_day';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function groupKey(Media $media): ?string
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $key = $local->format('Y-m-d');
-            $byDay[$key] ??= [];
-            $byDay[$key][] = $m;
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
         }
 
-        if ($byDay === []) {
-            return [];
+        return $takenAt->setTimezone($this->timezone)->format('Y-m-d');
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    protected function groupParams(string $key, array $members): ?array
+    {
+        if (\count($members) < $this->minItemsPerDay) {
+            return null;
         }
 
-        /** @var list<ClusterDraft> $out */
-        $out = [];
+        $sum = 0.0;
+        $count = 0;
 
-        foreach ($byDay as $day => $list) {
-            if (\count($list) < $this->minItemsPerDay) {
+        foreach ($members as $media) {
+            $hint = $this->weather->getHint($media);
+            if ($hint === null) {
                 continue;
             }
 
-            $sum = 0.0;
-            $n   = 0;
-
-            foreach ($list as $m) {
-                $hint = $this->weather->getHint($m);
-                if ($hint === null) {
-                    continue;
-                }
-                $p = (float) ($hint['rain_prob'] ?? 0.0);
-                // Clamp just in case provider goes beyond [0..1]
-                if ($p < 0.0) { $p = 0.0; }
-                if ($p > 1.0) { $p = 1.0; }
-
-                $sum += $p;
-                $n++;
+            $probability = (float) ($hint['rain_prob'] ?? 0.0);
+            if ($probability < 0.0) {
+                $probability = 0.0;
+            } elseif ($probability > 1.0) {
+                $probability = 1.0;
             }
 
-            if ($n === 0) {
-                // no usable hints for that day
-                continue;
-            }
-
-            $avg = $sum / (float) $n;
-            if ($avg < $this->minAvgRainProb) {
-                continue;
-            }
-
-            $centroid = MediaMath::centroid($list);
-            $time     = MediaMath::timeRange($list);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'rain_prob'   => $avg,
-                    'time_range'  => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $list)
-            );
+            $sum += $probability;
+            $count++;
         }
 
-        return $out;
+        if ($count === 0) {
+            return null;
+        }
+
+        $average = $sum / (float) $count;
+        if ($average < $this->minAvgRainProb) {
+            return null;
+        }
+
+        return [
+            'rain_prob' => $average,
+        ];
     }
 }

--- a/src/Clusterer/RoadTripClusterStrategy.php
+++ b/src/Clusterer/RoadTripClusterStrategy.php
@@ -38,9 +38,9 @@ final class RoadTripClusterStrategy extends AbstractConsecutiveRunClusterStrateg
     /**
      * @param list<Media> $items
      */
-    protected function isDayEligible(string $day, array $items): bool
+    protected function isDayEligible(string $day, array $items, string $groupKey): bool
     {
-        if (!parent::isDayEligible($day, $items)) {
+        if (!parent::isDayEligible($day, $items, $groupKey)) {
             return false;
         }
 

--- a/src/Clusterer/RoadTripClusterStrategy.php
+++ b/src/Clusterer/RoadTripClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractConsecutiveRunClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,15 +13,16 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Detects multi-day road trips based on daily traveled distance (from GPS track).
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 88])]
-final class RoadTripClusterStrategy implements ClusterStrategyInterface
+final class RoadTripClusterStrategy extends AbstractConsecutiveRunClusterStrategy
 {
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
         private readonly float $minDailyKm = 120.0,
         private readonly int $minGpsSamplesPerDay = 8,
-        private readonly int $minNights = 3,       // => at least 4 days
-        private readonly int $minItemsTotal = 40
+        int $minNights = 3,       // => at least 4 days
+        int $minItemsTotal = 40,
+        string $timezone = 'Europe/Berlin'
     ) {
+        parent::__construct($timezone, $minGpsSamplesPerDay, $minItemsTotal, $minNights);
     }
 
     public function name(): string
@@ -29,121 +30,34 @@ final class RoadTripClusterStrategy implements ClusterStrategyInterface
         return 'road_trip';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            if ($m->getGpsLat() === null || $m->getGpsLon() === null) {
-                continue;
-            }
-            $d = $t->setTimezone($tz)->format('Y-m-d');
-            $byDay[$d] ??= [];
-            $byDay[$d][] = $m;
-        }
-
-        /** @var list<string> $travelDays */
-        $travelDays = [];
-        foreach ($byDay as $day => $list) {
-            if (\count($list) < $this->minGpsSamplesPerDay) {
-                continue;
-            }
-            \usort($list, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-            $km = 0.0;
-            for ($i = 1, $n = \count($list); $i < $n; $i++) {
-                $p = $list[$i - 1];
-                $q = $list[$i];
-                $km += MediaMath::haversineDistanceInMeters(
-                        (float) $p->getGpsLat(),
-                        (float) $p->getGpsLon(),
-                        (float) $q->getGpsLat(),
-                        (float) $q->getGpsLon()
-                    ) / 1000.0;
-            }
-            if ($km >= $this->minDailyKm) {
-                $travelDays[] = $day;
-            }
-        }
-
-        if ($travelDays === []) {
-            return [];
-        }
-
-        \sort($travelDays, \SORT_STRING);
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<string> $run */
-        $run = [];
-
-        $flush = function () use (&$run, &$out, $byDay): void {
-            if (\count($run) === 0) {
-                return;
-            }
-            $nights = \count($run) - 1;
-            if ($nights < $this->minNights) {
-                $run = [];
-                return;
-            }
-            /** @var list<Media> $members */
-            $members = [];
-            foreach ($run as $d) {
-                foreach ($byDay[$d] as $m) {
-                    $members[] = $m;
-                }
-            }
-            if (\count($members) < $this->minItemsTotal) {
-                $run = [];
-                return;
-            }
-
-            \usort($members, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-            $centroid = MediaMath::centroid($members);
-            $time     = MediaMath::timeRange($members);
-
-            $out[] = new ClusterDraft(
-                algorithm: 'road_trip',
-                params: [
-                    'nights'     => $nights,
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-            );
-
-            $run = [];
-        };
-
-        $prev = null;
-        foreach ($travelDays as $d) {
-            if ($prev !== null && !$this->isNextDay($prev, $d)) {
-                $flush();
-            }
-            $run[] = $d;
-            $prev  = $d;
-        }
-        $flush();
-
-        return $out;
+        return $media->getGpsLat() !== null && $media->getGpsLon() !== null;
     }
 
-    private function isNextDay(string $a, string $b): bool
+    /**
+     * @param list<Media> $items
+     */
+    protected function isDayEligible(string $day, array $items): bool
     {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
+        if (!parent::isDayEligible($day, $items)) {
             return false;
         }
-        return ($tb - $ta) === 86400;
+
+        \usort($items, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
+
+        $km = 0.0;
+        for ($i = 1, $n = \count($items); $i < $n; $i++) {
+            $prev = $items[$i - 1];
+            $curr = $items[$i];
+            $km += MediaMath::haversineDistanceInMeters(
+                (float) $prev->getGpsLat(),
+                (float) $prev->getGpsLon(),
+                (float) $curr->getGpsLat(),
+                (float) $curr->getGpsLon()
+            ) / 1000.0;
+        }
+
+        return $km >= $this->minDailyKm;
     }
 }

--- a/src/Clusterer/SeasonClusterStrategy.php
+++ b/src/Clusterer/SeasonClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\SeasonHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 58])]
 final class SeasonClusterStrategy extends AbstractGroupedClusterStrategy
 {
+    use SeasonHelperTrait;
+
     public function __construct(
         private readonly int $minItems = 20
     ) {
@@ -32,21 +35,9 @@ final class SeasonClusterStrategy extends AbstractGroupedClusterStrategy
             return null;
         }
 
-        $month = (int) $takenAt->format('n');
-        $year  = (int) $takenAt->format('Y');
+        $info = $this->seasonInfo($takenAt);
 
-        $season = match (true) {
-            $month >= 3 && $month <= 5  => 'Frühling',
-            $month >= 6 && $month <= 8  => 'Sommer',
-            $month >= 9 && $month <= 11 => 'Herbst',
-            default => 'Winter',
-        };
-
-        if ($season === 'Winter' && $month === 12) {
-            $year += 1;
-        }
-
-        return $year . ':' . $season;
+        return $info['seasonYear'] . ':' . $info['season'];
     }
 
     /**

--- a/src/Clusterer/SeasonClusterStrategy.php
+++ b/src/Clusterer/SeasonClusterStrategy.php
@@ -30,6 +30,14 @@ final class SeasonClusterStrategy extends AbstractTimezoneAwareGroupedClusterStr
         return 'season';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         $info = $this->seasonInfo($local);
@@ -42,10 +50,6 @@ final class SeasonClusterStrategy extends AbstractTimezoneAwareGroupedClusterStr
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         [$yearStr, $season] = \explode(':', $key, 2);
 
         return [

--- a/src/Clusterer/SeasonClusterStrategy.php
+++ b/src/Clusterer/SeasonClusterStrategy.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Winter is Dec–Feb (December assigned to next year).
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 58])]
-final class SeasonClusterStrategy implements ClusterStrategyInterface
+final class SeasonClusterStrategy extends AbstractGroupedClusterStrategy
 {
     public function __construct(
         private readonly int $minItems = 20
@@ -25,66 +25,44 @@ final class SeasonClusterStrategy implements ClusterStrategyInterface
         return 'season';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function groupKey(Media $media): ?string
     {
-        /** @var array<string, list<Media>> $groups */
-        $groups = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $month = (int) $t->format('n');
-            $year  = (int) $t->format('Y');
-
-            $season = match (true) {
-                $month >= 3 && $month <= 5  => 'Frühling',
-                $month >= 6 && $month <= 8  => 'Sommer',
-                $month >= 9 && $month <= 11 => 'Herbst',
-                default => 'Winter',
-            };
-
-            // Winter: Dezember gehört zum Winter des Folgejahres (2024-12 ⇒ Winter 2025)
-            if ($season === 'Winter' && $month === 12) {
-                $year += 1;
-            }
-
-            $key = $year . ':' . $season;
-            $groups[$key] ??= [];
-            $groups[$key][] = $m;
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
         }
 
-        /** @var list<ClusterDraft> $out */
-        $out = [];
+        $month = (int) $takenAt->format('n');
+        $year  = (int) $takenAt->format('Y');
 
-        foreach ($groups as $key => $members) {
-            if (\count($members) < $this->minItems) {
-                continue;
-            }
+        $season = match (true) {
+            $month >= 3 && $month <= 5  => 'Frühling',
+            $month >= 6 && $month <= 8  => 'Sommer',
+            $month >= 9 && $month <= 11 => 'Herbst',
+            default => 'Winter',
+        };
 
-            [$yearStr, $season] = \explode(':', $key, 2);
-            $yearInt = (int) $yearStr;
-
-            $centroid = MediaMath::centroid($members);
-            $time     = MediaMath::timeRange($members);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'label'      => $season,
-                    'year'       => $yearInt,
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-            );
+        if ($season === 'Winter' && $month === 12) {
+            $year += 1;
         }
 
-        return $out;
+        return $year . ':' . $season;
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    protected function groupParams(string $key, array $members): ?array
+    {
+        if (\count($members) < $this->minItems) {
+            return null;
+        }
+
+        [$yearStr, $season] = \explode(':', $key, 2);
+
+        return [
+            'label' => $season,
+            'year' => (int) $yearStr,
+        ];
     }
 }

--- a/src/Clusterer/SeasonOverYearsClusterStrategy.php
+++ b/src/Clusterer/SeasonOverYearsClusterStrategy.php
@@ -31,6 +31,14 @@ final class SeasonOverYearsClusterStrategy extends AbstractTimezoneAwareGroupedC
         return 'season_over_years';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         return $this->seasonInfo($local)['season'];
@@ -41,10 +49,6 @@ final class SeasonOverYearsClusterStrategy extends AbstractTimezoneAwareGroupedC
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         $yearsMap = $this->uniqueLocalDateParts($members, 'Y');
         if (\count($yearsMap) < $this->minYears) {
             return null;

--- a/src/Clusterer/SeasonOverYearsClusterStrategy.php
+++ b/src/Clusterer/SeasonOverYearsClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\SeasonHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class SeasonOverYearsClusterStrategy extends AbstractGroupedClusterStrategy
 {
+    use SeasonHelperTrait;
+
     public function __construct(
         private readonly int $minYears = 3,
         private readonly int $minItems = 30
@@ -33,14 +36,7 @@ final class SeasonOverYearsClusterStrategy extends AbstractGroupedClusterStrateg
             return null;
         }
 
-        $month = (int) $takenAt->format('n');
-
-        return match (true) {
-            $month >= 3 && $month <= 5  => 'Frühling',
-            $month >= 6 && $month <= 8  => 'Sommer',
-            $month >= 9 && $month <= 11 => 'Herbst',
-            default => 'Winter',
-        };
+        return $this->seasonInfo($takenAt)['season'];
     }
 
     /**

--- a/src/Clusterer/SignificantPlaceClusterStrategy.php
+++ b/src/Clusterer/SignificantPlaceClusterStrategy.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\Support\AbstractGeoCellClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -13,13 +14,14 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Creates one cluster per significant place with enough distinct visit days.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 82])]
-final class SignificantPlaceClusterStrategy implements ClusterStrategyInterface
+final class SignificantPlaceClusterStrategy extends AbstractGeoCellClusterStrategy
 {
     public function __construct(
-        private readonly float $gridDegrees = 0.01, // ~1.1 km in lat (varies with lon)
+        float $gridDegrees = 0.01,
         private readonly int $minVisitDays = 3,
         private readonly int $minItemsTotal = 20
     ) {
+        parent::__construct($gridDegrees);
     }
 
     public function name(): string
@@ -27,67 +29,37 @@ final class SignificantPlaceClusterStrategy implements ClusterStrategyInterface
         return 'significant_place';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media): bool
     {
-        /** @var array<string, list<Media>> $byCell */
-        $byCell = [];
-
-        foreach ($items as $m) {
-            $lat = $m->getGpsLat();
-            $lon = $m->getGpsLon();
-            $t   = $m->getTakenAt();
-            if ($lat === null || $lon === null || !$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $cell = $this->cellKey((float) $lat, (float) $lon);
-            $byCell[$cell] ??= [];
-            $byCell[$cell][] = $m;
-        }
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-
-        foreach ($byCell as $cell => $list) {
-            if (\count($list) < $this->minItemsTotal) {
-                continue;
-            }
-
-            /** @var array<string,bool> $days */
-            $days = [];
-            foreach ($list as $m) {
-                $days[$m->getTakenAt()->format('Y-m-d')] = true;
-            }
-            if (\count($days) < $this->minVisitDays) {
-                continue;
-            }
-
-            $centroid = MediaMath::centroid($list);
-            $time     = MediaMath::timeRange($list);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'grid_cell'   => $cell,
-                    'visit_days'  => \count($days),
-                    'time_range'  => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $list)
-            );
-        }
-
-        return $out;
+        return $media->getTakenAt() instanceof DateTimeImmutable;
     }
 
-    private function cellKey(float $lat, float $lon): string
+    protected function minMembersPerCell(): int
     {
-        $gd = $this->gridDegrees;
-        $rlat = $gd * \floor($lat / $gd);
-        $rlon = $gd * \floor($lon / $gd);
-        return \sprintf('%.4f,%.4f', $rlat, $rlon);
+        return $this->minItemsTotal;
+    }
+
+    /**
+     * @param list<Media> $members
+     * @return list<ClusterDraft>
+     */
+    protected function clustersForCell(string $cell, array $members): array
+    {
+        $visitDays = $this->uniqueDateParts($members, 'Y-m-d');
+
+        if (\count($visitDays) < $this->minVisitDays) {
+            return [];
+        }
+
+        return [
+            $this->buildClusterDraft(
+                $this->name(),
+                $members,
+                [
+                    'grid_cell'  => $cell,
+                    'visit_days' => \count($visitDays),
+                ]
+            ),
+        ];
     }
 }

--- a/src/Clusterer/SnowDayClusterStrategy.php
+++ b/src/Clusterer/SnowDayClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Builds "Snow Day" clusters using winter months and snow/ski keywords.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 55])]
-final class SnowDayClusterStrategy extends AbstractTimeGapClusterStrategy
+final class SnowDayClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = ['schnee', 'snow', 'ski', 'langlauf', 'skitour', 'snowboard', 'piste', 'eiszapfen'];
@@ -30,11 +30,15 @@ final class SnowDayClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'snow_day';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
+    {
+        return self::KEYWORDS;
+    }
+
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
         $month = (int) $local->format('n');
-        $isWinter = $month === 12 || $month <= 2;
 
-        return $isWinter && $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return $month === 12 || $month <= 2;
     }
 }

--- a/src/Clusterer/SnowDayClusterStrategy.php
+++ b/src/Clusterer/SnowDayClusterStrategy.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds "Snow Day" clusters using winter months and snow/ski keywords.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 55])]
-final class SnowDayClusterStrategy implements ClusterStrategyInterface
+final class SnowDayClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = ['schnee', 'snow', 'ski', 'langlauf', 'skitour', 'snowboard', 'piste', 'eiszapfen'];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 2 * 3600,
-        private readonly int $minItems = 6
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 2 * 3600,
+        int $minItems = 6
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -27,89 +30,11 @@ final class SnowDayClusterStrategy implements ClusterStrategyInterface
         return 'snow_day';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
+        $month = (int) $local->format('n');
+        $isWinter = $month === 12 || $month <= 2;
 
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $month = (int) $local->format('n');
-            $winter = ($month === 12 || $month <= 2);
-            $path = \strtolower($m->getPath());
-            if ($winter && $this->looksSnow($path)) {
-                $cand[] = $m;
-            }
-        }
-
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $lastTs = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($lastTs !== null && ($ts - $lastTs) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $lastTs = $ts;
-        }
-        $flush();
-
-        return $out;
-    }
-
-    private function looksSnow(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['schnee', 'snow', 'ski', 'langlauf', 'skitour', 'snowboard', 'piste', 'eiszapfen'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return $isWinter && $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 }

--- a/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
+++ b/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
@@ -4,33 +4,28 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractKeywordConsecutiveRunOverYearsStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best multi-day winter snow vacation per year and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
-final class SnowVacationOverYearsClusterStrategy implements ClusterStrategyInterface
+final class SnowVacationOverYearsClusterStrategy extends AbstractKeywordConsecutiveRunOverYearsStrategy
 {
-    use ClusterBuildHelperTrait;
-
     /** @var list<string> */
     private const KEYWORDS = ['schnee', 'snow', 'ski', 'langlauf', 'skitour', 'snowboard', 'piste', 'gondel', 'lift', 'alpen', 'hütte', 'huette'];
 
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 4,
-        private readonly int $minNights = 3,
-        private readonly int $maxNights = 14,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 30
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 4,
+        int $minNights = 3,
+        int $maxNights = 14,
+        int $minYears = 3,
+        int $minItemsTotal = 30
     ) {
-        if ($this->maxNights < $this->minNights) {
-            throw new \InvalidArgumentException('maxNights must be >= minNights.');
-        }
+        parent::__construct($timezone, $minNights, $maxNights, $minItemsPerDay, $minYears, $minItemsTotal);
     }
 
     public function name(): string
@@ -38,84 +33,21 @@ final class SnowVacationOverYearsClusterStrategy implements ClusterStrategyInter
         return 'snow_vacation_over_years';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        $byYearDay = $this->buildYearDayIndex(
-            $items,
-            $tz,
-            function (Media $media, DateTimeImmutable $local): bool {
-                if (!$this->mediaPathContains($media, self::KEYWORDS)) {
-                    return false;
-                }
-
-                $month = (int) $local->format('n');
-                return $month === 12 || $month <= 2;
-            }
-        );
-
-        $membersAllYears = [];
-        $yearsPicked     = [];
-
-        foreach ($byYearDay as $year => $daysMap) {
-            $runs = $this->buildConsecutiveRuns($daysMap);
-
-            $candidates = [];
-            foreach ($runs as $run) {
-                $nights = \count($run['days']) - 1;
-                if ($nights < $this->minNights || $nights > $this->maxNights) {
-                    continue;
-                }
-
-                $ok = true;
-                foreach ($run['days'] as $day) {
-                    if (\count($daysMap[$day]) < $this->minItemsPerDay) {
-                        $ok = false;
-                        break;
-                    }
-                }
-
-                if ($ok) {
-                    $candidates[] = $run;
-                }
-            }
-
-            if ($candidates === []) {
-                continue;
-            }
-
-            \usort($candidates, static function (array $a, array $b): int {
-                $na = \count($a['items']);
-                $nb = \count($b['items']);
-                if ($na !== $nb) {
-                    return $na < $nb ? 1 : -1;
-                }
-                $sa = \count($a['days']);
-                $sb = \count($b['days']);
-                if ($sa !== $sb) {
-                    return $sa < $sb ? 1 : -1;
-                }
-                return \strcmp($a['days'][0], $b['days'][0]);
-            });
-
-            $best = $candidates[0];
-            foreach ($best['items'] as $media) {
-                $membersAllYears[] = $media;
-            }
-            $yearsPicked[$year] = true;
+        if (!parent::shouldConsider($media, $local)) {
+            return false;
         }
 
-        return $this->buildOverYearsDrafts(
-            $membersAllYears,
-            $yearsPicked,
-            $this->minYears,
-            $this->minItemsTotal,
-            $this->name()
-        );
+        $month = (int) $local->format('n');
+        return $month === 12 || $month <= 2;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function keywords(): array
+    {
+        return self::KEYWORDS;
     }
 }

--- a/src/Clusterer/SportsEventClusterStrategy.php
+++ b/src/Clusterer/SportsEventClusterStrategy.php
@@ -4,24 +4,34 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Sports events based on keywords (stadium/match/club names) and weekend bias.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 78])]
-final class SportsEventClusterStrategy implements ClusterStrategyInterface
+final class SportsEventClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'stadion', 'arena', 'sportpark', 'eishalle',
+        'match', 'spiel', 'game', 'derby',
+        'fussball', 'fußball', 'football', 'soccer',
+        'handball', 'basketball', 'eishockey', 'hockey',
+        'tennis', 'marathon', 'lauf', 'run', 'triathlon',
+        'bundesliga', 'dfb', 'uefa', 'champions', 'cup',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 3 * 3600,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 3 * 3600,
         private readonly float $radiusMeters = 500.0,
-        private readonly int $minItems = 5,
+        int $minItems = 5,
         private readonly bool $preferWeekend = true
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -29,119 +39,31 @@ final class SportsEventClusterStrategy implements ClusterStrategyInterface
         return 'sports_event';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if (!$this->looksSporty($path)) {
-                continue;
-            }
-            if ($this->preferWeekend) {
-                $dow = (int) $t->setTimezone($tz)->format('N'); // 1..7
-                if ($dow !== 6 && $dow !== 7) {
-                    // still allow, but you could continue; here we keep it lenient
-                }
-            }
-            $cand[] = $m;
+        if (!$this->mediaMatchesKeywords($media, self::KEYWORDS)) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
+        if (!$this->preferWeekend) {
+            return true;
         }
 
-        \usort($cand, static fn(Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            // compactness (stadium/arena)
-            $ok = true;
-            foreach ($gps as $m) {
-                $d = MediaMath::haversineDistanceInMeters(
-                    (float)$centroid['lat'], (float)$centroid['lon'],
-                    (float)$m->getGpsLat(), (float)$m->getGpsLon()
-                );
-                if ($d > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if ($ok === false) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
+        $dow = (int) $local->format('N');
+        if ($dow === 6 || $dow === 7) {
+            return true;
         }
-        $flush();
 
-        return $out;
+        // Keep weekday shots for leniency, mirroring the previous implementation.
+        return true;
     }
 
-    private function looksSporty(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = [
-            'stadion', 'arena', 'sportpark', 'eishalle',
-            'match', 'spiel', 'game', 'derby',
-            'fussball', 'fußball', 'football', 'soccer',
-            'handball', 'basketball', 'eishockey', 'hockey',
-            'tennis', 'marathon', 'lauf', 'run', 'triathlon',
-            'bundesliga', 'dfb', 'uefa', 'champions', 'cup'
-        ];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\MediaMath;
+
+/**
+ * Shared logic for at-home day/weekend clustering strategies.
+ */
+abstract class AbstractAtHomeClusterStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(
+        private readonly ?float $homeLat,
+        private readonly ?float $homeLon,
+        private readonly float $homeRadiusMeters,
+        private readonly float $minHomeShare,
+        private readonly int $minItemsPerDay,
+        private readonly int $minItemsTotal,
+        string $timezone
+    ) {
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        if ($this->homeLat === null || $this->homeLon === null) {
+            return [];
+        }
+
+        $byDay = $this->groupByDay($items);
+        if ($byDay === []) {
+            return [];
+        }
+
+        $homeOnly = $this->filterHomeDays($byDay);
+        if ($homeOnly === []) {
+            return [];
+        }
+
+        $runs = $this->buildConsecutiveRuns($homeOnly);
+
+        $drafts = [];
+        foreach ($runs as $run) {
+            if (\count($run['items']) < $this->minItemsTotal) {
+                continue;
+            }
+
+            $drafts[] = $this->buildClusterDraft(
+                $this->name(),
+                $run['items'],
+                $this->additionalDraftParams($run)
+            );
+        }
+
+        return $drafts;
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return array<string, list<Media>>
+     */
+    private function groupByDay(array $items): array
+    {
+        $byDay = [];
+
+        foreach ($items as $media) {
+            $takenAt = $media->getTakenAt();
+            if (!$takenAt instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            $local = $takenAt->setTimezone($this->timezone);
+            $dow   = (int) $local->format('N');
+            if (!$this->isDesiredDay($dow)) {
+                continue;
+            }
+
+            $key = $local->format('Y-m-d');
+            $byDay[$key] ??= [];
+            $byDay[$key][] = $media;
+        }
+
+        return $byDay;
+    }
+
+    /**
+     * @param array<string, list<Media>> $byDay
+     * @return array<string, list<Media>>
+     */
+    private function filterHomeDays(array $byDay): array
+    {
+        $homeOnly = [];
+
+        foreach ($byDay as $day => $list) {
+            if (\count($list) < $this->minItemsPerDay) {
+                continue;
+            }
+
+            $within = [];
+            foreach ($list as $media) {
+                $lat = $media->getGpsLat();
+                $lon = $media->getGpsLon();
+                if ($lat === null || $lon === null) {
+                    continue;
+                }
+
+                $dist = MediaMath::haversineDistanceInMeters(
+                    (float) $lat,
+                    (float) $lon,
+                    (float) $this->homeLat,
+                    (float) $this->homeLon
+                );
+
+                if ($dist <= $this->homeRadiusMeters) {
+                    $within[] = $media;
+                }
+            }
+
+            if ($within === []) {
+                continue;
+            }
+
+            $share = \count($within) / (float) \count($list);
+            if ($share >= $this->minHomeShare) {
+                $homeOnly[$day] = $within;
+            }
+        }
+
+        return $homeOnly;
+    }
+
+    /**
+     * @param array{days:list<string>, items:list<Media>} $run
+     * @return array<string,mixed>
+     */
+    protected function additionalDraftParams(array $run): array
+    {
+        return [];
+    }
+
+    /**
+     * @param int $dayOfWeek 1=Mon..7=Sun
+     */
+    abstract protected function isDesiredDay(int $dayOfWeek): bool;
+}

--- a/src/Clusterer/Support/AbstractBestDayOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractBestDayOverYearsStrategy.php
@@ -85,11 +85,4 @@ abstract class AbstractBestDayOverYearsStrategy implements ClusterStrategyInterf
         return $this->minItemsTotal;
     }
 
-    /**
-     * @param list<string> $keywords
-     */
-    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
-    {
-        return $this->mediaPathContains($media, $keywords);
-    }
 }

--- a/src/Clusterer/Support/AbstractBestDayOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractBestDayOverYearsStrategy.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Base class for strategies that pick the best day per year and aggregate the result across years.
+ */
+abstract class AbstractBestDayOverYearsStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(
+        string $timezone,
+        private readonly int $minItemsPerDay,
+        private readonly int $minYears,
+        private readonly int $minItemsTotal
+    ) {
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        $byYearDay = $this->buildYearDayIndex(
+            $items,
+            $this->timezone(),
+            fn (Media $media, DateTimeImmutable $local): bool => $this->shouldConsider($media, $local)
+        );
+
+        $best = $this->pickBestDayPerYear($byYearDay, $this->minItemsPerDay);
+
+        return $this->buildOverYearsDrafts(
+            $best['members'],
+            $best['years'],
+            $this->minYears,
+            $this->minItemsTotal,
+            $this->name(),
+            $this->additionalDraftParams($best)
+        );
+    }
+
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array{members:list<Media>, years:array<int,bool>} $best
+     * @return array<string,mixed>
+     */
+    protected function additionalDraftParams(array $best): array
+    {
+        return [];
+    }
+
+    protected function timezone(): DateTimeZone
+    {
+        return $this->timezone;
+    }
+
+    protected function minItemsPerDay(): int
+    {
+        return $this->minItemsPerDay;
+    }
+
+    protected function minYears(): int
+    {
+        return $this->minYears;
+    }
+
+    protected function minItemsTotal(): int
+    {
+        return $this->minItemsTotal;
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
+    {
+        return $this->mediaPathContains($media, $keywords);
+    }
+}

--- a/src/Clusterer/Support/AbstractConsecutiveRunClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractConsecutiveRunClusterStrategy.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use InvalidArgumentException;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Base implementation for multi-day run strategies operating on consecutive days.
+ */
+abstract class AbstractConsecutiveRunClusterStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(
+        string $timezone,
+        private readonly int $minItemsPerDay,
+        private readonly int $minItemsTotal,
+        private readonly int $minNights,
+        private readonly int $maxNights = \PHP_INT_MAX
+    ) {
+        if ($maxNights < $minNights) {
+            throw new InvalidArgumentException('maxNights must be >= minNights.');
+        }
+
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        if (!$this->isEnabled()) {
+            return [];
+        }
+
+        $daysMap = $this->buildDaysMap($items);
+
+        foreach ($daysMap as $day => $list) {
+            if (!$this->isDayEligible($day, $list)) {
+                unset($daysMap[$day]);
+            }
+        }
+
+        if ($daysMap === []) {
+            return [];
+        }
+
+        $drafts = [];
+        $runs = $this->buildConsecutiveRuns($daysMap);
+
+        foreach ($runs as $run) {
+            $nights = \max(0, \count($run['days']) - 1);
+            if ($nights < $this->minNights || $nights > $this->maxNights) {
+                continue;
+            }
+
+            $members = $run['items'];
+            if (\count($members) < $this->minItemsTotal) {
+                continue;
+            }
+
+            if (!$this->isRunValid($run, $daysMap, $nights, $members)) {
+                continue;
+            }
+
+            $drafts[] = $this->buildClusterDraft(
+                $this->name(),
+                $members,
+                $this->runParams($run, $daysMap, $nights, $members)
+            );
+        }
+
+        return $drafts;
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return array<string, list<Media>>
+     */
+    private function buildDaysMap(array $items): array
+    {
+        $map = [];
+
+        foreach ($items as $media) {
+            $takenAt = $media->getTakenAt();
+            if (!$takenAt instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            $local = $takenAt->setTimezone($this->timezone);
+            if (!$this->shouldConsider($media, $local)) {
+                continue;
+            }
+
+            $day = $local->format('Y-m-d');
+            $map[$day] ??= [];
+            $map[$day][] = $media;
+        }
+
+        return $map;
+    }
+
+    protected function isEnabled(): bool
+    {
+        return true;
+    }
+
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param list<Media> $items
+     */
+    protected function isDayEligible(string $day, array $items): bool
+    {
+        return \count($items) >= $this->minItemsPerDay;
+    }
+
+    /**
+     * @param array{days:list<string>, items:list<Media>} $run
+     * @param array<string, list<Media>> $daysMap
+     * @param list<Media> $members
+     */
+    protected function isRunValid(array $run, array $daysMap, int $nights, array $members): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param array{days:list<string>, items:list<Media>} $run
+     * @param array<string, list<Media>> $daysMap
+     * @param list<Media> $members
+     * @return array<string, mixed>
+     */
+    protected function runParams(array $run, array $daysMap, int $nights, array $members): array
+    {
+        return ['nights' => $nights];
+    }
+
+    protected function timezone(): DateTimeZone
+    {
+        return $this->timezone;
+    }
+
+    protected function minItemsPerDay(): int
+    {
+        return $this->minItemsPerDay;
+    }
+
+    protected function minItemsTotal(): int
+    {
+        return $this->minItemsTotal;
+    }
+
+    protected function minNights(): int
+    {
+        return $this->minNights;
+    }
+
+    protected function maxNights(): int
+    {
+        return $this->maxNights;
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
+    {
+        return $this->mediaPathContains($media, $keywords);
+    }
+}

--- a/src/Clusterer/Support/AbstractConsecutiveRunClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractConsecutiveRunClusterStrategy.php
@@ -213,11 +213,4 @@ abstract class AbstractConsecutiveRunClusterStrategy implements ClusterStrategyI
         return $this->maxNights;
     }
 
-    /**
-     * @param list<string> $keywords
-     */
-    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
-    {
-        return $this->mediaPathContains($media, $keywords);
-    }
 }

--- a/src/Clusterer/Support/AbstractConsecutiveRunOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractConsecutiveRunOverYearsStrategy.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use InvalidArgumentException;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Base class for strategies that pick the best multi-day run per year and aggregate the result across years.
+ */
+abstract class AbstractConsecutiveRunOverYearsStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(
+        string $timezone,
+        private readonly int $minNights,
+        private readonly int $maxNights,
+        private readonly int $minItemsPerDay,
+        private readonly int $minYears,
+        private readonly int $minItemsTotal
+    ) {
+        if ($maxNights < $minNights) {
+            throw new InvalidArgumentException('maxNights must be >= minNights.');
+        }
+
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        $byYearDay = $this->buildYearDayIndex(
+            $items,
+            $this->timezone,
+            fn (Media $media, DateTimeImmutable $local): bool => $this->shouldConsider($media, $local)
+        );
+
+        $membersAllYears = [];
+        $yearsPicked = [];
+
+        foreach ($byYearDay as $year => $daysMap) {
+            $best = $this->findBestRun($daysMap);
+            if ($best === null) {
+                continue;
+            }
+
+            foreach ($best['items'] as $media) {
+                $membersAllYears[] = $media;
+            }
+            $yearsPicked[$year] = true;
+        }
+
+        return $this->buildOverYearsDrafts(
+            $membersAllYears,
+            $yearsPicked,
+            $this->minYears,
+            $this->minItemsTotal,
+            $this->name(),
+            $this->additionalDraftParams()
+        );
+    }
+
+    /**
+     * @param array<string, list<Media>> $daysMap
+     * @return array{days:list<string>, items:list<Media>}|null
+     */
+    private function findBestRun(array $daysMap): ?array
+    {
+        foreach ($daysMap as $day => $list) {
+            if (!$this->isDayEligible($day, $list)) {
+                unset($daysMap[$day]);
+            }
+        }
+
+        if ($daysMap === []) {
+            return null;
+        }
+
+        $runs = $this->buildConsecutiveRuns($daysMap);
+
+        $candidates = [];
+        foreach ($runs as $run) {
+            $nights = \count($run['days']) - 1;
+            if ($nights < $this->minNights || $nights > $this->maxNights) {
+                continue;
+            }
+            if (!$this->isRunValid($run, $daysMap)) {
+                continue;
+            }
+            $candidates[] = $run;
+        }
+
+        if ($candidates === []) {
+            return null;
+        }
+
+        \usort($candidates, self::runComparator());
+
+        return $candidates[0];
+    }
+
+    /**
+     * @return callable(array{days:list<string>, items:list<Media>}, array{days:list<string>, items:list<Media>}):int
+     */
+    private static function runComparator(): callable
+    {
+        return static function (array $a, array $b): int {
+            $na = \count($a['items']);
+            $nb = \count($b['items']);
+            if ($na !== $nb) {
+                return $na < $nb ? 1 : -1;
+            }
+
+            $sa = \count($a['days']);
+            $sb = \count($b['days']);
+            if ($sa !== $sb) {
+                return $sa < $sb ? 1 : -1;
+            }
+
+            return \strcmp($a['days'][0], $b['days'][0]);
+        };
+    }
+
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param list<Media> $items
+     */
+    protected function isDayEligible(string $day, array $items): bool
+    {
+        return \count($items) >= $this->minItemsPerDay;
+    }
+
+    /**
+     * @param array{days:list<string>, items:list<Media>} $run
+     * @param array<string, list<Media>> $daysMap
+     */
+    protected function isRunValid(array $run, array $daysMap): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function additionalDraftParams(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
+    {
+        return $this->mediaPathContains($media, $keywords);
+    }
+
+    /**
+     * @param list<string> $days
+     */
+    protected function containsWeekendDay(array $days): bool
+    {
+        foreach ($days as $d) {
+            $ts = \strtotime($d . ' 12:00:00');
+            if ($ts === false) {
+                continue;
+            }
+            $dow = (int) \gmdate('N', $ts);
+            if ($dow === 6 || $dow === 7) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Clusterer/Support/AbstractConsecutiveRunOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractConsecutiveRunOverYearsStrategy.php
@@ -163,14 +163,6 @@ abstract class AbstractConsecutiveRunOverYearsStrategy implements ClusterStrateg
     }
 
     /**
-     * @param list<string> $keywords
-     */
-    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
-    {
-        return $this->mediaPathContains($media, $keywords);
-    }
-
-    /**
      * @param list<string> $days
      */
     protected function containsWeekendDay(array $days): bool

--- a/src/Clusterer/Support/AbstractFilteredOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractFilteredOverYearsStrategy.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Base for strategies that filter media per year and build a single over-years memory.
+ */
+abstract class AbstractFilteredOverYearsStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(
+        string $timezone,
+        private readonly int $perYearMin,
+        private readonly int $minYears,
+        private readonly int $minItemsTotal
+    ) {
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        /** @var array<int, list<Media>> $byYear */
+        $byYear = [];
+
+        foreach ($items as $media) {
+            $takenAt = $media->getTakenAt();
+            if (!$takenAt instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            $local = $takenAt->setTimezone($this->timezone);
+            if (!$this->shouldInclude($media, $local)) {
+                continue;
+            }
+
+            $year = (int) $local->format('Y');
+            $byYear[$year] ??= [];
+            $byYear[$year][] = $media;
+        }
+
+        if ($byYear === []) {
+            return [];
+        }
+
+        $members = [];
+        $years = [];
+
+        foreach ($byYear as $year => $list) {
+            if (!$this->isYearEligible($year, $list)) {
+                continue;
+            }
+
+            $normalized = $this->normalizeYearMembers($year, $list);
+            if ($normalized === []) {
+                continue;
+            }
+
+            foreach ($normalized as $media) {
+                $members[] = $media;
+            }
+
+            $years[$year] = true;
+        }
+
+        return $this->buildOverYearsDrafts(
+            $members,
+            $years,
+            $this->minYears,
+            $this->minItemsTotal,
+            $this->name(),
+            $this->additionalDraftParams($members, $years)
+        );
+    }
+
+    protected function timezone(): DateTimeZone
+    {
+        return $this->timezone;
+    }
+
+    protected function perYearMin(): int
+    {
+        return $this->perYearMin;
+    }
+
+    protected function minYears(): int
+    {
+        return $this->minYears;
+    }
+
+    protected function minItemsTotal(): int
+    {
+        return $this->minItemsTotal;
+    }
+
+    protected function isYearEligible(int $year, array $members): bool
+    {
+        return \count($members) >= $this->perYearMin;
+    }
+
+    /**
+     * @param list<Media> $members
+     *
+     * @return list<Media>
+     */
+    protected function normalizeYearMembers(int $year, array $members): array
+    {
+        return $members;
+    }
+
+    /**
+     * @param list<Media> $members
+     * @param array<int, bool> $years
+     *
+     * @return array<string, mixed>
+     */
+    protected function additionalDraftParams(array $members, array $years): array
+    {
+        return [];
+    }
+
+    abstract protected function shouldInclude(Media $media, DateTimeImmutable $local): bool;
+}

--- a/src/Clusterer/Support/AbstractFilteredTimeGapClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractFilteredTimeGapClusterStrategy.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Extension of the session-based time gap strategy that adds reusable keyword filtering
+ * and optional spatial radius validation for compact event clusters.
+ */
+abstract class AbstractFilteredTimeGapClusterStrategy extends AbstractTimeGapClusterStrategy
+{
+    /**
+     * @return list<string>
+     */
+    protected function keywords(): array
+    {
+        return [];
+    }
+
+    final protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        if (!$this->passesContextFilters($media, $local)) {
+            return false;
+        }
+
+        $keywords = $this->keywords();
+        if ($keywords !== [] && !$this->mediaMatchesKeywords($media, $keywords)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
+    {
+        return true;
+    }
+
+    protected function sessionRadiusMeters(): ?float
+    {
+        return null;
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
+    {
+        if (!parent::isSessionValid($members)) {
+            return false;
+        }
+
+        $radius = $this->sessionRadiusMeters();
+        if ($radius === null) {
+            return true;
+        }
+
+        return $this->allWithinRadius($members, $radius);
+    }
+}

--- a/src/Clusterer/Support/AbstractGeoCellClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractGeoCellClusterStrategy.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Base for strategies that group media by coarse geo cells before building clusters.
+ */
+abstract class AbstractGeoCellClusterStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    public function __construct(private readonly float $gridDegrees = 0.01)
+    {
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        /** @var array<string, list<Media>> $cells */
+        $cells = [];
+
+        foreach ($items as $media) {
+            $lat = $media->getGpsLat();
+            $lon = $media->getGpsLon();
+            if ($lat === null || $lon === null) {
+                continue;
+            }
+
+            if (!$this->shouldConsider($media)) {
+                continue;
+            }
+
+            $key = $this->cellKey((float) $lat, (float) $lon);
+            $cells[$key] ??= [];
+            $cells[$key][] = $media;
+        }
+
+        if ($cells === []) {
+            return [];
+        }
+
+        $drafts = [];
+
+        foreach ($cells as $cell => $members) {
+            if (\count($members) < $this->minMembersPerCell()) {
+                continue;
+            }
+
+            foreach ($this->clustersForCell($cell, $members) as $draft) {
+                $drafts[] = $draft;
+            }
+        }
+
+        return $drafts;
+    }
+
+    protected function shouldConsider(Media $media): bool
+    {
+        return true;
+    }
+
+    protected function minMembersPerCell(): int
+    {
+        return 1;
+    }
+
+    /**
+     * @param list<Media> $members
+     * @return list<ClusterDraft>
+     */
+    abstract protected function clustersForCell(string $cell, array $members): array;
+
+    protected function cellKey(float $lat, float $lon): string
+    {
+        $gd = $this->gridDegrees;
+        $rlat = $gd * \floor($lat / $gd);
+        $rlon = $gd * \floor($lon / $gd);
+
+        return \sprintf('%.4f,%.4f', $rlat, $rlon);
+    }
+
+    protected function gridDegrees(): float
+    {
+        return $this->gridDegrees;
+    }
+}

--- a/src/Clusterer/Support/AbstractGroupedClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractGroupedClusterStrategy.php
@@ -46,6 +46,11 @@ abstract class AbstractGroupedClusterStrategy implements ClusterStrategyInterfac
         $drafts = [];
 
         foreach ($groups as $key => $members) {
+            $minSize = $this->minimumGroupSize($key, $members);
+            if ($minSize > 0 && \count($members) < $minSize) {
+                continue;
+            }
+
             $params = $this->groupParams($key, $members);
             if ($params === null) {
                 continue;
@@ -65,6 +70,14 @@ abstract class AbstractGroupedClusterStrategy implements ClusterStrategyInterfac
     protected function shouldConsider(Media $media): bool
     {
         return true;
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return 0;
     }
 
     abstract protected function groupKey(Media $media): ?string;

--- a/src/Clusterer/Support/AbstractGroupedClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractGroupedClusterStrategy.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Base class for strategies that bucket media into keyed groups and build a single cluster per key.
+ */
+abstract class AbstractGroupedClusterStrategy implements ClusterStrategyInterface
+{
+    use ClusterBuildHelperTrait;
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    final public function cluster(array $items): array
+    {
+        /** @var array<string, list<Media>> $groups */
+        $groups = [];
+
+        foreach ($items as $media) {
+            if (!$this->shouldConsider($media)) {
+                continue;
+            }
+
+            $key = $this->groupKey($media);
+            if ($key === null) {
+                continue;
+            }
+
+            $groups[$key] ??= [];
+            $groups[$key][] = $media;
+        }
+
+        if ($groups === []) {
+            return [];
+        }
+
+        $drafts = [];
+
+        foreach ($groups as $key => $members) {
+            $params = $this->groupParams($key, $members);
+            if ($params === null) {
+                continue;
+            }
+
+            $drafts[] = $this->buildClusterDraft($this->name(), $members, $params);
+        }
+
+        return $drafts;
+    }
+
+    protected function shouldConsider(Media $media): bool
+    {
+        return true;
+    }
+
+    abstract protected function groupKey(Media $media): ?string;
+
+    /**
+     * @param list<Media> $members
+     *
+     * @return array<string, mixed>|null Null to skip the group.
+     */
+    abstract protected function groupParams(string $key, array $members): ?array;
+}

--- a/src/Clusterer/Support/AbstractGroupedClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractGroupedClusterStrategy.php
@@ -20,6 +20,8 @@ abstract class AbstractGroupedClusterStrategy implements ClusterStrategyInterfac
      */
     final public function cluster(array $items): array
     {
+        $this->beforeGrouping();
+
         /** @var array<string, list<Media>> $groups */
         $groups = [];
 
@@ -53,6 +55,11 @@ abstract class AbstractGroupedClusterStrategy implements ClusterStrategyInterfac
         }
 
         return $drafts;
+    }
+
+    protected function beforeGrouping(): void
+    {
+        // Default no-op hook for subclasses that need to prepare per-run context.
     }
 
     protected function shouldConsider(Media $media): bool

--- a/src/Clusterer/Support/AbstractKeywordBestDayOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractKeywordBestDayOverYearsStrategy.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Adds keyword based filtering to {@see AbstractBestDayOverYearsStrategy}.
+ */
+abstract class AbstractKeywordBestDayOverYearsStrategy extends AbstractBestDayOverYearsStrategy
+{
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        return $this->mediaMatchesKeywords($media, $this->keywords());
+    }
+
+    /**
+     * @return list<string>
+     */
+    abstract protected function keywords(): array;
+}

--- a/src/Clusterer/Support/AbstractKeywordConsecutiveRunOverYearsStrategy.php
+++ b/src/Clusterer/Support/AbstractKeywordConsecutiveRunOverYearsStrategy.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Adds keyword based filtering to {@see AbstractConsecutiveRunOverYearsStrategy}.
+ */
+abstract class AbstractKeywordConsecutiveRunOverYearsStrategy extends AbstractConsecutiveRunOverYearsStrategy
+{
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    {
+        return $this->mediaMatchesKeywords($media, $this->keywords());
+    }
+
+    /**
+     * @return list<string>
+     */
+    abstract protected function keywords(): array;
+}

--- a/src/Clusterer/Support/AbstractTimeGapClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractTimeGapClusterStrategy.php
@@ -248,11 +248,4 @@ abstract class AbstractTimeGapClusterStrategy implements ClusterStrategyInterfac
         return true;
     }
 
-    /**
-     * @param list<string> $keywords
-     */
-    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
-    {
-        return $this->mediaPathContains($media, $keywords);
-    }
 }

--- a/src/Clusterer/Support/AbstractTimezoneAwareGroupedClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractTimezoneAwareGroupedClusterStrategy.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Adds reusable timezone handling helpers for grouped cluster strategies that
+ * need to work with local timestamps.
+ */
+abstract class AbstractTimezoneAwareGroupedClusterStrategy extends AbstractGroupedClusterStrategy
+{
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(string $timezone = 'Europe/Berlin')
+    {
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    protected function timezone(): DateTimeZone
+    {
+        return $this->timezone;
+    }
+
+    protected function takenAt(Media $media): ?DateTimeImmutable
+    {
+        $takenAt = $media->getTakenAt();
+
+        return $takenAt instanceof DateTimeImmutable ? $takenAt : null;
+    }
+
+    protected function localTakenAt(Media $media): ?DateTimeImmutable
+    {
+        $takenAt = $this->takenAt($media);
+
+        return $takenAt?->setTimezone($this->timezone);
+    }
+}

--- a/src/Clusterer/Support/AbstractTimezoneAwareGroupedClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractTimezoneAwareGroupedClusterStrategy.php
@@ -20,6 +20,18 @@ abstract class AbstractTimezoneAwareGroupedClusterStrategy extends AbstractGroup
         $this->timezone = new DateTimeZone($timezone);
     }
 
+    final protected function groupKey(Media $media): ?string
+    {
+        $local = $this->localTakenAt($media);
+        if ($local === null) {
+            return null;
+        }
+
+        return $this->localGroupKey($media, $local);
+    }
+
+    abstract protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string;
+
     protected function timezone(): DateTimeZone
     {
         return $this->timezone;
@@ -37,5 +49,14 @@ abstract class AbstractTimezoneAwareGroupedClusterStrategy extends AbstractGroup
         $takenAt = $this->takenAt($media);
 
         return $takenAt?->setTimezone($this->timezone);
+    }
+
+    /**
+     * @param list<Media> $members
+     * @return array<string, bool>
+     */
+    protected function uniqueLocalDateParts(array $members, string $format): array
+    {
+        return $this->uniqueDateParts($members, $format, $this->timezone);
     }
 }

--- a/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
+
+/**
+ * Shared base for single-day weather-based clustering strategies.
+ */
+abstract class AbstractWeatherDayClusterStrategy extends AbstractGroupedClusterStrategy
+{
+    private readonly DateTimeZone $timezone;
+
+    public function __construct(
+        protected readonly WeatherHintProviderInterface $weather,
+        string $timezone = 'Europe/Berlin'
+    ) {
+        $this->timezone = new DateTimeZone($timezone);
+    }
+
+    final protected function groupKey(Media $media): ?string
+    {
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
+        }
+
+        return $takenAt->setTimezone($this->timezone)->format('Y-m-d');
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    final protected function groupParams(string $key, array $members): ?array
+    {
+        if (\count($members) < $this->minItemsPerDay()) {
+            return null;
+        }
+
+        $sum = 0.0;
+        $count = 0;
+
+        foreach ($members as $media) {
+            $hint = $this->weather->getHint($media);
+            if ($hint === null) {
+                continue;
+            }
+
+            $score = $this->scoreFromHint($hint);
+            if ($score === null) {
+                continue;
+            }
+
+            $sum += $this->clampScore($score);
+            $count++;
+        }
+
+        if ($count < $this->minHintsPerDay()) {
+            return null;
+        }
+
+        $average = $sum / (float) $count;
+        if (!$this->passesAverageThreshold($average)) {
+            return null;
+        }
+
+        return $this->buildParams($average, $count);
+    }
+
+    protected function minItemsPerDay(): int
+    {
+        return 1;
+    }
+
+    protected function minHintsPerDay(): int
+    {
+        return 1;
+    }
+
+    protected function clampScore(float $score): float
+    {
+        if ($score < 0.0) {
+            return 0.0;
+        }
+
+        if ($score > 1.0) {
+            return 1.0;
+        }
+
+        return $score;
+    }
+
+    /**
+     * @param array<string, mixed> $hint
+     */
+    abstract protected function scoreFromHint(array $hint): ?float;
+
+    abstract protected function passesAverageThreshold(float $average): bool;
+
+    /**
+     * @return array<string, mixed>
+     */
+    abstract protected function buildParams(float $average, int $count): array;
+}

--- a/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
@@ -3,33 +3,29 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer\Support;
 
-use DateTimeImmutable;
-use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
 
 /**
  * Shared base for single-day weather-based clustering strategies.
  */
-abstract class AbstractWeatherDayClusterStrategy extends AbstractGroupedClusterStrategy
+abstract class AbstractWeatherDayClusterStrategy extends AbstractTimezoneAwareGroupedClusterStrategy
 {
-    private readonly DateTimeZone $timezone;
-
     public function __construct(
         protected readonly WeatherHintProviderInterface $weather,
         string $timezone = 'Europe/Berlin'
     ) {
-        $this->timezone = new DateTimeZone($timezone);
+        parent::__construct($timezone);
     }
 
     final protected function groupKey(Media $media): ?string
     {
-        $takenAt = $media->getTakenAt();
-        if (!$takenAt instanceof DateTimeImmutable) {
+        $local = $this->localTakenAt($media);
+        if ($local === null) {
             return null;
         }
 
-        return $takenAt->setTimezone($this->timezone)->format('Y-m-d');
+        return $local->format('Y-m-d');
     }
 
     /**

--- a/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
@@ -19,6 +19,14 @@ abstract class AbstractWeatherDayClusterStrategy extends AbstractTimezoneAwareGr
         parent::__construct($timezone);
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItemsPerDay();
+    }
+
     final protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         return $local->format('Y-m-d');
@@ -29,10 +37,6 @@ abstract class AbstractWeatherDayClusterStrategy extends AbstractTimezoneAwareGr
      */
     final protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItemsPerDay()) {
-            return null;
-        }
-
         $sum = 0.0;
         $count = 0;
 

--- a/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractWeatherDayClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer\Support;
 
+use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
 
@@ -18,13 +19,8 @@ abstract class AbstractWeatherDayClusterStrategy extends AbstractTimezoneAwareGr
         parent::__construct($timezone);
     }
 
-    final protected function groupKey(Media $media): ?string
+    final protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
-
         return $local->format('Y-m-d');
     }
 

--- a/src/Clusterer/Support/ClusterBuildHelperTrait.php
+++ b/src/Clusterer/Support/ClusterBuildHelperTrait.php
@@ -218,6 +218,29 @@ trait ClusterBuildHelperTrait
         return $runs;
     }
 
+    /**
+     * Collects distinct formatted date parts from the given members.
+     *
+     * @param list<Media> $members
+     * @return array<string, bool>
+     */
+    protected function uniqueDateParts(array $members, string $format, ?DateTimeZone $timezone = null): array
+    {
+        $distinct = [];
+
+        foreach ($members as $media) {
+            $takenAt = $media->getTakenAt();
+            if (!$takenAt instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            $local = $timezone !== null ? $takenAt->setTimezone($timezone) : $takenAt;
+            $distinct[$local->format($format)] = true;
+        }
+
+        return $distinct;
+    }
+
     private function isNextDay(string $a, string $b): bool
     {
         $ta = \strtotime($a . ' 00:00:00');

--- a/src/Clusterer/Support/ClusterBuildHelperTrait.php
+++ b/src/Clusterer/Support/ClusterBuildHelperTrait.php
@@ -219,6 +219,25 @@ trait ClusterBuildHelperTrait
     }
 
     /**
+     * Flattens a day-to-media map into a sequential list of media entries.
+     *
+     * @param array<string, list<Media>> $daysMap
+     * @return list<Media>
+     */
+    private function flattenDayMembers(array $daysMap): array
+    {
+        $members = [];
+
+        foreach ($daysMap as $list) {
+            foreach ($list as $media) {
+                $members[] = $media;
+            }
+        }
+
+        return $members;
+    }
+
+    /**
      * Collects distinct formatted date parts from the given members.
      *
      * @param list<Media> $members
@@ -252,6 +271,16 @@ trait ClusterBuildHelperTrait
     }
 
     /**
+     * Checks whether the media path contains any of the provided keywords.
+     *
+     * @param list<string> $keywords
+     */
+    protected function mediaMatchesKeywords(Media $media, array $keywords): bool
+    {
+        return $this->pathContainsKeyword(\strtolower($media->getPath()), $keywords);
+    }
+
+    /**
      * @param list<string> $keywords
      */
     private function pathContainsKeyword(string $pathLower, array $keywords): bool
@@ -263,13 +292,5 @@ trait ClusterBuildHelperTrait
         }
 
         return false;
-    }
-
-    /**
-     * @param list<string> $keywords
-     */
-    private function mediaPathContains(Media $media, array $keywords): bool
-    {
-        return $this->pathContainsKeyword(\strtolower($media->getPath()), $keywords);
     }
 }

--- a/src/Clusterer/Support/PlaceLabelHelperTrait.php
+++ b/src/Clusterer/Support/PlaceLabelHelperTrait.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+
+/**
+ * Provides a small helper for strategies that attach majority place labels to clusters.
+ *
+ * @property-read LocationHelper $locHelper
+ */
+trait PlaceLabelHelperTrait
+{
+    /**
+     * Adds the majority place label (if any) of the given members to the provided params array.
+     *
+     * @param list<Media> $members
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    private function withMajorityPlace(array $members, array $params = []): array
+    {
+        $label = $this->locHelper->majorityLabel($members);
+
+        if ($label !== null) {
+            $params['place'] = $label;
+        }
+
+        return $params;
+    }
+}
+

--- a/src/Clusterer/Support/SeasonHelperTrait.php
+++ b/src/Clusterer/Support/SeasonHelperTrait.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+
+/**
+ * Helper for translating a date into a German season label and canonical year.
+ */
+trait SeasonHelperTrait
+{
+    /**
+     * @return array{season:string, seasonYear:int}
+     */
+    private function seasonInfo(DateTimeImmutable $date): array
+    {
+        $month = (int) $date->format('n');
+        $year = (int) $date->format('Y');
+
+        $season = match (true) {
+            $month >= 3 && $month <= 5  => 'Frühling',
+            $month >= 6 && $month <= 8  => 'Sommer',
+            $month >= 9 && $month <= 11 => 'Herbst',
+            default => 'Winter',
+        };
+
+        if ($season === 'Winter' && $month === 12) {
+            $year++;
+        }
+
+        return ['season' => $season, 'seasonYear' => $year];
+    }
+}

--- a/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
+++ b/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
@@ -36,12 +36,8 @@ final class ThisMonthOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
         $this->currentMonth = (int) $now->format('n');
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
         if ((int) $local->format('n') !== $this->currentMonth) {
             return null;
         }
@@ -58,12 +54,12 @@ final class ThisMonthOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
             return null;
         }
 
-        $yearsMap = $this->uniqueDateParts($members, 'Y', $this->timezone());
+        $yearsMap = $this->uniqueLocalDateParts($members, 'Y');
         if (\count($yearsMap) < $this->minYears) {
             return null;
         }
 
-        $daysMap = $this->uniqueDateParts($members, 'Y-m-d', $this->timezone());
+        $daysMap = $this->uniqueLocalDateParts($members, 'Y-m-d');
         if (\count($daysMap) < $this->minDistinctDays) {
             return null;
         }

--- a/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
+++ b/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
@@ -30,6 +30,14 @@ final class ThisMonthOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
         return 'this_month_over_years';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function beforeGrouping(): void
     {
         $now = new DateTimeImmutable('now', $this->timezone());
@@ -50,10 +58,6 @@ final class ThisMonthOverYearsClusterStrategy extends AbstractTimezoneAwareGroup
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         $yearsMap = $this->uniqueLocalDateParts($members, 'Y');
         if (\count($yearsMap) < $this->minYears) {
             return null;

--- a/src/Clusterer/TimeSimilarityStrategy.php
+++ b/src/Clusterer/TimeSimilarityStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\PlaceLabelHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -12,6 +13,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 50])]
 final class TimeSimilarityStrategy extends AbstractTimeGapClusterStrategy
 {
+    use PlaceLabelHelperTrait;
+
     private ?string $lastLocalityKey = null;
 
     public function __construct(
@@ -67,13 +70,7 @@ final class TimeSimilarityStrategy extends AbstractTimeGapClusterStrategy
 
     protected function sessionParams(array $members): array
     {
-        $params = [];
-        $label = $this->locHelper->majorityLabel($members);
-        if ($label !== null) {
-            $params['place'] = $label;
-        }
-
-        return $params;
+        return $this->withMajorityPlace($members);
     }
 
     private function resolveLocalityKey(Media $media): ?string

--- a/src/Clusterer/TransitTravelDayClusterStrategy.php
+++ b/src/Clusterer/TransitTravelDayClusterStrategy.php
@@ -28,6 +28,14 @@ final class TransitTravelDayClusterStrategy extends AbstractTimezoneAwareGrouped
         return 'transit_travel_day';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minGpsSamples;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         if ($media->getGpsLat() === null || $media->getGpsLon() === null) {
@@ -42,10 +50,6 @@ final class TransitTravelDayClusterStrategy extends AbstractTimezoneAwareGrouped
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minGpsSamples) {
-            return null;
-        }
-
         \usort($members, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
 
         $distanceKm = 0.0;

--- a/src/Clusterer/TransitTravelDayClusterStrategy.php
+++ b/src/Clusterer/TransitTravelDayClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
@@ -27,10 +28,9 @@ final class TransitTravelDayClusterStrategy extends AbstractTimezoneAwareGrouped
         return 'transit_travel_day';
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null || $media->getGpsLat() === null || $media->getGpsLon() === null) {
+        if ($media->getGpsLat() === null || $media->getGpsLon() === null) {
             return null;
         }
 

--- a/src/Clusterer/VideoStoriesClusterStrategy.php
+++ b/src/Clusterer/VideoStoriesClusterStrategy.php
@@ -26,6 +26,14 @@ final class VideoStoriesClusterStrategy extends AbstractTimezoneAwareGroupedClus
         return 'video_stories';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function shouldConsider(Media $media): bool
     {
         $mime = $media->getMime();
@@ -43,10 +51,6 @@ final class VideoStoriesClusterStrategy extends AbstractTimezoneAwareGroupedClus
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         return [];
     }
 }

--- a/src/Clusterer/VideoStoriesClusterStrategy.php
+++ b/src/Clusterer/VideoStoriesClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractTimezoneAwareGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -32,13 +33,8 @@ final class VideoStoriesClusterStrategy extends AbstractTimezoneAwareGroupedClus
         return !\is_string($mime) || \str_starts_with($mime, 'video/');
     }
 
-    protected function groupKey(Media $media): ?string
+    protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
-        $local = $this->localTakenAt($media);
-        if ($local === null) {
-            return null;
-        }
-
         return $local->format('Y-m-d');
     }
 

--- a/src/Clusterer/VideoStoriesClusterStrategy.php
+++ b/src/Clusterer/VideoStoriesClusterStrategy.php
@@ -5,20 +5,23 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Collects videos into day-based stories (local time).
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 41])]
-final class VideoStoriesClusterStrategy implements ClusterStrategyInterface
+final class VideoStoriesClusterStrategy extends AbstractGroupedClusterStrategy
 {
+    private readonly DateTimeZone $timezone;
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
+        string $timezone = 'Europe/Berlin',
         private readonly int $minItems = 2
     ) {
+        $this->timezone = new DateTimeZone($timezone);
     }
 
     public function name(): string
@@ -26,54 +29,32 @@ final class VideoStoriesClusterStrategy implements ClusterStrategyInterface
         return 'video_stories';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media): bool
     {
-        $tz = new DateTimeZone($this->timezone);
+        $mime = $media->getMime();
 
-        /** @var array<string, list<Media>> $byDay */
-        $byDay = [];
+        return !\is_string($mime) || \str_starts_with($mime, 'video/');
+    }
 
-        foreach ($items as $m) {
-            $mime = $m->getMime();
-            if (!\is_string($mime) || \strpos($mime, 'video/') !== 0) {
-                continue;
-            }
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $key = $local->format('Y-m-d');
-            $byDay[$key] ??= [];
-            $byDay[$key][] = $m;
+    protected function groupKey(Media $media): ?string
+    {
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
         }
 
-        /** @var list<ClusterDraft> $out */
-        $out = [];
+        return $takenAt->setTimezone($this->timezone)->format('Y-m-d');
+    }
 
-        foreach ($byDay as $day => $members) {
-            if (\count($members) < $this->minItems) {
-                continue;
-            }
-            \usort($members, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-
-            $centroid = MediaMath::centroid($members);
-            $time     = MediaMath::timeRange($members);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $members)
-            );
+    /**
+     * @param list<Media> $members
+     */
+    protected function groupParams(string $key, array $members): ?array
+    {
+        if (\count($members) < $this->minItems) {
+            return null;
         }
 
-        return $out;
+        return [];
     }
 }

--- a/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
+++ b/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
@@ -3,34 +3,29 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
+use InvalidArgumentException;
+use MagicSunday\Memories\Clusterer\Support\AbstractConsecutiveRunOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best weekend getaway (1..3 nights) per year and aggregates them into one over-years memory.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 61])]
-final class WeekendGetawaysOverYearsClusterStrategy implements ClusterStrategyInterface
+final class WeekendGetawaysOverYearsClusterStrategy extends AbstractConsecutiveRunOverYearsStrategy
 {
-    use ClusterBuildHelperTrait;
-
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minNights = 1,
-        private readonly int $maxNights = 3,
-        private readonly int $minItemsPerDay = 4,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 24
+        string $timezone = 'Europe/Berlin',
+        int $minNights = 1,
+        int $maxNights = 3,
+        int $minItemsPerDay = 4,
+        int $minYears = 3,
+        int $minItemsTotal = 24
     ) {
-        if ($this->minNights < 1) {
-            throw new \InvalidArgumentException('minNights must be >= 1.');
+        if ($minNights < 1) {
+            throw new InvalidArgumentException('minNights must be >= 1.');
         }
-        if ($this->maxNights < $this->minNights) {
-            throw new \InvalidArgumentException('maxNights must be >= minNights.');
-        }
+
+        parent::__construct($timezone, $minNights, $maxNights, $minItemsPerDay, $minYears, $minItemsTotal);
     }
 
     public function name(): string
@@ -38,99 +33,8 @@ final class WeekendGetawaysOverYearsClusterStrategy implements ClusterStrategyIn
         return 'weekend_getaways_over_years';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function isRunValid(array $run, array $daysMap): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        $byYearDay = $this->buildYearDayIndex($items, $tz);
-
-        $membersAllYears = [];
-        $yearsPicked     = [];
-
-        foreach ($byYearDay as $year => $daysMap) {
-            $runs = $this->buildConsecutiveRuns($daysMap);
-
-            $candidates = [];
-
-            foreach ($runs as $run) {
-                $nDays = \count($run['days']);
-                if ($nDays < 2) {
-                    continue;
-                }
-                $nights = $nDays - 1;
-                if ($nights < $this->minNights || $nights > $this->maxNights) {
-                    continue;
-                }
-                if (!$this->containsWeekendDay($run['days'])) {
-                    continue;
-                }
-
-                $ok = true;
-                foreach ($run['days'] as $day) {
-                    if (\count($daysMap[$day]) < $this->minItemsPerDay) {
-                        $ok = false;
-                        break;
-                    }
-                }
-
-                if ($ok) {
-                    $candidates[] = $run;
-                }
-            }
-
-            if ($candidates === []) {
-                continue;
-            }
-
-            \usort($candidates, function (array $a, array $b): int {
-                $na = \count($a['items']);
-                $nb = \count($b['items']);
-                if ($na !== $nb) {
-                    return $na < $nb ? 1 : -1;
-                }
-                $sa = \count($a['days']);
-                $sb = \count($b['days']);
-                if ($sa !== $sb) {
-                    return $sa < $sb ? 1 : -1;
-                }
-                return \strcmp($a['days'][0], $b['days'][0]);
-            });
-
-            $best = $candidates[0];
-            foreach ($best['items'] as $media) {
-                $membersAllYears[] = $media;
-            }
-            $yearsPicked[$year] = true;
-        }
-
-        return $this->buildOverYearsDrafts(
-            $membersAllYears,
-            $yearsPicked,
-            $this->minYears,
-            $this->minItemsTotal,
-            $this->name()
-        );
-    }
-
-    /**
-     * @param list<string> $days
-     */
-    private function containsWeekendDay(array $days): bool
-    {
-        foreach ($days as $d) {
-            $ts = \strtotime($d . ' 12:00:00');
-            if ($ts === false) {
-                continue;
-            }
-            $dow = (int) \gmdate('N', $ts); // 1..7
-            if ($dow === 6 || $dow === 7) {
-                return true;
-            }
-        }
-        return false;
+        return $this->containsWeekendDay($run['days']);
     }
 }

--- a/src/Clusterer/WeekendTripClusterStrategy.php
+++ b/src/Clusterer/WeekendTripClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\AbstractConsecutiveRunClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\PlaceLabelHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
@@ -18,6 +19,8 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 85])]
 final class WeekendTripClusterStrategy extends AbstractConsecutiveRunClusterStrategy
 {
+    use PlaceLabelHelperTrait;
+
     private ?float $lastRunDistanceKm = null;
 
     public function __construct(
@@ -67,13 +70,7 @@ final class WeekendTripClusterStrategy extends AbstractConsecutiveRunClusterStra
      */
     protected function runParams(array $run, array $daysMap, int $nights, array $members, string $groupKey): array
     {
-        $params = ['nights' => $nights];
-
-        $label = $this->locHelper->majorityLabel($members);
-        if ($label !== null) {
-            $params['place'] = $label;
-        }
-
+        $params = $this->withMajorityPlace($members, ['nights' => $nights]);
         $distance = $this->lastRunDistanceKm ?? $this->distanceFromHomeKm($members);
         if ($distance !== null) {
             $params['distance_km'] = $distance;

--- a/src/Clusterer/YearInReviewClusterStrategy.php
+++ b/src/Clusterer/YearInReviewClusterStrategy.php
@@ -27,6 +27,14 @@ final class YearInReviewClusterStrategy extends AbstractTimezoneAwareGroupedClus
         return 'year_in_review';
     }
 
+    /**
+     * @param list<Media> $members
+     */
+    protected function minimumGroupSize(string $key, array $members): int
+    {
+        return $this->minItems;
+    }
+
     protected function localGroupKey(Media $media, DateTimeImmutable $local): ?string
     {
         return $local->format('Y');
@@ -37,10 +45,6 @@ final class YearInReviewClusterStrategy extends AbstractTimezoneAwareGroupedClus
      */
     protected function groupParams(string $key, array $members): ?array
     {
-        if (\count($members) < $this->minItems) {
-            return null;
-        }
-
         $monthsMap = $this->uniqueLocalDateParts($members, 'n');
         if (\count($monthsMap) < $this->minDistinctMonths) {
             return null;

--- a/src/Clusterer/YearInReviewClusterStrategy.php
+++ b/src/Clusterer/YearInReviewClusterStrategy.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\AbstractGroupedClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds one macro cluster per year if enough items exist.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 60])]
-final class YearInReviewClusterStrategy implements ClusterStrategyInterface
+final class YearInReviewClusterStrategy extends AbstractGroupedClusterStrategy
 {
     public function __construct(
         private readonly int $minItems = 150,
@@ -25,55 +25,32 @@ final class YearInReviewClusterStrategy implements ClusterStrategyInterface
         return 'year_in_review';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function groupKey(Media $media): ?string
     {
-        /** @var array<int, list<Media>> $byYear */
-        $byYear = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $y = (int) $t->format('Y');
-            $byYear[$y] ??= [];
-            $byYear[$y][] = $m;
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
         }
 
-        /** @var list<ClusterDraft> $out */
-        $out = [];
+        return $takenAt->format('Y');
+    }
 
-        foreach ($byYear as $year => $list) {
-            if (\count($list) < $this->minItems) {
-                continue;
-            }
-            /** @var array<int,bool> $months */
-            $months = [];
-            foreach ($list as $m) {
-                $months[(int) $m->getTakenAt()->format('n')] = true;
-            }
-            if (\count($months) < $this->minDistinctMonths) {
-                continue;
-            }
-
-            $centroid = MediaMath::centroid($list);
-            $time     = MediaMath::timeRange($list);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'year'       => $year,
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $list)
-            );
+    /**
+     * @param list<Media> $members
+     */
+    protected function groupParams(string $key, array $members): ?array
+    {
+        if (\count($members) < $this->minItems) {
+            return null;
         }
 
-        return $out;
+        $monthsMap = $this->uniqueDateParts($members, 'n');
+        if (\count($monthsMap) < $this->minDistinctMonths) {
+            return null;
+        }
+
+        return [
+            'year' => (int) $key,
+        ];
     }
 }

--- a/src/Clusterer/ZooAquariumClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumClusterStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
+use MagicSunday\Memories\Clusterer\Support\AbstractFilteredTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * Clusters "Zoo & Aquarium" moments using filename/path keywords and compact time sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 73])]
-final class ZooAquariumClusterStrategy extends AbstractTimeGapClusterStrategy
+final class ZooAquariumClusterStrategy extends AbstractFilteredTimeGapClusterStrategy
 {
     /** @var list<string> */
     private const KEYWORDS = [
@@ -33,22 +33,20 @@ final class ZooAquariumClusterStrategy extends AbstractTimeGapClusterStrategy
         return 'zoo_aquarium';
     }
 
-    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
+    protected function keywords(): array
     {
-        $hour = (int) $local->format('G');
-        if ($hour < 9 || $hour > 20) {
-            return false;
-        }
-
-        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
+        return self::KEYWORDS;
     }
 
-    /**
-     * @param list<Media> $members
-     */
-    protected function isSessionValid(array $members): bool
+    protected function passesContextFilters(Media $media, DateTimeImmutable $local): bool
     {
-        return parent::isSessionValid($members)
-            && $this->allWithinRadius($members, $this->radiusMeters);
+        $hour = (int) $local->format('G');
+
+        return $hour >= 9 && $hour <= 20;
+    }
+
+    protected function sessionRadiusMeters(): ?float
+    {
+        return $this->radiusMeters;
     }
 }

--- a/src/Clusterer/ZooAquariumClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumClusterStrategy.php
@@ -4,23 +4,28 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\AbstractTimeGapClusterStrategy;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters "Zoo & Aquarium" moments using filename/path keywords and compact time sessions.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 73])]
-final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
+final class ZooAquariumClusterStrategy extends AbstractTimeGapClusterStrategy
 {
+    /** @var list<string> */
+    private const KEYWORDS = [
+        'zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark',
+    ];
+
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $sessionGapSeconds = 2 * 3600,
+        string $timezone = 'Europe/Berlin',
+        int $sessionGapSeconds = 2 * 3600,
         private readonly float $radiusMeters = 400.0,
-        private readonly int $minItems = 5
+        int $minItems = 5
     ) {
+        parent::__construct($timezone, $sessionGapSeconds, $minItems);
     }
 
     public function name(): string
@@ -28,109 +33,22 @@ final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
         return 'zoo_aquarium';
     }
 
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
+    protected function shouldConsider(Media $media, DateTimeImmutable $local): bool
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var list<Media> $cand */
-        $cand = [];
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            if (!$t instanceof DateTimeImmutable) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $h = (int) $local->format('G'); // prefer day/afternoon
-            if ($h < 9 || $h > 20) {
-                continue;
-            }
-            $path = \strtolower($m->getPath());
-            if ($this->looksZoo($path)) {
-                $cand[] = $m;
-            }
+        $hour = (int) $local->format('G');
+        if ($hour < 9 || $hour > 20) {
+            return false;
         }
 
-        if (\count($cand) < $this->minItems) {
-            return [];
-        }
-
-        \usort($cand, static fn (Media $a, Media $b): int =>
-            ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
-        );
-
-        /** @var list<ClusterDraft> $out */
-        $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
-            $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-
-            // spatial compactness if GPS exists
-            $ok = true;
-            foreach ($gps as $m) {
-                $d = MediaMath::haversineDistanceInMeters(
-                    (float) $centroid['lat'], (float) $centroid['lon'],
-                    (float) $m->getGpsLat(), (float) $m->getGpsLon()
-                );
-                if ($d > $this->radiusMeters) {
-                    $ok = false;
-                    break;
-                }
-            }
-            if ($ok === false) {
-                $buf = [];
-                return;
-            }
-
-            $time = MediaMath::timeRange($buf);
-
-            $out[] = new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
-            );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
-        }
-        $flush();
-
-        return $out;
+        return $this->mediaMatchesKeywords($media, self::KEYWORDS);
     }
 
-    private function looksZoo(string $pathLower): bool
+    /**
+     * @param list<Media> $members
+     */
+    protected function isSessionValid(array $members): bool
     {
-        /** @var list<string> $kw */
-        $kw = ['zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
+        return parent::isSessionValid($members)
+            && $this->allWithinRadius($members, $this->radiusMeters);
     }
 }

--- a/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
@@ -3,29 +3,25 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
+use MagicSunday\Memories\Clusterer\Support\AbstractKeywordBestDayOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks best zoo/aquarium day per year and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
-final class ZooAquariumOverYearsClusterStrategy implements ClusterStrategyInterface
+final class ZooAquariumOverYearsClusterStrategy extends AbstractKeywordBestDayOverYearsStrategy
 {
-    use ClusterBuildHelperTrait;
-
     /** @var list<string> */
     private const KEYWORDS = ['zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark'];
 
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 5,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 18
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 5,
+        int $minYears = 3,
+        int $minItemsTotal = 18
     ) {
+        parent::__construct($timezone, $minItemsPerDay, $minYears, $minItemsTotal);
     }
 
     public function name(): string
@@ -34,27 +30,10 @@ final class ZooAquariumOverYearsClusterStrategy implements ClusterStrategyInterf
     }
 
     /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
+     * @return list<string>
      */
-    public function cluster(array $items): array
+    protected function keywords(): array
     {
-        $tz = new DateTimeZone($this->timezone);
-
-        $byYearDay = $this->buildYearDayIndex(
-            $items,
-            $tz,
-            fn (Media $media, DateTimeImmutable $local): bool => $this->mediaPathContains($media, self::KEYWORDS)
-        );
-
-        $best = $this->pickBestDayPerYear($byYearDay, $this->minItemsPerDay);
-
-        return $this->buildOverYearsDrafts(
-            $best['members'],
-            $best['years'],
-            $this->minYears,
-            $this->minItemsTotal,
-            $this->name()
-        );
+        return self::KEYWORDS;
     }
 }


### PR DESCRIPTION
## Summary
- add reusable support classes that consolidate shared logic for day-based, multi-day, and at-home clustering strategies
- refactor the beach, museum, zoo, camping, snow vacation, weekend getaway, and at-home strategies to extend the new bases and drop duplicated code

## Testing
- php -l src/Clusterer/Support/AbstractBestDayOverYearsStrategy.php src/Clusterer/Support/AbstractKeywordBestDayOverYearsStrategy.php src/Clusterer/Support/AbstractConsecutiveRunOverYearsStrategy.php src/Clusterer/Support/AbstractKeywordConsecutiveRunOverYearsStrategy.php src/Clusterer/Support/AbstractAtHomeClusterStrategy.php src/Clusterer/BeachOverYearsClusterStrategy.php src/Clusterer/MuseumOverYearsClusterStrategy.php src/Clusterer/ZooAquariumOverYearsClusterStrategy.php src/Clusterer/CampingOverYearsClusterStrategy.php src/Clusterer/SnowVacationOverYearsClusterStrategy.php src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php src/Clusterer/AtHomeWeekdayClusterStrategy.php src/Clusterer/AtHomeWeekendClusterStrategy.php

------
https://chatgpt.com/codex/tasks/task_e_68d2eb531d988323b902e33a55ea0054