### PR TITLE
Move cluster strategy priorities to config

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -91,6 +91,60 @@ parameters:
     memories.cluster.consolidate.require_valid_time: true
     memories.cluster.consolidate.min_valid_year: 1990
 
+    # Cluster Strategy Priorities
+    memories.cluster.priority.anniversary_cluster_strategy: 64
+    memories.cluster.priority.at_home_weekday_cluster_strategy: 43
+    memories.cluster.priority.at_home_weekend_cluster_strategy: 44
+    memories.cluster.priority.beach_over_years_cluster_strategy: 63
+    memories.cluster.priority.burst_cluster_strategy: 95
+    memories.cluster.priority.camping_over_years_cluster_strategy: 63
+    memories.cluster.priority.camping_trip_cluster_strategy: 83
+    memories.cluster.priority.cityscape_night_cluster_strategy: 76
+    memories.cluster.priority.cross_dimension_cluster_strategy: 68
+    memories.cluster.priority.day_album_cluster_strategy: 53
+    memories.cluster.priority.device_similarity_strategy: 30
+    memories.cluster.priority.dining_out_cluster_strategy: 52
+    memories.cluster.priority.festival_summer_cluster_strategy: 77
+    memories.cluster.priority.first_visit_place_cluster_strategy: 83
+    memories.cluster.priority.golden_hour_cluster_strategy: 57
+    memories.cluster.priority.hike_adventure_cluster_strategy: 74
+    memories.cluster.priority.holiday_event_cluster_strategy: 79
+    memories.cluster.priority.kids_birthday_party_cluster_strategy: 72
+    memories.cluster.priority.location_similarity_strategy: 81
+    memories.cluster.priority.long_trip_cluster_strategy: 90
+    memories.cluster.priority.monthly_highlights_cluster_strategy: 59
+    memories.cluster.priority.morning_coffee_cluster_strategy: 51
+    memories.cluster.priority.museum_over_years_cluster_strategy: 62
+    memories.cluster.priority.new_year_eve_cluster_strategy: 79
+    memories.cluster.priority.nightlife_event_cluster_strategy: 75
+    memories.cluster.priority.on_this_day_over_years_cluster_strategy: 66
+    memories.cluster.priority.one_year_ago_cluster_strategy: 65
+    memories.cluster.priority.panorama_cluster_strategy: 47
+    memories.cluster.priority.panorama_over_years_cluster_strategy: 46
+    memories.cluster.priority.person_cohort_cluster_strategy: 80
+    memories.cluster.priority.pet_moments_cluster_strategy: 49
+    memories.cluster.priority.phash_similarity_strategy: 100
+    memories.cluster.priority.photo_motif_cluster_strategy: 48
+    memories.cluster.priority.portrait_orientation_cluster_strategy: 45
+    memories.cluster.priority.rainy_day_cluster_strategy: 54
+    memories.cluster.priority.road_trip_cluster_strategy: 88
+    memories.cluster.priority.season_cluster_strategy: 58
+    memories.cluster.priority.season_over_years_cluster_strategy: 62
+    memories.cluster.priority.significant_place_cluster_strategy: 82
+    memories.cluster.priority.snow_day_cluster_strategy: 55
+    memories.cluster.priority.snow_vacation_over_years_cluster_strategy: 63
+    memories.cluster.priority.sports_event_cluster_strategy: 78
+    memories.cluster.priority.sunny_day_cluster_strategy: 56
+    memories.cluster.priority.this_month_over_years_cluster_strategy: 178
+    memories.cluster.priority.time_similarity_strategy: 50
+    memories.cluster.priority.transit_travel_day_cluster_strategy: 87
+    memories.cluster.priority.video_stories_cluster_strategy: 41
+    memories.cluster.priority.weekend_getaways_over_years_cluster_strategy: 61
+    memories.cluster.priority.weekend_trip_cluster_strategy: 85
+    memories.cluster.priority.year_in_review_cluster_strategy: 60
+    memories.cluster.priority.zoo_aquarium_cluster_strategy: 73
+    memories.cluster.priority.zoo_aquarium_over_years_cluster_strategy: 62
+
     # Scoring Defaults
     memories.score.min_valid_year: 1995
     memories.score.time_range.min_samples: 3

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -161,21 +161,29 @@ services:
         arguments:
             $maxGapSeconds: 21600   # 6h
             $minItems: 15
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.time_similarity_strategy%' }
 
     MagicSunday\Memories\Clusterer\LocationSimilarityStrategy:
         arguments:
             $radiusMeters: 150.0
             $minItems: 5
             $maxSpanHours: 24
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.location_similarity_strategy%' }
 
     MagicSunday\Memories\Clusterer\DeviceSimilarityStrategy:
         arguments:
             $minItems: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.device_similarity_strategy%' }
 
     MagicSunday\Memories\Clusterer\PhashSimilarityStrategy:
         arguments:
             $maxHamming: 6
             $minItems: 2
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.phash_similarity_strategy%' }
 
     # --- Composition & session heuristics ---
     MagicSunday\Memories\Clusterer\BurstClusterStrategy:
@@ -183,23 +191,31 @@ services:
             $maxGapSeconds: 90
             $maxMoveMeters: 50.0
             $minItems: 3
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.burst_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\PhotoMotifClusterStrategy:
         arguments:
             $sessionGapSeconds: 172800   # 48h
             $minItems: 10
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.photo_motif_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\CrossDimensionClusterStrategy:
         arguments:
             $timeGapSeconds: 7200        # 2h
             $radiusMeters: 150.0
             $minItems: 6
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.cross_dimension_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\PanoramaClusterStrategy:
         arguments:
             $minAspect: 2.4
             $sessionGapSeconds: 10800   # 3h
             $minItems: 3
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.panorama_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\PanoramaOverYearsClusterStrategy:
         arguments:
@@ -207,23 +223,31 @@ services:
             $perYearMin: 3
             $minYears: 3
             $minItemsTotal: 15
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.panorama_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\PortraitOrientationClusterStrategy:
         arguments:
             $minPortraitRatio: 1.2
             $sessionGapSeconds: 7200      # 2h
             $minItems: 4
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.portrait_orientation_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\VideoStoriesClusterStrategy:
         arguments:
             $timezone: 'Europe/Berlin'
             $minItems: 2
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.video_stories_cluster_strategy%' }
 
     # --- Daily life & home rituals ---
     MagicSunday\Memories\Clusterer\DayAlbumClusterStrategy:
         arguments:
             $timezone: 'Europe/Berlin'
             $minItems: 8
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.day_album_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\MorningCoffeeClusterStrategy:
         arguments:
@@ -231,6 +255,8 @@ services:
             $sessionGapSeconds: 5400      # 1.5h
             $radiusMeters: 200.0
             $minItems: 3
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.morning_coffee_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\AtHomeWeekendClusterStrategy:
         arguments:
@@ -241,6 +267,8 @@ services:
             $minItemsPerDay: 4
             $minItemsTotal: 6
             $timezone: 'Europe/Berlin'
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.at_home_weekend_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\AtHomeWeekdayClusterStrategy:
         arguments:
@@ -251,6 +279,8 @@ services:
             $minItemsPerDay: 4
             $minItemsTotal: 8
             $timezone: 'Europe/Berlin'
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.at_home_weekday_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\DiningOutClusterStrategy:
         arguments:
@@ -258,15 +288,21 @@ services:
             $sessionGapSeconds: 7200   # 2h
             $radiusMeters: 250.0
             $minItems: 4
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.dining_out_cluster_strategy%' }
 
     # --- Social celebrations & people ---
-    MagicSunday\Memories\Clusterer\AnniversaryClusterStrategy: ~
+    MagicSunday\Memories\Clusterer\AnniversaryClusterStrategy:
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.anniversary_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\PersonCohortClusterStrategy:
         arguments:
             $minPersons: 2
             $minItems: 5
             $windowDays: 14
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.person_cohort_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\KidsBirthdayPartyClusterStrategy:
         arguments:
@@ -274,15 +310,21 @@ services:
             $sessionGapSeconds: 10800     # 3h
             $radiusMeters: 250.0
             $minItems: 6
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.kids_birthday_party_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\PetMomentsClusterStrategy:
         arguments:
             $sessionGapSeconds: 7200   # 2h
             $minItems: 10
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.pet_moments_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\HolidayEventClusterStrategy:
         arguments:
             $minItems: 8
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.holiday_event_cluster_strategy%' }
 
     # --- Special outings & events ---
     MagicSunday\Memories\Clusterer\NightlifeEventClusterStrategy:
@@ -291,6 +333,8 @@ services:
             $timeGapSeconds: 10800       # 3h
             $radiusMeters: 300.0
             $minItems: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.nightlife_event_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\SportsEventClusterStrategy:
         arguments:
@@ -299,6 +343,8 @@ services:
             $radiusMeters: 500.0
             $minItems: 6
             $preferWeekend: true
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.sports_event_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\FestivalSummerClusterStrategy:
         arguments:
@@ -306,6 +352,8 @@ services:
             $sessionGapSeconds: 10800     # 3h
             $radiusMeters: 600.0
             $minItems: 10
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.festival_summer_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\NewYearEveClusterStrategy:
         arguments:
@@ -313,12 +361,16 @@ services:
             $startHour: 20
             $endHour: 2
             $minItems: 6
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.new_year_eve_cluster_strategy%' }
 
     # --- Travel & outdoor adventures ---
     MagicSunday\Memories\Clusterer\WeekendTripClusterStrategy:
         arguments:
             $minAwayKm: 80.0
             $minNights: 1
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.weekend_trip_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\WeekendGetawaysOverYearsClusterStrategy:
         arguments:
@@ -328,6 +380,8 @@ services:
             $minItemsPerDay: 4
             $minYears: 3
             $minItemsTotal: 24
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.weekend_getaways_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\LongTripClusterStrategy:
         arguments:
@@ -335,6 +389,8 @@ services:
             $homeLon: '%env(float:MEMORIES_HOME_LON)%'
             $minAwayKm: 150.0
             $minNights: 3
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.long_trip_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\RoadTripClusterStrategy:
         arguments:
@@ -343,6 +399,8 @@ services:
             $minGpsSamplesPerDay: 8
             $minNights: 3
             $minItemsTotal: 40
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.road_trip_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\HikeAdventureClusterStrategy:
         arguments:
@@ -350,6 +408,8 @@ services:
             $minDistanceKm: 6.0
             $minItems: 6
             $minItemsNoGps: 12
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.hike_adventure_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\CampingTripClusterStrategy:
         arguments:
@@ -358,6 +418,8 @@ services:
             $minNights: 2
             $maxNights: 14
             $minItemsTotal: 20
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.camping_trip_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\CampingOverYearsClusterStrategy:
         arguments:
@@ -367,6 +429,8 @@ services:
             $maxNights: 14
             $minYears: 3
             $minItemsTotal: 24
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.camping_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\BeachOverYearsClusterStrategy:
         arguments:
@@ -374,6 +438,8 @@ services:
             $minItemsPerDay: 6
             $minYears: 3
             $minItemsTotal: 24
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.beach_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\SnowVacationOverYearsClusterStrategy:
         arguments:
@@ -383,12 +449,16 @@ services:
             $maxNights: 14
             $minYears: 3
             $minItemsTotal: 30
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.snow_vacation_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\TransitTravelDayClusterStrategy:
         arguments:
             $timezone: 'Europe/Berlin'
             $minTravelKm: 60.0
             $minGpsSamples: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.transit_travel_day_cluster_strategy%' }
 
     # --- Place-based explorations ---
     MagicSunday\Memories\Clusterer\FirstVisitPlaceClusterStrategy:
@@ -399,12 +469,16 @@ services:
             $minNights: 0
             $maxNights: 3
             $minItemsTotal: 8
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.first_visit_place_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\SignificantPlaceClusterStrategy:
         arguments:
             $gridDegrees: 0.01
             $minVisitDays: 3
             $minItemsTotal: 20
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.significant_place_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\CityscapeNightClusterStrategy:
         arguments:
@@ -412,6 +486,8 @@ services:
             $sessionGapSeconds: 7200      # 2h
             $radiusMeters: 350.0
             $minItems: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.cityscape_night_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\ZooAquariumClusterStrategy:
         arguments:
@@ -419,6 +495,8 @@ services:
             $sessionGapSeconds: 7200      # 2h
             $radiusMeters: 400.0
             $minItems: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.zoo_aquarium_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\ZooAquariumOverYearsClusterStrategy:
         arguments:
@@ -426,6 +504,8 @@ services:
             $minItemsPerDay: 5
             $minYears: 3
             $minItemsTotal: 18
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.zoo_aquarium_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\MuseumOverYearsClusterStrategy:
         arguments:
@@ -433,16 +513,22 @@ services:
             $minItemsPerDay: 5
             $minYears: 3
             $minItemsTotal: 18
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.museum_over_years_cluster_strategy%' }
 
     # --- Weather & seasonal highlights ---
     MagicSunday\Memories\Clusterer\SeasonClusterStrategy:
         arguments:
             $minItems: 20
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.season_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\SeasonOverYearsClusterStrategy:
         arguments:
             $minYears: 3
             $minItems: 30
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.season_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\SunnyDayClusterStrategy:
         arguments:
@@ -450,18 +536,24 @@ services:
             $minItemsPerDay: 6
             $minHintsPerDay: 3
             $timezone: 'Europe/Berlin'
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.sunny_day_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\RainyDayClusterStrategy:
         arguments:
             $minAvgRainProb: 0.6
             $minItemsPerDay: 6
             $timezone: 'Europe/Berlin'
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.rainy_day_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\SnowDayClusterStrategy:
         arguments:
             $timezone: 'Europe/Berlin'
             $sessionGapSeconds: 7200      # 2h
             $minItems: 6
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.snow_day_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\GoldenHourClusterStrategy:
         arguments:
@@ -476,6 +568,8 @@ services:
                 - 20
             $sessionGapSeconds: 5400
             $minItems: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.golden_hour_cluster_strategy%' }
 
     # --- Temporal retrospectives ---
     MagicSunday\Memories\Clusterer\ThisMonthOverYearsClusterStrategy:
@@ -484,6 +578,8 @@ services:
             $minYears: 3
             $minItems: 24
             $minDistinctDays: 8
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.this_month_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\OnThisDayOverYearsClusterStrategy:
         arguments:
@@ -491,23 +587,31 @@ services:
             $windowDays: 0
             $minYears: 3
             $minItems: 12
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.on_this_day_over_years_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\OneYearAgoClusterStrategy:
         arguments:
             $timezone: 'Europe/Berlin'
             $windowDays: 3
             $minItems: 8
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.one_year_ago_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\YearInReviewClusterStrategy:
         arguments:
             $minItems: 150
             $minDistinctMonths: 5
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.year_in_review_cluster_strategy%' }
 
     MagicSunday\Memories\Clusterer\MonthlyHighlightsClusterStrategy:
         arguments:
             $timezone: 'Europe/Berlin'
             $minItems: 40
             $minDistinctDays: 10
+        tags:
+            - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.monthly_highlights_cluster_strategy%' }
 
     MagicSunday\Memories\Service\Clusterer\TitleGeneratorInterface:
         alias: MagicSunday\Memories\Service\Clusterer\SmartTitleGenerator

--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -7,9 +7,7 @@ use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 64])]
 final class AnniversaryClusterStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;

--- a/src/Clusterer/AtHomeWeekdayClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekdayClusterStrategy.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Clusterer\Support\AbstractAtHomeClusterStrategy;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters home-based weekday sessions (Mon–Fri) when most photos are within a home radius.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 43])]
 final class AtHomeWeekdayClusterStrategy extends AbstractAtHomeClusterStrategy
 {
     public function __construct(

--- a/src/Clusterer/AtHomeWeekendClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekendClusterStrategy.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Clusterer\Support\AbstractAtHomeClusterStrategy;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters home-based weekend sessions: Saturday/Sunday where most photos are within a home radius.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 44])]
 final class AtHomeWeekendClusterStrategy extends AbstractAtHomeClusterStrategy
 {
     public function __construct(

--- a/src/Clusterer/BeachOverYearsClusterStrategy.php
+++ b/src/Clusterer/BeachOverYearsClusterStrategy.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best "beach day" per year (based on filename keywords) and aggregates over years.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
 final class BeachOverYearsClusterStrategy extends KeywordBestDayOverYearsStrategy
 {
     public function __construct(

--- a/src/Clusterer/BurstClusterStrategy.php
+++ b/src/Clusterer/BurstClusterStrategy.php
@@ -6,13 +6,11 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Groups items captured within a short time & small spatial window.
  * Typical for bursts/series shots.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 95])]
 final class BurstClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/CampingOverYearsClusterStrategy.php
+++ b/src/Clusterer/CampingOverYearsClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best multi-day camping run per year and aggregates over years.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
 final class CampingOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/CampingTripClusterStrategy.php
+++ b/src/Clusterer/CampingTripClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Multi-day camping runs (consecutive days) using keywords.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 83])]
 final class CampingTripClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/CityscapeNightClusterStrategy.php
+++ b/src/Clusterer/CityscapeNightClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * City night sessions: night hours & urban keywords, spatially compact.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 76])]
 final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/CrossDimensionClusterStrategy.php
+++ b/src/Clusterer/CrossDimensionClusterStrategy.php
@@ -6,13 +6,11 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters items that are both temporally and spatially close.
  * Sliding-session approach with time gap and radius constraints.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 68])]
 final class CrossDimensionClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/DayAlbumClusterStrategy.php
+++ b/src/Clusterer/DayAlbumClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Groups photos by local calendar day. Produces compact "Day Tour" clusters.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 53])]
 final class DayAlbumClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/DeviceSimilarityStrategy.php
+++ b/src/Clusterer/DeviceSimilarityStrategy.php
@@ -7,9 +7,7 @@ use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 30])]
 final class DeviceSimilarityStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;

--- a/src/Clusterer/DiningOutClusterStrategy.php
+++ b/src/Clusterer/DiningOutClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects dining-out moments based on evening hours and food/venue keywords; spatially compact sessions.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 52])]
 final class DiningOutClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/FestivalSummerClusterStrategy.php
+++ b/src/Clusterer/FestivalSummerClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Outdoor festival/open-air sessions in summer months.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 77])]
 final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/FirstVisitPlaceClusterStrategy.php
+++ b/src/Clusterer/FirstVisitPlaceClusterStrategy.php
@@ -9,12 +9,10 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects the earliest visit session per geogrid cell (first time at this place).
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 83])]
 final class FirstVisitPlaceClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/GoldenHourClusterStrategy.php
+++ b/src/Clusterer/GoldenHourClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Heuristic "Golden Hour" clusters around morning/evening hours.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 57])]
 final class GoldenHourClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/HikeAdventureClusterStrategy.php
+++ b/src/Clusterer/HikeAdventureClusterStrategy.php
@@ -5,12 +5,10 @@ namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Groups hiking/adventure sessions based on keywords; validates by traveled distance if GPS is available.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 74])]
 final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/HolidayEventClusterStrategy.php
+++ b/src/Clusterer/HolidayEventClusterStrategy.php
@@ -8,13 +8,11 @@ use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\Calendar;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds clusters for German (federal) holidays per year (no state-specific).
  * Simple exact-date grouping; minimal dependencies.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 79])]
 final class HolidayEventClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/KidsBirthdayPartyClusterStrategy.php
+++ b/src/Clusterer/KidsBirthdayPartyClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects kids' birthday parties based on keywords; compact time sessions.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 72])]
 final class KidsBirthdayPartyClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/LocationSimilarityStrategy.php
+++ b/src/Clusterer/LocationSimilarityStrategy.php
@@ -7,9 +7,7 @@ use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 81])]
 final class LocationSimilarityStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;

--- a/src/Clusterer/LongTripClusterStrategy.php
+++ b/src/Clusterer/LongTripClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects multi-night trips away from home based on per-day centroids and distance threshold.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 90])]
 final class LongTripClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds a highlight memory for each (year, month) with sufficient coverage.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 59])]
 final class MonthlyHighlightsClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/MorningCoffeeClusterStrategy.php
+++ b/src/Clusterer/MorningCoffeeClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Morning café/breakfast moments based on time and keywords, spatially compact.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 51])]
 final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/MuseumOverYearsClusterStrategy.php
+++ b/src/Clusterer/MuseumOverYearsClusterStrategy.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks best museum day per year and aggregates over years.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class MuseumOverYearsClusterStrategy extends KeywordBestDayOverYearsStrategy
 {
     public function __construct(

--- a/src/Clusterer/NewYearEveClusterStrategy.php
+++ b/src/Clusterer/NewYearEveClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds New Year's Eve clusters (local night around Dec 31 → Jan 1).
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 79])]
 final class NewYearEveClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters evening/night sessions (20:00–04:00 local time) with time gap and spatial compactness.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 75])]
 final class NightlifeEventClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
+++ b/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
@@ -7,13 +7,11 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Collects all photos taken around today's month/day across different years.
  * Example: Feb-14 across 2014..2025 within a +/- window of days.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 66])]
 final class OnThisDayOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/OneYearAgoClusterStrategy.php
+++ b/src/Clusterer/OneYearAgoClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds a memory around the same date last year within a +/- window.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 65])]
 final class OneYearAgoClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/PanoramaClusterStrategy.php
+++ b/src/Clusterer/PanoramaClusterStrategy.php
@@ -5,12 +5,10 @@ namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters panorama photos (very wide aspect ratio) into time sessions.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 47])]
 final class PanoramaClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/PanoramaOverYearsClusterStrategy.php
+++ b/src/Clusterer/PanoramaOverYearsClusterStrategy.php
@@ -5,12 +5,10 @@ namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Aggregates panoramas across years; requires per-year minimum.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 46])]
 final class PanoramaOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/PersonCohortClusterStrategy.php
+++ b/src/Clusterer/PersonCohortClusterStrategy.php
@@ -5,13 +5,11 @@ namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters items by stable co-occurrence of persons within a time window.
  * Requires Media to expose person tags via getPersonIds() -> list<int>.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 80])]
 final class PersonCohortClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/PetMomentsClusterStrategy.php
+++ b/src/Clusterer/PetMomentsClusterStrategy.php
@@ -5,12 +5,10 @@ namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Heuristic pet moments based on path keywords; grouped into time sessions.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 49])]
 final class PetMomentsClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/PhashSimilarityStrategy.php
+++ b/src/Clusterer/PhashSimilarityStrategy.php
@@ -6,9 +6,7 @@ namespace MagicSunday\Memories\Clusterer;
 use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 100])]
 final class PhashSimilarityStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;

--- a/src/Clusterer/PhotoMotifClusterStrategy.php
+++ b/src/Clusterer/PhotoMotifClusterStrategy.php
@@ -6,7 +6,6 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Heuristic photo motif clustering based on path/camera hints.
@@ -23,7 +22,6 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *  - Schnee & Winter      → snow_winter
  *  - Action & Outdoor     → action_outdoor
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 48])]
 final class PhotoMotifClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/PortraitOrientationClusterStrategy.php
+++ b/src/Clusterer/PortraitOrientationClusterStrategy.php
@@ -5,12 +5,10 @@ namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Portrait-oriented photos grouped into time sessions (no face detection).
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 45])]
 final class PortraitOrientationClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/RainyDayClusterStrategy.php
+++ b/src/Clusterer/RainyDayClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds "Rainy Day" clusters when weather hints indicate significant rain on a local day.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 54])]
 final class RainyDayClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/RoadTripClusterStrategy.php
+++ b/src/Clusterer/RoadTripClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Detects multi-day road trips based on daily traveled distance (from GPS track).
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 88])]
 final class RoadTripClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/SeasonClusterStrategy.php
+++ b/src/Clusterer/SeasonClusterStrategy.php
@@ -6,13 +6,11 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Groups media by meteorological seasons per year (DE).
  * Winter is Dec–Feb (December assigned to next year).
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 58])]
 final class SeasonClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/SeasonOverYearsClusterStrategy.php
+++ b/src/Clusterer/SeasonOverYearsClusterStrategy.php
@@ -6,13 +6,11 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Aggregates each season across multiple years into a memory
  * (e.g., "Sommer im Laufe der Jahre").
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class SeasonOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/SignificantPlaceClusterStrategy.php
+++ b/src/Clusterer/SignificantPlaceClusterStrategy.php
@@ -7,13 +7,11 @@ use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Aggregates recurring places using a coarse geogrid (lat/lon rounding).
  * Creates one cluster per significant place with enough distinct visit days.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 82])]
 final class SignificantPlaceClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/SnowDayClusterStrategy.php
+++ b/src/Clusterer/SnowDayClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds "Snow Day" clusters using winter months and snow/ski keywords.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 55])]
 final class SnowDayClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
+++ b/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best multi-day winter snow vacation per year and aggregates over years.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 63])]
 final class SnowVacationOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/SportsEventClusterStrategy.php
+++ b/src/Clusterer/SportsEventClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Sports events based on keywords (stadium/match/club names) and weekend bias.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 78])]
 final class SportsEventClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/SunnyDayClusterStrategy.php
+++ b/src/Clusterer/SunnyDayClusterStrategy.php
@@ -8,13 +8,11 @@ use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds "Sunny Day" clusters when weather hints indicate strong sunshine on a local day.
  * Priority: use sun_prob; fallback to 1 - cloud_cover; fallback to 1 - rain_prob.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 56])]
 final class SunnyDayClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
+++ b/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Aggregates all items from the current month across different years.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 178])]
 final class ThisMonthOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/TimeSimilarityStrategy.php
+++ b/src/Clusterer/TimeSimilarityStrategy.php
@@ -7,9 +7,7 @@ use DateTimeImmutable;
 use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 50])]
 final class TimeSimilarityStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;

--- a/src/Clusterer/TransitTravelDayClusterStrategy.php
+++ b/src/Clusterer/TransitTravelDayClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Marks "travel days" by summing GPS path distance within the day.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 87])]
 final class TransitTravelDayClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/VideoStoriesClusterStrategy.php
+++ b/src/Clusterer/VideoStoriesClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Collects videos into day-based stories (local time).
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 41])]
 final class VideoStoriesClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
+++ b/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
@@ -8,12 +8,10 @@ use DateTimeZone;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks the best weekend getaway (1..3 nights) per year and aggregates them into one over-years memory.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 61])]
 final class WeekendGetawaysOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     use ConsecutiveDaysTrait;

--- a/src/Clusterer/WeekendTripClusterStrategy.php
+++ b/src/Clusterer/WeekendTripClusterStrategy.php
@@ -9,14 +9,12 @@ use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Detects short weekend trips (Fri afternoon to Sun/Monday),
  * sufficiently far from a configured home location.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 85])]
 final class WeekendTripClusterStrategy implements ClusterStrategyInterface
 {
     use ClusterBuildHelperTrait;

--- a/src/Clusterer/YearInReviewClusterStrategy.php
+++ b/src/Clusterer/YearInReviewClusterStrategy.php
@@ -6,12 +6,10 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Builds one macro cluster per year if enough items exist.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 60])]
 final class YearInReviewClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/ZooAquariumClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumClusterStrategy.php
@@ -7,12 +7,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Clusters "Zoo & Aquarium" moments using filename/path keywords and compact time sessions.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 73])]
 final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
 {
     public function __construct(

--- a/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumOverYearsClusterStrategy.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer;
 
 use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Picks best zoo/aquarium day per year and aggregates over years.
  */
-#[AutoconfigureTag('memories.cluster_strategy', attributes: ['priority' => 62])]
 final class ZooAquariumOverYearsClusterStrategy extends KeywordBestDayOverYearsStrategy
 {
     public function __construct(


### PR DESCRIPTION
## Summary
- add explicit priority parameters for each cluster strategy and wire them through service tags
- drop the AutoconfigureTag attribute usage from the cluster strategy classes now that priorities live in configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d44939ab94832381da3d4a00b75191