### PR TITLE
Add constructor guards to cluster strategies

### DIFF
--- a/src/Clusterer/BurstClusterStrategy.php
+++ b/src/Clusterer/BurstClusterStrategy.php
@@ -18,6 +18,15 @@ final class BurstClusterStrategy implements ClusterStrategyInterface
         private readonly float $maxMoveMeters = 50.0,
         private readonly int $minItems = 3
     ) {
+        if ($this->maxGapSeconds < 1) {
+            throw new \InvalidArgumentException('maxGapSeconds must be >= 1.');
+        }
+        if ($this->maxMoveMeters < 0.0) {
+            throw new \InvalidArgumentException('maxMoveMeters must be >= 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/CampingOverYearsClusterStrategy.php
+++ b/src/Clusterer/CampingOverYearsClusterStrategy.php
@@ -24,8 +24,23 @@ final class CampingOverYearsClusterStrategy implements ClusterStrategyInterface
         private readonly int $minYears = 3,
         private readonly int $minItemsTotal = 24
     ) {
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minNights < 1) {
+            throw new \InvalidArgumentException('minNights must be >= 1.');
+        }
+        if ($this->maxNights < 1) {
+            throw new \InvalidArgumentException('maxNights must be >= 1.');
+        }
         if ($this->maxNights < $this->minNights) {
             throw new \InvalidArgumentException('maxNights must be >= minNights.');
+        }
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
         }
     }
 

--- a/src/Clusterer/CampingTripClusterStrategy.php
+++ b/src/Clusterer/CampingTripClusterStrategy.php
@@ -23,8 +23,20 @@ final class CampingTripClusterStrategy implements ClusterStrategyInterface
         private readonly int $maxNights = 14,
         private readonly int $minItemsTotal = 20
     ) {
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minNights < 1) {
+            throw new \InvalidArgumentException('minNights must be >= 1.');
+        }
+        if ($this->maxNights < 1) {
+            throw new \InvalidArgumentException('maxNights must be >= 1.');
+        }
         if ($this->maxNights < $this->minNights) {
             throw new \InvalidArgumentException('maxNights must be >= minNights.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
         }
     }
 

--- a/src/Clusterer/CityscapeNightClusterStrategy.php
+++ b/src/Clusterer/CityscapeNightClusterStrategy.php
@@ -19,6 +19,15 @@ final class CityscapeNightClusterStrategy implements ClusterStrategyInterface
         private readonly float $radiusMeters = 350.0,
         private readonly int $minItems = 5
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/CrossDimensionClusterStrategy.php
+++ b/src/Clusterer/CrossDimensionClusterStrategy.php
@@ -18,6 +18,15 @@ final class CrossDimensionClusterStrategy implements ClusterStrategyInterface
         private readonly float $radiusMeters = 150.0,      // 150 m
         private readonly int $minItems = 6
     ) {
+        if ($this->timeGapSeconds < 1) {
+            throw new \InvalidArgumentException('timeGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/DayAlbumClusterStrategy.php
+++ b/src/Clusterer/DayAlbumClusterStrategy.php
@@ -17,6 +17,9 @@ final class DayAlbumClusterStrategy implements ClusterStrategyInterface
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItems = 8
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/DeviceSimilarityStrategy.php
+++ b/src/Clusterer/DeviceSimilarityStrategy.php
@@ -16,6 +16,9 @@ final class DeviceSimilarityStrategy implements ClusterStrategyInterface
         private readonly LocationHelper $locHelper,
         private readonly int $minItems = 5,
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/DiningOutClusterStrategy.php
+++ b/src/Clusterer/DiningOutClusterStrategy.php
@@ -21,6 +21,12 @@ final class DiningOutClusterStrategy implements ClusterStrategyInterface
         private readonly int $minHour = 17,
         private readonly int $maxHour = 23
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
         if ($this->minItems < 1) {
             throw new \InvalidArgumentException('minItems must be >= 1.');
         }

--- a/src/Clusterer/FestivalSummerClusterStrategy.php
+++ b/src/Clusterer/FestivalSummerClusterStrategy.php
@@ -23,6 +23,12 @@ final class FestivalSummerClusterStrategy implements ClusterStrategyInterface
         private readonly int $afternoonStartHour = 14,
         private readonly int $lateNightCutoffHour = 2
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
         if ($this->minItems < 1) {
             throw new \InvalidArgumentException('minItems must be >= 1.');
         }

--- a/src/Clusterer/FirstVisitPlaceClusterStrategy.php
+++ b/src/Clusterer/FirstVisitPlaceClusterStrategy.php
@@ -26,8 +26,23 @@ final class FirstVisitPlaceClusterStrategy implements ClusterStrategyInterface
         private readonly int $maxNights = 3,
         private readonly int $minItemsTotal = 8
     ) {
+        if ($this->gridDegrees <= 0.0) {
+            throw new \InvalidArgumentException('gridDegrees must be > 0.');
+        }
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minNights < 0) {
+            throw new \InvalidArgumentException('minNights must be >= 0.');
+        }
+        if ($this->maxNights < 0) {
+            throw new \InvalidArgumentException('maxNights must be >= 0.');
+        }
         if ($this->maxNights < $this->minNights) {
             throw new \InvalidArgumentException('maxNights must be >= minNights.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
         }
     }
 

--- a/src/Clusterer/GoldenHourClusterStrategy.php
+++ b/src/Clusterer/GoldenHourClusterStrategy.php
@@ -21,6 +21,22 @@ final class GoldenHourClusterStrategy implements ClusterStrategyInterface
         private readonly int $sessionGapSeconds = 90 * 60,
         private readonly int $minItems = 5
     ) {
+        if ($this->morningHours === [] || $this->eveningHours === []) {
+            throw new \InvalidArgumentException('Morning and evening hours must not be empty.');
+        }
+        foreach ([$this->morningHours, $this->eveningHours] as $hours) {
+            foreach ($hours as $hour) {
+                if (!\is_int($hour) || $hour < 0 || $hour > 23) {
+                    throw new \InvalidArgumentException('Hour values must be integers within 0..23.');
+                }
+            }
+        }
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/HikeAdventureClusterStrategy.php
+++ b/src/Clusterer/HikeAdventureClusterStrategy.php
@@ -17,6 +17,18 @@ final class HikeAdventureClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItems = 6,
         private readonly int $minItemsNoGps = 12 // stricter if no GPS available
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minDistanceKm <= 0.0) {
+            throw new \InvalidArgumentException('minDistanceKm must be > 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
+        if ($this->minItemsNoGps < 1) {
+            throw new \InvalidArgumentException('minItemsNoGps must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/HolidayEventClusterStrategy.php
+++ b/src/Clusterer/HolidayEventClusterStrategy.php
@@ -18,6 +18,9 @@ final class HolidayEventClusterStrategy implements ClusterStrategyInterface
     public function __construct(
         private readonly int $minItems = 8
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/LocationSimilarityStrategy.php
+++ b/src/Clusterer/LocationSimilarityStrategy.php
@@ -18,6 +18,15 @@ final class LocationSimilarityStrategy implements ClusterStrategyInterface
         private readonly int $minItems = 5,
         private readonly int $maxSpanHours = 24,
     ) {
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
+        if ($this->maxSpanHours < 0) {
+            throw new \InvalidArgumentException('maxSpanHours must be >= 0.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/LongTripClusterStrategy.php
+++ b/src/Clusterer/LongTripClusterStrategy.php
@@ -25,6 +25,15 @@ final class LongTripClusterStrategy implements ClusterStrategyInterface
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItemsPerDay = 3
     ) {
+        if ($this->minAwayKm <= 0.0) {
+            throw new \InvalidArgumentException('minAwayKm must be > 0.');
+        }
+        if ($this->minNights < 1) {
+            throw new \InvalidArgumentException('minNights must be >= 1.');
+        }
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -18,6 +18,12 @@ final class MonthlyHighlightsClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItems = 40,
         private readonly int $minDistinctDays = 10
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
+        if ($this->minDistinctDays < 1) {
+            throw new \InvalidArgumentException('minDistinctDays must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/MorningCoffeeClusterStrategy.php
+++ b/src/Clusterer/MorningCoffeeClusterStrategy.php
@@ -21,6 +21,12 @@ final class MorningCoffeeClusterStrategy implements ClusterStrategyInterface
         private readonly int $minHour = 7,
         private readonly int $maxHour = 10
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
         if ($this->minItems < 1) {
             throw new \InvalidArgumentException('minItems must be >= 1.');
         }

--- a/src/Clusterer/NewYearEveClusterStrategy.php
+++ b/src/Clusterer/NewYearEveClusterStrategy.php
@@ -20,6 +20,12 @@ final class NewYearEveClusterStrategy implements ClusterStrategyInterface
         private readonly int $endHour = 2,
         private readonly int $minItems = 6
     ) {
+        if ($this->startHour < 0 || $this->startHour > 23 || $this->endHour < 0 || $this->endHour > 23) {
+            throw new \InvalidArgumentException('Hour bounds must be within 0..23.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -19,6 +19,15 @@ final class NightlifeEventClusterStrategy implements ClusterStrategyInterface
         private readonly float $radiusMeters = 300.0,
         private readonly int $minItems = 5
     ) {
+        if ($this->timeGapSeconds < 1) {
+            throw new \InvalidArgumentException('timeGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
+++ b/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
@@ -20,6 +20,15 @@ final class OnThisDayOverYearsClusterStrategy implements ClusterStrategyInterfac
         private readonly int $minYears   = 3,
         private readonly int $minItems   = 12
     ) {
+        if ($this->windowDays < 0) {
+            throw new \InvalidArgumentException('windowDays must be >= 0.');
+        }
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/OneYearAgoClusterStrategy.php
+++ b/src/Clusterer/OneYearAgoClusterStrategy.php
@@ -19,6 +19,12 @@ final class OneYearAgoClusterStrategy implements ClusterStrategyInterface
         private readonly int $windowDays = 3,
         private readonly int $minItems   = 8
     ) {
+        if ($this->windowDays < 0) {
+            throw new \InvalidArgumentException('windowDays must be >= 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/PanoramaClusterStrategy.php
+++ b/src/Clusterer/PanoramaClusterStrategy.php
@@ -16,6 +16,15 @@ final class PanoramaClusterStrategy implements ClusterStrategyInterface
         private readonly int $sessionGapSeconds = 3 * 3600,
         private readonly int $minItems = 3
     ) {
+        if ($this->minAspect <= 0.0) {
+            throw new \InvalidArgumentException('minAspect must be > 0.');
+        }
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/PersonCohortClusterStrategy.php
+++ b/src/Clusterer/PersonCohortClusterStrategy.php
@@ -17,6 +17,15 @@ final class PersonCohortClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItems   = 5,
         private readonly int $windowDays = 14
     ) {
+        if ($this->minPersons < 1) {
+            throw new \InvalidArgumentException('minPersons must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
+        if ($this->windowDays < 0) {
+            throw new \InvalidArgumentException('windowDays must be >= 0.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/PetMomentsClusterStrategy.php
+++ b/src/Clusterer/PetMomentsClusterStrategy.php
@@ -15,6 +15,12 @@ final class PetMomentsClusterStrategy implements ClusterStrategyInterface
         private readonly int $sessionGapSeconds = 2 * 3600,
         private readonly int $minItems = 6
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/PhashSimilarityStrategy.php
+++ b/src/Clusterer/PhashSimilarityStrategy.php
@@ -16,6 +16,12 @@ final class PhashSimilarityStrategy implements ClusterStrategyInterface
         private readonly int $maxHamming = 6,
         private readonly int $minItems = 2,
     ) {
+        if ($this->maxHamming < 0) {
+            throw new \InvalidArgumentException('maxHamming must be >= 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/PhotoMotifClusterStrategy.php
+++ b/src/Clusterer/PhotoMotifClusterStrategy.php
@@ -28,6 +28,12 @@ final class PhotoMotifClusterStrategy implements ClusterStrategyInterface
         private readonly int $sessionGapSeconds = 48 * 3600, // split sessions after 48h gap
         private readonly int $minItems = 6
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/PortraitOrientationClusterStrategy.php
+++ b/src/Clusterer/PortraitOrientationClusterStrategy.php
@@ -16,6 +16,15 @@ final class PortraitOrientationClusterStrategy implements ClusterStrategyInterfa
         private readonly int $sessionGapSeconds = 2 * 3600,
         private readonly int $minItems = 4
     ) {
+        if ($this->minPortraitRatio <= 0.0) {
+            throw new \InvalidArgumentException('minPortraitRatio must be > 0.');
+        }
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/RainyDayClusterStrategy.php
+++ b/src/Clusterer/RainyDayClusterStrategy.php
@@ -20,6 +20,12 @@ final class RainyDayClusterStrategy implements ClusterStrategyInterface
         private readonly float $minAvgRainProb = 0.6,  // 0..1
         private readonly int $minItemsPerDay = 6
     ) {
+        if ($this->minAvgRainProb < 0.0 || $this->minAvgRainProb > 1.0) {
+            throw new \InvalidArgumentException('minAvgRainProb must be within 0..1.');
+        }
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/RoadTripClusterStrategy.php
+++ b/src/Clusterer/RoadTripClusterStrategy.php
@@ -23,6 +23,18 @@ final class RoadTripClusterStrategy implements ClusterStrategyInterface
         private readonly int $minNights = 3,       // => at least 4 days
         private readonly int $minItemsTotal = 40
     ) {
+        if ($this->minDailyKm <= 0.0) {
+            throw new \InvalidArgumentException('minDailyKm must be > 0.');
+        }
+        if ($this->minGpsSamplesPerDay < 1) {
+            throw new \InvalidArgumentException('minGpsSamplesPerDay must be >= 1.');
+        }
+        if ($this->minNights < 1) {
+            throw new \InvalidArgumentException('minNights must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/SeasonClusterStrategy.php
+++ b/src/Clusterer/SeasonClusterStrategy.php
@@ -16,6 +16,9 @@ final class SeasonClusterStrategy implements ClusterStrategyInterface
     public function __construct(
         private readonly int $minItems = 20
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/SeasonOverYearsClusterStrategy.php
+++ b/src/Clusterer/SeasonOverYearsClusterStrategy.php
@@ -17,6 +17,12 @@ final class SeasonOverYearsClusterStrategy implements ClusterStrategyInterface
         private readonly int $minYears = 3,
         private readonly int $minItems = 30
     ) {
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/SignificantPlaceClusterStrategy.php
+++ b/src/Clusterer/SignificantPlaceClusterStrategy.php
@@ -20,6 +20,15 @@ final class SignificantPlaceClusterStrategy implements ClusterStrategyInterface
         private readonly int $minVisitDays = 3,
         private readonly int $minItemsTotal = 20
     ) {
+        if ($this->gridDegrees <= 0.0) {
+            throw new \InvalidArgumentException('gridDegrees must be > 0.');
+        }
+        if ($this->minVisitDays < 1) {
+            throw new \InvalidArgumentException('minVisitDays must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/SnowDayClusterStrategy.php
+++ b/src/Clusterer/SnowDayClusterStrategy.php
@@ -18,6 +18,12 @@ final class SnowDayClusterStrategy implements ClusterStrategyInterface
         private readonly int $sessionGapSeconds = 2 * 3600,
         private readonly int $minItems = 6
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
+++ b/src/Clusterer/SnowVacationOverYearsClusterStrategy.php
@@ -24,8 +24,23 @@ final class SnowVacationOverYearsClusterStrategy implements ClusterStrategyInter
         private readonly int $minYears = 3,
         private readonly int $minItemsTotal = 30
     ) {
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minNights < 1) {
+            throw new \InvalidArgumentException('minNights must be >= 1.');
+        }
+        if ($this->maxNights < 1) {
+            throw new \InvalidArgumentException('maxNights must be >= 1.');
+        }
         if ($this->maxNights < $this->minNights) {
             throw new \InvalidArgumentException('maxNights must be >= minNights.');
+        }
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
         }
     }
 

--- a/src/Clusterer/SportsEventClusterStrategy.php
+++ b/src/Clusterer/SportsEventClusterStrategy.php
@@ -20,6 +20,15 @@ final class SportsEventClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItems = 5,
         private readonly bool $preferWeekend = true
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/SunnyDayClusterStrategy.php
+++ b/src/Clusterer/SunnyDayClusterStrategy.php
@@ -22,6 +22,15 @@ final class SunnyDayClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItemsPerDay = 6,
         private readonly int $minHintsPerDay = 3
     ) {
+        if ($this->minAvgSunScore < 0.0 || $this->minAvgSunScore > 1.0) {
+            throw new \InvalidArgumentException('minAvgSunScore must be within 0..1.');
+        }
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minHintsPerDay < 1) {
+            throw new \InvalidArgumentException('minHintsPerDay must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
@@ -36,12 +36,31 @@ abstract class AbstractAtHomeClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItemsTotal,
         private readonly string $timezone,
     ) {
+        if ($this->algorithm === '') {
+            throw new \InvalidArgumentException('algorithm must not be empty.');
+        }
+        if ($this->homeRadiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('homeRadiusMeters must be > 0.');
+        }
+        if ($this->minHomeShare < 0.0 || $this->minHomeShare > 1.0) {
+            throw new \InvalidArgumentException('minHomeShare must be within 0..1.');
+        }
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
+        }
         $lookup = [];
         foreach ($allowedWeekdays as $dow) {
             $dow = (int) $dow;
             if ($dow >= 1 && $dow <= 7) {
                 $lookup[$dow] = true;
             }
+        }
+
+        if ($lookup === []) {
+            throw new \InvalidArgumentException('allowedWeekdays must contain at least one weekday between 1 and 7.');
         }
 
         $this->allowedWeekdayLookup = $lookup;

--- a/src/Clusterer/Support/KeywordBestDayOverYearsStrategy.php
+++ b/src/Clusterer/Support/KeywordBestDayOverYearsStrategy.php
@@ -25,6 +25,18 @@ abstract class KeywordBestDayOverYearsStrategy implements ClusterStrategyInterfa
         private readonly int $minItemsTotal,
         private readonly array $keywords
     ) {
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
+        }
+        if ($this->keywords === []) {
+            throw new \InvalidArgumentException('keywords must not be empty.');
+        }
     }
 
     /**

--- a/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
+++ b/src/Clusterer/ThisMonthOverYearsClusterStrategy.php
@@ -19,6 +19,15 @@ final class ThisMonthOverYearsClusterStrategy implements ClusterStrategyInterfac
         private readonly int $minItems = 24,
         private readonly int $minDistinctDays = 8
     ) {
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
+        if ($this->minDistinctDays < 1) {
+            throw new \InvalidArgumentException('minDistinctDays must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/TimeSimilarityStrategy.php
+++ b/src/Clusterer/TimeSimilarityStrategy.php
@@ -17,6 +17,12 @@ final class TimeSimilarityStrategy implements ClusterStrategyInterface
         private readonly int $maxGapSeconds = 21600,
         private readonly int $minItems = 5,
     ) {
+        if ($this->maxGapSeconds < 1) {
+            throw new \InvalidArgumentException('maxGapSeconds must be >= 1.');
+        }
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/TransitTravelDayClusterStrategy.php
+++ b/src/Clusterer/TransitTravelDayClusterStrategy.php
@@ -18,6 +18,12 @@ final class TransitTravelDayClusterStrategy implements ClusterStrategyInterface
         private readonly float $minTravelKm = 60.0,
         private readonly int $minGpsSamples = 5
     ) {
+        if ($this->minTravelKm <= 0.0) {
+            throw new \InvalidArgumentException('minTravelKm must be > 0.');
+        }
+        if ($this->minGpsSamples < 1) {
+            throw new \InvalidArgumentException('minGpsSamples must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/VideoStoriesClusterStrategy.php
+++ b/src/Clusterer/VideoStoriesClusterStrategy.php
@@ -17,6 +17,9 @@ final class VideoStoriesClusterStrategy implements ClusterStrategyInterface
         private readonly string $timezone = 'Europe/Berlin',
         private readonly int $minItems = 2
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
+++ b/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
@@ -27,8 +27,20 @@ final class WeekendGetawaysOverYearsClusterStrategy implements ClusterStrategyIn
         if ($this->minNights < 1) {
             throw new \InvalidArgumentException('minNights must be >= 1.');
         }
+        if ($this->maxNights < 1) {
+            throw new \InvalidArgumentException('maxNights must be >= 1.');
+        }
         if ($this->maxNights < $this->minNights) {
             throw new \InvalidArgumentException('maxNights must be >= minNights.');
+        }
+        if ($this->minItemsPerDay < 1) {
+            throw new \InvalidArgumentException('minItemsPerDay must be >= 1.');
+        }
+        if ($this->minYears < 1) {
+            throw new \InvalidArgumentException('minYears must be >= 1.');
+        }
+        if ($this->minItemsTotal < 1) {
+            throw new \InvalidArgumentException('minItemsTotal must be >= 1.');
         }
     }
 

--- a/src/Clusterer/WeekendTripClusterStrategy.php
+++ b/src/Clusterer/WeekendTripClusterStrategy.php
@@ -27,6 +27,12 @@ final class WeekendTripClusterStrategy implements ClusterStrategyInterface
         private readonly int $minNights = 1,
         private readonly int $minItems = 3,
     ) {
+        if ($this->minAwayKm <= 0.0) {
+            throw new \InvalidArgumentException('minAwayKm must be > 0.');
+        }
+        if ($this->minNights < 0) {
+            throw new \InvalidArgumentException('minNights must be >= 0.');
+        }
         if ($this->minItems < 1) {
             throw new \InvalidArgumentException('minItems must be >= 1.');
         }

--- a/src/Clusterer/YearInReviewClusterStrategy.php
+++ b/src/Clusterer/YearInReviewClusterStrategy.php
@@ -16,6 +16,12 @@ final class YearInReviewClusterStrategy implements ClusterStrategyInterface
         private readonly int $minItems = 150,
         private readonly int $minDistinctMonths = 5
     ) {
+        if ($this->minItems < 1) {
+            throw new \InvalidArgumentException('minItems must be >= 1.');
+        }
+        if ($this->minDistinctMonths < 1 || $this->minDistinctMonths > 12) {
+            throw new \InvalidArgumentException('minDistinctMonths must be within 1..12.');
+        }
     }
 
     public function name(): string

--- a/src/Clusterer/ZooAquariumClusterStrategy.php
+++ b/src/Clusterer/ZooAquariumClusterStrategy.php
@@ -21,6 +21,12 @@ final class ZooAquariumClusterStrategy implements ClusterStrategyInterface
         private readonly int $minHour = 9,
         private readonly int $maxHour = 20
     ) {
+        if ($this->sessionGapSeconds < 1) {
+            throw new \InvalidArgumentException('sessionGapSeconds must be >= 1.');
+        }
+        if ($this->radiusMeters <= 0.0) {
+            throw new \InvalidArgumentException('radiusMeters must be > 0.');
+        }
         if ($this->minItems < 1) {
             throw new \InvalidArgumentException('minItems must be >= 1.');
         }


### PR DESCRIPTION
## Summary
- add missing guard clauses to cluster strategy constructors so that minimum counts, distance thresholds, and time windows are validated eagerly
- harden shared at-home and keyword-over-years support classes with consistency checks for their configuration inputs

## Testing
- `find src/Clusterer -name '*.php' -print0 | xargs -0 -n1 php -l >/tmp/php_lint.log`


------
https://chatgpt.com/codex/tasks/task_e_68d4cfcbd99c83238e9fe0d7431335a6