### PR TITLE
Refactor cluster strategies to share time gap splitting

### DIFF
--- a/src/Clusterer/CityscapeNightClusterStrategy.php
+++ b/src/Clusterer/CityscapeNightClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 76])]
 final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 2 * 3600,
@@ -64,21 +67,14 @@ final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
 
-            // spatial compactness if GPS exists
             $ok = true;
             foreach ($gps as $m) {
                 $d = MediaMath::haversineDistanceInMeters(
@@ -91,34 +87,19 @@ final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
                 }
             }
             if ($ok === false) {
-                $buf = [];
-                return;
+                continue;
             }
 
-            $time = MediaMath::timeRange($buf);
+            $time = MediaMath::timeRange($session);
             $out[] = new ClusterDraft(
-                algorithm: 'cityscape_night',
+                algorithm: $this->name(),
                 params: [
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn(Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/FestivalSummerClusterStrategy.php
+++ b/src/Clusterer/FestivalSummerClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 77])]
 final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 3 * 3600,
@@ -68,22 +71,14 @@ final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
 
-            // compactness for open-air area
             $ok = true;
             foreach ($gps as $m) {
                 $d = MediaMath::haversineDistanceInMeters(
@@ -96,11 +91,10 @@ final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
                 }
             }
             if ($ok === false) {
-                $buf = [];
-                return;
+                continue;
             }
 
-            $time = MediaMath::timeRange($buf);
+            $time = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -108,23 +102,9 @@ final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/HikeAdventureClusterStrategy.php
+++ b/src/Clusterer/HikeAdventureClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,6 +14,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 74])]
 final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly int $sessionGapSeconds = 3 * 3600,
         private readonly float $minDistanceKm = 6.0, // require at least ~6km if GPS is present
@@ -50,22 +53,13 @@ final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            $n = \count($buf);
-            if ($n < $this->minItems) {
-                $buf = [];
-                return;
-            }
-
-            // If GPS available, require minimum traveled distance
-            $withGps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $n = \count($session);
+            $withGps = \array_values(\array_filter($session, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
 
             if ($withGps !== []) {
                 \usort($withGps, static fn (Media $a, Media $b): int =>
@@ -83,19 +77,14 @@ final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
                         ) / 1000.0;
                 }
                 if ($km < $this->minDistanceKm) {
-                    $buf = [];
-                    return;
+                    continue;
                 }
-            } else {
-                // No GPS: require more items to reduce false positives
-                if ($n < $this->minItemsNoGps) {
-                    $buf = [];
-                    return;
-                }
+            } elseif ($n < $this->minItemsNoGps) {
+                continue;
             }
 
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
+            $centroid = MediaMath::centroid($session);
+            $time     = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -103,24 +92,9 @@ final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/KidsBirthdayPartyClusterStrategy.php
+++ b/src/Clusterer/KidsBirthdayPartyClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 72])]
 final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 3 * 3600,
@@ -62,19 +65,13 @@ final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
+        foreach ($sessions as $session) {
             // spatial compactness (if GPS exists)
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+            $gps = \array_values(\array_filter($session, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
 
             $ok = true;
@@ -89,11 +86,10 @@ final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
                 }
             }
             if (!$ok) {
-                $buf = [];
-                return;
+                continue;
             }
 
-            $time = MediaMath::timeRange($buf);
+            $time = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -101,23 +97,9 @@ final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/MorningCoffeeClusterStrategy.php
+++ b/src/Clusterer/MorningCoffeeClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 51])]
 final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 90 * 60,
@@ -62,21 +65,14 @@ final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
 
-            // compactness
             $ok = true;
             foreach ($gps as $m) {
                 $d = MediaMath::haversineDistanceInMeters(
@@ -89,11 +85,10 @@ final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
                 }
             }
             if ($ok === false) {
-                $buf = [];
-                return;
+                continue;
             }
 
-            $time = MediaMath::timeRange($buf);
+            $time = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -101,23 +96,9 @@ final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
                    'time_range' => $time,
                 ],
                 centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn(Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/PanoramaClusterStrategy.php
+++ b/src/Clusterer/PanoramaClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,6 +14,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 47])]
 final class PanoramaClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly float $minAspect = 2.4,     // width / height threshold
         private readonly int $sessionGapSeconds = 3 * 3600,
@@ -55,20 +58,14 @@ final class PanoramaClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-            $time = MediaMath::timeRange($buf);
+            $time     = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -76,23 +73,9 @@ final class PanoramaClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/PetMomentsClusterStrategy.php
+++ b/src/Clusterer/PetMomentsClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,6 +14,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 49])]
 final class PetMomentsClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly int $sessionGapSeconds = 2 * 3600,
         private readonly int $minItems = 6
@@ -46,20 +49,14 @@ final class PetMomentsClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
-            $time = MediaMath::timeRange($buf);
+            $time     = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -67,23 +64,9 @@ final class PetMomentsClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/PortraitOrientationClusterStrategy.php
+++ b/src/Clusterer/PortraitOrientationClusterStrategy.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -13,6 +14,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 45])]
 final class PortraitOrientationClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly float $minPortraitRatio = 1.2, // height / width
         private readonly int $sessionGapSeconds = 2 * 3600,
@@ -57,19 +60,13 @@ final class PortraitOrientationClusterStrategy implements ClusterStrategyInterfa
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
+        foreach ($sessions as $session) {
+            $centroid = MediaMath::centroid($session);
+            $time     = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -77,23 +74,9 @@ final class PortraitOrientationClusterStrategy implements ClusterStrategyInterfa
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn(Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/SnowDayClusterStrategy.php
+++ b/src/Clusterer/SnowDayClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 55])]
 final class SnowDayClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 2 * 3600,
@@ -60,19 +63,13 @@ final class SnowDayClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $lastTs = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $centroid = MediaMath::centroid($buf);
-            $time     = MediaMath::timeRange($buf);
+        foreach ($sessions as $session) {
+            $centroid = MediaMath::centroid($session);
+            $time     = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -80,23 +77,9 @@ final class SnowDayClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($lastTs !== null && ($ts - $lastTs) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $lastTs = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/SportsEventClusterStrategy.php
+++ b/src/Clusterer/SportsEventClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 78])]
 final class SportsEventClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 3 * 3600,
@@ -66,21 +69,14 @@ final class SportsEventClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn(Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
 
-            // compactness (stadium/arena)
             $ok = true;
             foreach ($gps as $m) {
                 $d = MediaMath::haversineDistanceInMeters(
@@ -93,11 +89,10 @@ final class SportsEventClusterStrategy implements ClusterStrategyInterface
                 }
             }
             if ($ok === false) {
-                $buf = [];
-                return;
+                continue;
             }
 
-            $time = MediaMath::timeRange($buf);
+            $time = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -105,23 +100,9 @@ final class SportsEventClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float)$centroid['lat'], 'lon' => (float)$centroid['lon']],
-                members: \array_map(static fn(Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn(Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }

--- a/src/Clusterer/Support/TimeGapSplitterTrait.php
+++ b/src/Clusterer/Support/TimeGapSplitterTrait.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Helper trait to split media into sessions separated by a time gap.
+ */
+trait TimeGapSplitterTrait
+{
+    /**
+     * Split already sorted media into sessions separated by the given gap.
+     *
+     * @param list<Media> $items Sorted in ascending order by the taken-at timestamp.
+     * @return list<list<Media>>
+     */
+    private function splitIntoTimeGapSessions(array $items, int $sessionGapSeconds, int $minItems): array
+    {
+        if ($items === []) {
+            return [];
+        }
+
+        /** @var list<list<Media>> $sessions */
+        $sessions = [];
+        /** @var list<Media> $buffer */
+        $buffer = [];
+        $lastTimestamp = null;
+
+        foreach ($items as $media) {
+            $timestamp = $media->getTakenAt()?->getTimestamp();
+            if ($timestamp === null) {
+                continue;
+            }
+
+            if ($lastTimestamp !== null && ($timestamp - $lastTimestamp) > $sessionGapSeconds) {
+                if (\count($buffer) >= $minItems) {
+                    $sessions[] = $buffer;
+                }
+                $buffer = [];
+            }
+
+            $buffer[] = $media;
+            $lastTimestamp = $timestamp;
+        }
+
+        if (\count($buffer) >= $minItems) {
+            $sessions[] = $buffer;
+        }
+
+        return $sessions;
+    }
+}

--- a/src/Clusterer/ZooAquariumClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumClusterStrategy.php
@@ -5,6 +5,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Support\TimeGapSplitterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 73])]
 final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
 {
+    use TimeGapSplitterTrait;
+
     public function __construct(
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $sessionGapSeconds = 2 * 3600,
@@ -62,21 +65,14 @@ final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
             ($a->getTakenAt()?->getTimestamp() ?? 0) <=> ($b->getTakenAt()?->getTimestamp() ?? 0)
         );
 
+        $sessions = $this->splitIntoTimeGapSessions($cand, $this->sessionGapSeconds, $this->minItems);
+
         /** @var list<ClusterDraft> $out */
         $out = [];
-        /** @var list<Media> $buf */
-        $buf = [];
-        $last = null;
-
-        $flush = function () use (&$buf, &$out): void {
-            if (\count($buf) < $this->minItems) {
-                $buf = [];
-                return;
-            }
-            $gps = \array_values(\array_filter($buf, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
+        foreach ($sessions as $session) {
+            $gps = \array_values(\array_filter($session, static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null));
             $centroid = $gps !== [] ? MediaMath::centroid($gps) : ['lat' => 0.0, 'lon' => 0.0];
 
-            // spatial compactness if GPS exists
             $ok = true;
             foreach ($gps as $m) {
                 $d = MediaMath::haversineDistanceInMeters(
@@ -89,11 +85,10 @@ final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
                 }
             }
             if ($ok === false) {
-                $buf = [];
-                return;
+                continue;
             }
 
-            $time = MediaMath::timeRange($buf);
+            $time = MediaMath::timeRange($session);
 
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
@@ -101,23 +96,9 @@ final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
                     'time_range' => $time,
                 ],
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: \array_map(static fn (Media $m): int => $m->getId(), $buf)
+                members: \array_map(static fn (Media $m): int => $m->getId(), $session)
             );
-            $buf = [];
-        };
-
-        foreach ($cand as $m) {
-            $ts = $m->getTakenAt()?->getTimestamp();
-            if ($ts === null) {
-                continue;
-            }
-            if ($last !== null && ($ts - $last) > $this->sessionGapSeconds) {
-                $flush();
-            }
-            $buf[] = $m;
-            $last = $ts;
         }
-        $flush();
 
         return $out;
     }


### PR DESCRIPTION
## Summary
- add a reusable `TimeGapSplitterTrait` to centralise time based session splitting
- refactor the various session-based cluster strategies to call the shared helper and drop duplicated flush logic

## Testing
- `composer ci:test:php:lint` *(fails: bin/php not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f0e0eb9883239823964b60098b2e