### PR TITLE
Use query builder consistently

### DIFF
--- a/src/Command/FeedExportHtmlCommand.php
+++ b/src/Command/FeedExportHtmlCommand.php
@@ -80,12 +80,14 @@ final class FeedExportHtmlCommand extends Command
         $io->title('📰 HTML-Vorschau des Rückblick-Feeds');
 
         // 1) Load clusters from DB
+        $qb = $this->em->createQueryBuilder()
+            ->select('c')
+            ->from(ClusterEntity::class, 'c')
+            ->orderBy('c.createdAt', 'DESC')
+            ->setMaxResults($limitClusters);
+
         /** @var list<ClusterEntity> $entities */
-        $entities = $this->em->createQuery(
-            'SELECT c FROM MagicSunday\Memories\Entity\Cluster c ORDER BY c.createdAt DESC'
-        )
-            ->setMaxResults($limitClusters)
-            ->getResult();
+        $entities = $qb->getQuery()->getResult();
 
         if ($entities === []) {
             $io->warning('Keine Cluster in der Datenbank gefunden.');

--- a/src/Command/FeedPreviewCommand.php
+++ b/src/Command/FeedPreviewCommand.php
@@ -75,12 +75,14 @@ final class FeedPreviewCommand extends Command
 
         $limit = \max(1, (int) $input->getOption('limit-clusters'));
 
+        $qb = $this->em->createQueryBuilder()
+            ->select('c')
+            ->from(ClusterEntity::class, 'c')
+            ->orderBy('c.createdAt', 'DESC')
+            ->setMaxResults($limit);
+
         /** @var list<ClusterEntity> $entities */
-        $entities = $this->em->createQuery(
-            'SELECT c FROM MagicSunday\Memories\Entity\Cluster c ORDER BY c.createdAt DESC'
-        )
-            ->setMaxResults($limit)
-            ->getResult();
+        $entities = $qb->getQuery()->getResult();
 
         if ($entities === []) {
             $io->warning('Keine Cluster in der Datenbank gefunden.');

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -23,10 +23,13 @@ final class MediaRepository
             return [];
         }
 
-        $q = $this->em->createQuery(
-            'SELECT m FROM MagicSunday\Memories\Entity\Media m WHERE m.id IN (:ids)'
-        );
-        $q->setParameter('ids', $ids);
+        $qb = $this->em->createQueryBuilder()
+            ->select('m')
+            ->from(Media::class, 'm')
+            ->where('m.id IN (:ids)')
+            ->setParameter('ids', $ids);
+
+        $q = $qb->getQuery();
 
         /** @var list<Media> $items */
         $items = $q->getResult();

--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -124,13 +124,15 @@ final class ClusterPersistenceService
         /** @var list<string> $fpList */
         $fpList  = \array_keys($fps);
 
-        $q = $this->em->createQuery(
-            'SELECT c.algorithm AS alg, c.fingerprint AS fp
-               FROM ' . Cluster::class . ' c
-              WHERE c.algorithm IN (:algs) AND c.fingerprint IN (:fps)'
-        );
-        $q->setParameter('algs', $algList);
-        $q->setParameter('fps',  $fpList);
+        $qb = $this->em->createQueryBuilder()
+            ->select('c.algorithm AS alg', 'c.fingerprint AS fp')
+            ->from(Cluster::class, 'c')
+            ->where('c.algorithm IN (:algs)')
+            ->andWhere('c.fingerprint IN (:fps)')
+            ->setParameter('algs', $algList)
+            ->setParameter('fps', $fpList);
+
+        $q = $qb->getQuery();
 
         /** @var list<array{alg:string, fp:string}> $rows */
         $rows = $q->getResult();

--- a/src/Service/Geocoding/LocationCellIndex.php
+++ b/src/Service/Geocoding/LocationCellIndex.php
@@ -22,7 +22,11 @@ final class LocationCellIndex
      */
     public function warmUpFromDb(?int $max = null): int
     {
-        $q = $this->em->createQuery('SELECT l.id, l.cell FROM '.Location::class.' l');
+        $qb = $this->em->createQueryBuilder()
+            ->select('l.id', 'l.cell')
+            ->from(Location::class, 'l');
+
+        $q = $qb->getQuery();
         if ($max !== null && $max > 0) {
             $q->setMaxResults($max);
         }


### PR DESCRIPTION
## Summary
- replace remaining EntityManager::createQuery usages with QueryBuilder equivalents for consistent Doctrine usage
- update feed commands, media repository, and services to build queries via QueryBuilder while keeping existing limits and hydration logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4d0af93f8832388dcfd6d345b525e