### PR TITLE
Refactor cluster strategy helpers

### DIFF
--- a/src/Clusterer/AtHomeWeekdayClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekdayClusterStrategy.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 43])]
 final class AtHomeWeekdayClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly ?float $homeLat = null,
         private readonly ?float $homeLon = null,
@@ -159,15 +162,5 @@ final class AtHomeWeekdayClusterStrategy implements ClusterStrategyInterface
         $flush();
 
         return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 }

--- a/src/Clusterer/AtHomeWeekendClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekendClusterStrategy.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 44])]
 final class AtHomeWeekendClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly ?float $homeLat = null,
         private readonly ?float $homeLon = null,
@@ -160,15 +163,5 @@ final class AtHomeWeekendClusterStrategy implements ClusterStrategyInterface
         $flush();
 
         return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 }

--- a/src/Clusterer/BeachOverYearsClusterStrategy.php
+++ b/src/Clusterer/BeachOverYearsClusterStrategy.php
@@ -3,111 +3,32 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best "beach day" per year (based on filename keywords) and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
-final class BeachOverYearsClusterStrategy implements ClusterStrategyInterface
+final class BeachOverYearsClusterStrategy extends KeywordBestDayOverYearsStrategy
 {
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 6,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 24
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 6,
+        int $minYears = 3,
+        int $minItemsTotal = 24
     ) {
+        parent::__construct(
+            timezone: $timezone,
+            minItemsPerDay: $minItemsPerDay,
+            minYears: $minYears,
+            minItemsTotal: $minItemsTotal,
+            keywords: ['strand', 'beach', 'meer', 'ocean', 'küste', 'kueste', 'coast', 'seaside', 'baltic', 'ostsee', 'nordsee', 'adriatic']
+        );
     }
 
     public function name(): string
     {
         return 'beach_over_years';
-    }
-
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
-    {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<int, array<string, list<Media>>> $byYearDay */
-        $byYearDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksBeach($path)) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $y = (int) $local->format('Y');
-            $d = $local->format('Y-m-d');
-            $byYearDay[$y] ??= [];
-            $byYearDay[$y][$d] ??= [];
-            $byYearDay[$y][$d][] = $m;
-        }
-
-        /** @var list<Media> $picked */
-        $picked = [];
-        /** @var array<int,bool> $years */
-        $years = [];
-
-        foreach ($byYearDay as $year => $days) {
-            // pick day with most items
-            $bestDay = null;
-            $bestCnt = 0;
-            foreach ($days as $d => $list) {
-                $c = \count($list);
-                if ($c >= $this->minItemsPerDay && $c > $bestCnt) {
-                    $bestCnt = $c;
-                    $bestDay = $d;
-                }
-            }
-            if ($bestDay === null) {
-                continue;
-            }
-            foreach ($days[$bestDay] as $m) {
-                $picked[] = $m;
-            }
-            $years[$year] = true;
-        }
-
-        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
-            return [];
-        }
-
-        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
-
-        return [
-            new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
-            ),
-        ];
-    }
-
-    private function looksBeach(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['strand', 'beach', 'meer', 'ocean', 'küste', 'kueste', 'coast', 'seaside', 'baltic', 'ostsee', 'nordsee', 'adriatic'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/Clusterer/CampingOverYearsClusterStrategy.php
+++ b/src/Clusterer/CampingOverYearsClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
 final class CampingOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 3,
@@ -152,16 +155,6 @@ final class CampingOverYearsClusterStrategy implements ClusterStrategyInterface
                 members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
             ),
         ];
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 
     private function looksCamping(string $pathLower): bool

--- a/src/Clusterer/CampingTripClusterStrategy.php
+++ b/src/Clusterer/CampingTripClusterStrategy.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 83])]
 final class CampingTripClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 3,
@@ -119,16 +122,6 @@ final class CampingTripClusterStrategy implements ClusterStrategyInterface
         $flush();
 
         return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 
     private function looksCamping(string $pathLower): bool

--- a/src/Clusterer/FirstVisitPlaceClusterStrategy.php
+++ b/src/Clusterer/FirstVisitPlaceClusterStrategy.php
@@ -6,6 +6,7 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 83])]
 final class FirstVisitPlaceClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly float $gridDegrees = 0.01, // ~1.1 km in lat
         private readonly string $timezone = 'Europe/Berlin',
@@ -148,15 +151,5 @@ final class FirstVisitPlaceClusterStrategy implements ClusterStrategyInterface
         $rlat = $gd * \floor($lat / $gd);
         $rlon = $gd * \floor($lon / $gd);
         return \sprintf('%.4f,%.4f', $rlat, $rlon);
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 }

--- a/src/Clusterer/LongTripClusterStrategy.php
+++ b/src/Clusterer/LongTripClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 90])]
 final class LongTripClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         /** Home base; if null, strategy is effectively disabled. */
         private readonly ?float $homeLat = null,
@@ -140,15 +143,5 @@ final class LongTripClusterStrategy implements ClusterStrategyInterface
         $flush();
 
         return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 }

--- a/src/Clusterer/MuseumOverYearsClusterStrategy.php
+++ b/src/Clusterer/MuseumOverYearsClusterStrategy.php
@@ -3,110 +3,32 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks best museum day per year and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
-final class MuseumOverYearsClusterStrategy implements ClusterStrategyInterface
+final class MuseumOverYearsClusterStrategy extends KeywordBestDayOverYearsStrategy
 {
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 5,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 18
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 5,
+        int $minYears = 3,
+        int $minItemsTotal = 18
     ) {
+        parent::__construct(
+            timezone: $timezone,
+            minItemsPerDay: $minItemsPerDay,
+            minYears: $minYears,
+            minItemsTotal: $minItemsTotal,
+            keywords: ['museum', 'galerie', 'gallery', 'ausstellung', 'exhibit', 'exhibition', 'kunsthalle']
+        );
     }
 
     public function name(): string
     {
         return 'museum_over_years';
-    }
-
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
-    {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<int, array<string, list<Media>>> $byYearDay */
-        $byYearDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksMuseum($path)) {
-                continue;
-            }
-            $local = $t->setTimezone($tz);
-            $y = (int) $local->format('Y');
-            $d = $local->format('Y-m-d');
-            $byYearDay[$y] ??= [];
-            $byYearDay[$y][$d] ??= [];
-            $byYearDay[$y][$d][] = $m;
-        }
-
-        /** @var list<Media> $picked */
-        $picked = [];
-        /** @var array<int,bool> $years */
-        $years = [];
-
-        foreach ($byYearDay as $year => $days) {
-            $bestDay = null;
-            $bestCnt = 0;
-            foreach ($days as $d => $list) {
-                $c = \count($list);
-                if ($c >= $this->minItemsPerDay && $c > $bestCnt) {
-                    $bestCnt = $c;
-                    $bestDay = $d;
-                }
-            }
-            if ($bestDay === null) {
-                continue;
-            }
-            foreach ($days[$bestDay] as $m) {
-                $picked[] = $m;
-            }
-            $years[$year] = true;
-        }
-
-        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
-            return [];
-        }
-
-        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
-
-        return [
-            new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
-            ),
-        ];
-    }
-
-    private function looksMuseum(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['museum', 'galerie', 'gallery', 'ausstellung', 'exhibit', 'exhibition', 'kunsthalle'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/Clusterer/RoadTripClusterStrategy.php
+++ b/src/Clusterer/RoadTripClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 88])]
 final class RoadTripClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly float $minDailyKm = 120.0,
@@ -135,15 +138,5 @@ final class RoadTripClusterStrategy implements ClusterStrategyInterface
         $flush();
 
         return $out;
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 }

--- a/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
+++ b/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
 final class SnowVacationOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 4,
@@ -160,16 +163,6 @@ final class SnowVacationOverYearsClusterStrategy implements ClusterStrategyInter
                 members: \array_map(static fn (Media $m): int => $m->getId(), $membersAllYears)
             ),
         ];
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 
     private function looksSnow(string $pathLower): bool

--- a/src/Clusterer/Support/ConsecutiveDaysTrait.php
+++ b/src/Clusterer/Support/ConsecutiveDaysTrait.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+/**
+ * Helper trait providing utilities for working with consecutive day strings.
+ */
+trait ConsecutiveDaysTrait
+{
+    private function isNextDay(string $a, string $b): bool
+    {
+        $ta = \strtotime($a . ' 00:00:00');
+        $tb = \strtotime($b . ' 00:00:00');
+
+        if ($ta === false || $tb === false) {
+            return false;
+        }
+
+        return ($tb - $ta) === 86400;
+    }
+}

--- a/src/Clusterer/Support/KeywordBestDayOverYearsStrategy.php
+++ b/src/Clusterer/Support/KeywordBestDayOverYearsStrategy.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\MediaMath;
+
+/**
+ * Shared implementation for strategies that pick the strongest keyword-based day per year.
+ */
+abstract class KeywordBestDayOverYearsStrategy implements ClusterStrategyInterface
+{
+    /**
+     * @param list<string> $keywords
+     */
+    public function __construct(
+        private readonly string $timezone,
+        private readonly int $minItemsPerDay,
+        private readonly int $minYears,
+        private readonly int $minItemsTotal,
+        private readonly array $keywords
+    ) {
+    }
+
+    /**
+     * @param list<Media> $items
+     * @return list<ClusterDraft>
+     */
+    public function cluster(array $items): array
+    {
+        $tz = new DateTimeZone($this->timezone);
+
+        /** @var array<int, array<string, list<Media>>> $byYearDay */
+        $byYearDay = [];
+
+        foreach ($items as $media) {
+            $takenAt = $media->getTakenAt();
+            if (!$takenAt instanceof DateTimeImmutable || !$this->matchesMedia($media)) {
+                continue;
+            }
+
+            $local = $takenAt->setTimezone($tz);
+            $year  = (int) $local->format('Y');
+            $day   = $local->format('Y-m-d');
+
+            $byYearDay[$year] ??= [];
+            $byYearDay[$year][$day] ??= [];
+            $byYearDay[$year][$day][] = $media;
+        }
+
+        /** @var list<Media> $picked */
+        $picked = [];
+        /** @var array<int,bool> $years */
+        $years = [];
+
+        foreach ($byYearDay as $year => $days) {
+            $bestDay = null;
+            $bestCount = 0;
+
+            foreach ($days as $day => $list) {
+                $count = \count($list);
+                if ($count >= $this->minItemsPerDay && $count > $bestCount) {
+                    $bestCount = $count;
+                    $bestDay = $day;
+                }
+            }
+
+            if ($bestDay === null) {
+                continue;
+            }
+
+            foreach ($days[$bestDay] as $media) {
+                $picked[] = $media;
+            }
+
+            $years[$year] = true;
+        }
+
+        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
+            return [];
+        }
+
+        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
+
+        $centroid = MediaMath::centroid($picked);
+        $time     = MediaMath::timeRange($picked);
+
+        return [
+            new ClusterDraft(
+                algorithm: $this->name(),
+                params: $this->buildParams($years, $time),
+                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
+                members: \array_map(static fn (Media $media): int => $media->getId(), $picked)
+            ),
+        ];
+    }
+
+    abstract public function name(): string;
+
+    /**
+     * @param array<int,bool> $years
+     * @param array{from:int,to:int} $timeRange
+     * @return array<string,mixed>
+     */
+    protected function buildParams(array $years, array $timeRange): array
+    {
+        return [
+            'years'      => \array_values(\array_keys($years)),
+            'time_range' => $timeRange,
+        ];
+    }
+
+    protected function matchesMedia(Media $media): bool
+    {
+        return $this->pathContainsKeyword($media->getPath());
+    }
+
+    private function pathContainsKeyword(string $path): bool
+    {
+        $lower = \strtolower($path);
+
+        foreach ($this->keywords as $keyword) {
+            if (\str_contains($lower, $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
+++ b/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 61])]
 final class WeekendGetawaysOverYearsClusterStrategy implements ClusterStrategyInterface
 {
+    use ConsecutiveDaysTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minNights = 1,
@@ -176,16 +179,6 @@ final class WeekendGetawaysOverYearsClusterStrategy implements ClusterStrategyIn
                 members: \array_map(static fn (Media $m): int => $m->getId(), $membersAllYears)
             ),
         ];
-    }
-
-    private function isNextDay(string $a, string $b): bool
-    {
-        $ta = \strtotime($a . ' 00:00:00');
-        $tb = \strtotime($b . ' 00:00:00');
-        if ($ta === false || $tb === false) {
-            return false;
-        }
-        return ($tb - $ta) === 86400;
     }
 
     /**

--- a/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
@@ -3,109 +3,32 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
-use DateTimeImmutable;
-use DateTimeZone;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks best zoo/aquarium day per year and aggregates over years.
  */
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
-final class ZooAquariumOverYearsClusterStrategy implements ClusterStrategyInterface
+final class ZooAquariumOverYearsClusterStrategy extends KeywordBestDayOverYearsStrategy
 {
     public function __construct(
-        private readonly string $timezone = 'Europe/Berlin',
-        private readonly int $minItemsPerDay = 5,
-        private readonly int $minYears = 3,
-        private readonly int $minItemsTotal = 18
+        string $timezone = 'Europe/Berlin',
+        int $minItemsPerDay = 5,
+        int $minYears = 3,
+        int $minItemsTotal = 18
     ) {
+        parent::__construct(
+            timezone: $timezone,
+            minItemsPerDay: $minItemsPerDay,
+            minYears: $minYears,
+            minItemsTotal: $minItemsTotal,
+            keywords: ['zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark']
+        );
     }
 
     public function name(): string
     {
         return 'zoo_aquarium_over_years';
-    }
-
-    /**
-     * @param list<Media> $items
-     * @return list<ClusterDraft>
-     */
-    public function cluster(array $items): array
-    {
-        $tz = new DateTimeZone($this->timezone);
-
-        /** @var array<int, array<string, list<Media>>> $byYearDay */
-        $byYearDay = [];
-
-        foreach ($items as $m) {
-            $t = $m->getTakenAt();
-            $path = \strtolower($m->getPath());
-            if (!$t instanceof DateTimeImmutable || !$this->looksZoo($path)) {
-                continue;
-            }
-            $y = (int) $t->format('Y');
-            $d = $t->setTimezone($tz)->format('Y-m-d');
-            $byYearDay[$y] ??= [];
-            $byYearDay[$y][$d] ??= [];
-            $byYearDay[$y][$d][] = $m;
-        }
-
-        /** @var list<Media> $picked */
-        $picked = [];
-        /** @var array<int,bool> $years */
-        $years = [];
-
-        foreach ($byYearDay as $year => $days) {
-            $bestDay = null;
-            $bestCnt = 0;
-            foreach ($days as $d => $list) {
-                $c = \count($list);
-                if ($c >= $this->minItemsPerDay && $c > $bestCnt) {
-                    $bestCnt = $c;
-                    $bestDay = $d;
-                }
-            }
-            if ($bestDay === null) {
-                continue;
-            }
-            foreach ($days[$bestDay] as $m) {
-                $picked[] = $m;
-            }
-            $years[$year] = true;
-        }
-
-        if (\count($years) < $this->minYears || \count($picked) < $this->minItemsTotal) {
-            return [];
-        }
-
-        \usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
-
-        return [
-            new ClusterDraft(
-                algorithm: $this->name(),
-                params: [
-                    'years'      => \array_values(\array_keys($years)),
-                    'time_range' => $time,
-                ],
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $picked)
-            ),
-        ];
-    }
-
-    private function looksZoo(string $pathLower): bool
-    {
-        /** @var list<string> $kw */
-        $kw = ['zoo', 'tierpark', 'wildpark', 'safari park', 'aquarium', 'sealife', 'sea life', 'zoopark'];
-        foreach ($kw as $k) {
-            if (\str_contains($pathLower, $k)) {
-                return true;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
## Summary
- introduce a reusable `KeywordBestDayOverYearsStrategy` so the beach, museum, and zoo yearly memories share their aggregation logic
- extract a `ConsecutiveDaysTrait` helper and apply it across the multi-day clustering strategies that need the same next-day check

## Testing
- `for f in src/Clusterer/AtHomeWeekdayClusterStrategy.php src/Clusterer/AtHomeWeekendClusterStrategy.php src/Clusterer/BeachOverYearsClusterStrategy.php src/Clusterer/CampingOverYearsClusterStrategy.php src/Clusterer/CampingTripClusterStrategy.php src/Clusterer/FirstVisitPlaceClusterStrategy.php src/Clusterer/LongTripClusterStrategy.php src/Clusterer/MuseumOverYearsClusterStrategy.php src/Clusterer/RoadTripClusterStrategy.php src/Clusterer/SnowVacationOverYearsClusterStrategy.php src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php src/Clusterer/ZooAquariumOverYearsClusterStrategy.php src/Clusterer/Support/ConsecutiveDaysTrait.php src/Clusterer/Support/KeywordBestDayOverYearsStrategy.php; do
    php -l $f || exit 1
done`

------
https://chatgpt.com/codex/tasks/task_e_68d3e951305083239116bcb920e7acdd