### PR TITLE
Incorporate POI context into composite scoring

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -16,6 +16,10 @@ parameters:
     memories.geocoding.nominatim.user_agent: 'Rueckblick/1.0'
     memories.geocoding.nominatim.zoom: 14
     memories.geocoding.delay_ms: 1200
+    memories.geocoding.overpass.base_url: 'https://overpass-api.de/api'
+    memories.geocoding.overpass.timeout: 25
+    memories.geocoding.overpass.radius_m: 250
+    memories.geocoding.overpass.max_pois: 15
 
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]
@@ -150,6 +154,20 @@ parameters:
     memories.score.min_valid_year: 1995
     memories.score.time_range.min_samples: 3
     memories.score.time_range.min_coverage: 0.6
+    memories.score.poi_category_boosts:
+        'tourism/*': 0.20
+        'tourism/museum': 0.30
+        'tourism/gallery': 0.22
+        'tourism/theme_park': 0.25
+        'leisure/park': 0.14
+        'leisure/playground': 0.12
+        'amenity/restaurant': 0.08
+        'amenity/cafe': 0.06
+        'historic/*': 0.18
+        'historic/castle': 0.22
+        'natural/beach': 0.20
+        'natural/viewpoint': 0.12
+        'shop/mall': 0.06
 
     # Feed Defaults
     memories.feed.min_score: 0.35

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -137,11 +137,26 @@ services:
     MagicSunday\Memories\Service\Geocoding\ReverseGeocoderInterface:
         alias: MagicSunday\Memories\Service\Geocoding\NominatimReverseGeocoder
 
+    MagicSunday\Memories\Service\Geocoding\OverpassClient:
+        arguments:
+            $http: '@Symfony\Contracts\HttpClient\HttpClientInterface'
+            $baseUrl: '%memories.geocoding.overpass.base_url%'
+            $userAgent: '%memories.geocoding.nominatim.user_agent%'
+            $contactEmail: '%memories.geocoding.nominatim.email%'
+            $queryTimeout: '%memories.geocoding.overpass.timeout%'
+            $httpTimeout: '%memories.geocoding.overpass.timeout%'
+
+    MagicSunday\Memories\Service\Geocoding\LocationPoiEnricher:
+        arguments:
+            $radiusMeters: '%memories.geocoding.overpass.radius_m%'
+            $maxPois: '%memories.geocoding.overpass.max_pois%'
+
     MagicSunday\Memories\Service\Geocoding\LocationCellIndex: ~
 
     MagicSunday\Memories\Service\Geocoding\LocationResolver:
         arguments:
             $cellDeg: 0.01
+            $poiEnricher: '@MagicSunday\Memories\Service\Geocoding\LocationPoiEnricher'
 
     MagicSunday\Memories\Service\Geocoding\MediaLocationLinker:
         arguments:
@@ -674,12 +689,13 @@ services:
     MagicSunday\Memories\Service\Clusterer\Scoring\CompositeClusterScorer:
         arguments:
             $weights:
-                quality: 0.22
-                people: 0.28
-                density: 0.12
-                novelty: 0.14
-                holiday: 0.08
-                recency: 0.16
+                quality: 0.20
+                people: 0.24
+                density: 0.11
+                novelty: 0.13
+                holiday: 0.07
+                recency: 0.15
+                poi: 0.10
             $algorithmBoosts:
                 long_trip: 1.30
                 road_trip: 1.25
@@ -733,6 +749,7 @@ services:
                 device_similarity: 0.82
                 phash_similarity: 0.55
                 burst: 0.55
+            $poiCategoryBoosts: '%memories.score.poi_category_boosts%'
             $qualityBaselineMegapixels: 12.0
             $minValidYear: '%memories.score.min_valid_year%'
             $timeRangeMinSamples: '%memories.score.time_range.min_samples%'

--- a/src/Clusterer/LocationSimilarityStrategy.php
+++ b/src/Clusterer/LocationSimilarityStrategy.php
@@ -73,6 +73,20 @@ final class LocationSimilarityStrategy implements ClusterStrategyInterface
                 $params['place'] = $label;
             }
 
+            $poi = $this->locHelper->majorityPoiContext($group);
+            if ($poi !== null) {
+                $params['poi_label'] = $poi['label'];
+                if ($poi['categoryKey'] !== null) {
+                    $params['poi_category_key'] = $poi['categoryKey'];
+                }
+                if ($poi['categoryValue'] !== null) {
+                    $params['poi_category_value'] = $poi['categoryValue'];
+                }
+                if ($poi['tags'] !== []) {
+                    $params['poi_tags'] = $poi['tags'];
+                }
+            }
+
             $drafts[] = new ClusterDraft(
                 algorithm: $this->name(),
                 params: $params,

--- a/src/Clusterer/SignificantPlaceClusterStrategy.php
+++ b/src/Clusterer/SignificantPlaceClusterStrategy.php
@@ -105,6 +105,20 @@ final class SignificantPlaceClusterStrategy implements ClusterStrategyInterface
                 $params['place'] = $label;
             }
 
+            $poi = $this->locHelper->majorityPoiContext($list);
+            if ($poi !== null) {
+                $params['poi_label'] = $poi['label'];
+                if ($poi['categoryKey'] !== null) {
+                    $params['poi_category_key'] = $poi['categoryKey'];
+                }
+                if ($poi['categoryValue'] !== null) {
+                    $params['poi_category_value'] = $poi['categoryValue'];
+                }
+                if ($poi['tags'] !== []) {
+                    $params['poi_tags'] = $poi['tags'];
+                }
+            }
+
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
                 params: $params,

--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -95,9 +95,15 @@ final class GeocodeCommand extends Command
             }
 
             // nur schlafen, wenn wirklich ein Netz-Call stattfand
-            if ($this->linker->consumeLastUsedNetwork() && $this->delayMs > 0) {
-                $netCalls++;
-                \usleep($this->delayMs * 1000);
+            $networkCalls = $this->linker->consumeLastNetworkCalls();
+            if ($networkCalls > 0) {
+                $netCalls += $networkCalls;
+
+                if ($this->delayMs > 0) {
+                    for ($i = 0; $i < $networkCalls; $i++) {
+                        \usleep($this->delayMs * 1000);
+                    }
+                }
             }
 
             $processed++;

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -72,6 +72,12 @@ class Location
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $boundingBox = null;
 
+    /**
+     * @var list<array<string,mixed>>|null nearby Points of Interest enriched via Overpass API
+     */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $pois = null;
+
     public function __construct(
         string $provider,
         string $providerPlaceId,
@@ -382,6 +388,24 @@ class Location
     public function setBoundingBox(?array $boundingBox): Location
     {
         $this->boundingBox = $boundingBox;
+        return $this;
+    }
+
+    /**
+     * @return list<array<string,mixed>>|null
+     */
+    public function getPois(): ?array
+    {
+        return $this->pois;
+    }
+
+    /**
+     * @param list<array<string,mixed>>|null $pois
+     */
+    public function setPois(?array $pois): Location
+    {
+        $this->pois = $pois;
+
         return $this;
     }
 }

--- a/src/Service/Clusterer/Scoring/CompositeClusterScorer.php
+++ b/src/Service/Clusterer/Scoring/CompositeClusterScorer.php
@@ -15,17 +15,30 @@ final class CompositeClusterScorer
         private readonly EntityManagerInterface $em,
         private readonly HolidayResolverInterface $holidayResolver,
         private readonly NoveltyHeuristic $novelty,
-        /** @var array{quality:float,people:float,density:float,novelty:float,holiday:float,recency:float} */
+        /**
+         * @var array{
+         *     quality:float,
+         *     people:float,
+         *     density:float,
+         *     novelty:float,
+         *     holiday:float,
+         *     recency:float,
+         *     poi?:float
+         * }
+         */
         private readonly array $weights = [
-            'quality' => 0.25,
-            'people'  => 0.20,
-            'density' => 0.15,
+            'quality' => 0.23,
+            'people'  => 0.18,
+            'density' => 0.14,
             'novelty' => 0.10,
             'holiday' => 0.10,
             'recency' => 0.20,
+            'poi'     => 0.05,
         ],
         /** @var array<string,float> $algorithmBoosts */
         private readonly array $algorithmBoosts = [],
+        /** @var array<string,float> $poiCategoryBoosts */
+        private readonly array $poiCategoryBoosts = [],
         private readonly float $qualityBaselineMegapixels = 12.0,
         private readonly int $minValidYear = 1990,
         private readonly int $timeRangeMinSamples = 3,
@@ -35,6 +48,17 @@ final class CompositeClusterScorer
             if ($boost <= 0.0) {
                 throw new \InvalidArgumentException(
                     \sprintf('Algorithm boost must be > 0.0, got %s => %f', (string) $algorithm, $boost)
+                );
+            }
+        }
+
+        foreach ($this->poiCategoryBoosts as $pattern => $boost) {
+            if (!\is_string($pattern) || $pattern === '') {
+                throw new \InvalidArgumentException('POI category boost keys must be non-empty strings.');
+            }
+            if (!\is_numeric($boost)) {
+                throw new \InvalidArgumentException(
+                    \sprintf('POI category boost for %s must be numeric.', $pattern)
                 );
             }
         }
@@ -107,6 +131,10 @@ final class CompositeClusterScorer
             }
             $c->setParam('recency', $recency);
 
+            // --- poi context (only available when strategies attached Overpass metadata)
+            $poiScore = $this->computePoiScore($c);
+            $c->setParam('poi_score', $poiScore);
+
             // --- weighted sum
             $score =
                 $this->weights['quality'] * $quality +
@@ -114,7 +142,8 @@ final class CompositeClusterScorer
                 $this->weights['density'] * $density +
                 $this->weights['novelty'] * $novelty +
                 $this->weights['holiday'] * $holiday +
-                $this->weights['recency'] * $recency;
+                $this->weights['recency'] * $recency +
+                ($this->weights['poi'] ?? 0.0) * $poiScore;
 
             $algorithm = $c->getAlgorithm();
             $boost     = $this->algorithmBoosts[$algorithm] ?? 1.0;
@@ -198,6 +227,79 @@ final class CompositeClusterScorer
             $this->timeRangeMinCoverage,
             $this->minValidYear
         );
+    }
+
+    private function computePoiScore(ClusterDraft $cluster): float
+    {
+        $params = $cluster->getParams();
+        $label = $this->stringOrNull($params['poi_label'] ?? null);
+        $categoryKey = $this->stringOrNull($params['poi_category_key'] ?? null);
+        $categoryValue = $this->stringOrNull($params['poi_category_value'] ?? null);
+        $tags = \is_array($params['poi_tags'] ?? null) ? $params['poi_tags'] : [];
+
+        $score = 0.0;
+
+        if ($label !== null) {
+            $score += 0.45;
+        }
+
+        if ($categoryKey !== null || $categoryValue !== null) {
+            $score += 0.25;
+        }
+
+        $score += $this->lookupPoiCategoryBoost($categoryKey, $categoryValue);
+
+        if (\is_array($tags)) {
+            if ($this->stringOrNull($tags['wikidata'] ?? null) !== null) {
+                $score += 0.15;
+            }
+            if ($this->stringOrNull($tags['website'] ?? null) !== null) {
+                $score += 0.05;
+            }
+        }
+
+        return $this->clamp01($score);
+    }
+
+    private function lookupPoiCategoryBoost(?string $categoryKey, ?string $categoryValue): float
+    {
+        if ($this->poiCategoryBoosts === []) {
+            return 0.0;
+        }
+
+        $boost = 0.0;
+
+        if ($categoryKey !== null) {
+            $boost += (float) ($this->poiCategoryBoosts[$categoryKey.'/*'] ?? 0.0);
+        }
+
+        if ($categoryValue !== null) {
+            $boost += (float) ($this->poiCategoryBoosts['*/'.$categoryValue] ?? 0.0);
+        }
+
+        if ($categoryKey !== null && $categoryValue !== null) {
+            $boost += (float) ($this->poiCategoryBoosts[$categoryKey.'/'.$categoryValue] ?? 0.0);
+        }
+
+        return $boost;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return \is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function clamp01(float $value): float
+    {
+        if ($value <= 0.0) {
+            return 0.0;
+        }
+
+        if ($value >= 1.0) {
+            return 1.0;
+        }
+
+        return $value;
     }
 
     private function computeHolidayScore(int $fromTs, int $toTs): float

--- a/src/Service/Geocoding/LocationPoiEnricher.php
+++ b/src/Service/Geocoding/LocationPoiEnricher.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Utility\MediaMath;
+
+/**
+ * Enriches Location entities with nearby Points of Interest using the Overpass API.
+ */
+final class LocationPoiEnricher
+{
+    public function __construct(
+        private readonly OverpassClient $client,
+        private readonly int $radiusMeters = 250,
+        private readonly int $maxPois = 15
+    ) {
+    }
+
+    /**
+     * Adds POI information to the location, returns true when the network was contacted.
+     */
+    public function enrich(Location $location, GeocodeResult $geocode): bool
+    {
+        $radius = $this->determineRadius($geocode);
+        $pois = $this->client->fetchPois($geocode->lat, $geocode->lon, $radius, $this->maxPois);
+        $usedNetwork = $this->client->consumeLastUsedNetwork();
+
+        if ($pois !== []) {
+            $location->setPois($pois);
+        } elseif ($usedNetwork && $location->getPois() === null) {
+            // Mark attempted enrichment to avoid hammering the API when no POIs exist.
+            $location->setPois([]);
+        }
+
+        return $usedNetwork;
+    }
+
+    private function determineRadius(GeocodeResult $geocode): int
+    {
+        $radius = $this->radiusMeters;
+        $bboxRadius = $this->radiusFromBoundingBox($geocode);
+
+        if ($bboxRadius !== null) {
+            $radius = \max($radius, $bboxRadius);
+        }
+
+        return $radius;
+    }
+
+    private function radiusFromBoundingBox(GeocodeResult $geocode): ?int
+    {
+        $bbox = $geocode->boundingBox;
+        if (!\is_array($bbox) || \count($bbox) !== 4) {
+            return null;
+        }
+
+        [$south, $north, $west, $east] = $bbox;
+        if (!\is_numeric($south) || !\is_numeric($north) || !\is_numeric($west) || !\is_numeric($east)) {
+            return null;
+        }
+
+        $centerLat = $geocode->lat;
+        $centerLon = $geocode->lon;
+
+        $distances = [
+            MediaMath::haversineDistanceInMeters($centerLat, $centerLon, (float) $north, $centerLon),
+            MediaMath::haversineDistanceInMeters($centerLat, $centerLon, (float) $south, $centerLon),
+            MediaMath::haversineDistanceInMeters($centerLat, $centerLon, $centerLat, (float) $east),
+            MediaMath::haversineDistanceInMeters($centerLat, $centerLon, $centerLat, (float) $west),
+        ];
+
+        $radius = (int) \ceil(\max($distances));
+
+        if ($radius <= 0) {
+            return null;
+        }
+
+        return \max(50, \min($radius, 1000));
+    }
+}

--- a/src/Service/Geocoding/OverpassClient.php
+++ b/src/Service/Geocoding/OverpassClient.php
@@ -1,0 +1,271 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Utility\MediaMath;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Minimal Overpass API client fetching nearby Points of Interest.
+ */
+final class OverpassClient
+{
+    /**
+     * Relevant tag keys we consider for POI categorisation.
+     *
+     * @var list<string>
+     */
+    private const TAG_KEYS = [
+        'tourism',
+        'amenity',
+        'leisure',
+        'sport',
+        'historic',
+        'man_made',
+        'shop',
+        'natural',
+        'landuse',
+        'place',
+        'building',
+    ];
+
+    private bool $lastUsedNetwork = false;
+
+    /**
+     * @param float $httpTimeout Timeout in seconds for the HTTP request (symfony client option).
+     */
+    public function __construct(
+        private readonly HttpClientInterface $http,
+        private readonly string $baseUrl = 'https://overpass-api.de/api',
+        private readonly string $userAgent = 'Rueckblick/1.0',
+        private readonly ?string $contactEmail = null,
+        private readonly int $queryTimeout = 25,
+        private readonly float $httpTimeout = 25.0
+    ) {
+    }
+
+    /**
+     * Fetches POIs around given coordinates.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function fetchPois(float $lat, float $lon, int $radiusMeters, int $limit): array
+    {
+        $this->lastUsedNetwork = false;
+
+        if ($radiusMeters <= 0 || $limit <= 0) {
+            return [];
+        }
+
+        $query = $this->buildQuery($lat, $lon, $radiusMeters, $limit);
+
+        try {
+            $this->lastUsedNetwork = true;
+            $response = $this->http->request('POST', $this->baseUrl.'/interpreter', [
+                'headers' => [
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                    'Accept'       => 'application/json',
+                    'User-Agent'   => $this->userAgentWithContact(),
+                ],
+                'body'    => [
+                    'data' => $query,
+                ],
+                'timeout' => $this->httpTimeout,
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                return [];
+            }
+
+            /** @var array<string,mixed> $payload */
+            $payload = $response->toArray(false);
+        } catch (TransportExceptionInterface|ClientExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface|DecodingExceptionInterface) {
+            return [];
+        }
+
+        $elements = $payload['elements'] ?? null;
+        if (!\is_array($elements)) {
+            return [];
+        }
+
+        /** @var array<string,array<string,mixed>> $pois */
+        $pois = [];
+        foreach ($elements as $element) {
+            if (!\is_array($element)) {
+                continue;
+            }
+
+            $id = $this->elementId($element);
+            if ($id === null || isset($pois[$id])) {
+                continue;
+            }
+
+            $coordinate = $this->extractCoordinate($element);
+            if ($coordinate === null) {
+                continue;
+            }
+
+            $tags = $element['tags'] ?? null;
+            if (!\is_array($tags)) {
+                $tags = [];
+            }
+
+            $name = $this->stringOrNull($tags['name'] ?? null);
+            $primaryKey = $this->primaryTagKey($tags);
+            $primaryValue = $primaryKey !== null ? $this->stringOrNull($tags[$primaryKey] ?? null) : null;
+
+            if ($name === null && $primaryValue === null) {
+                continue; // skip noisier features without any textual context
+            }
+
+            $selectedTags = $this->selectRelevantTags($tags);
+
+            $pois[$id] = [
+                'id'             => $id,
+                'name'           => $name,
+                'categoryKey'    => $primaryKey,
+                'categoryValue'  => $primaryValue,
+                'lat'            => $coordinate['lat'],
+                'lon'            => $coordinate['lon'],
+                'distanceMeters' => \round(
+                    MediaMath::haversineDistanceInMeters($lat, $lon, $coordinate['lat'], $coordinate['lon']),
+                    2
+                ),
+                'tags'           => $selectedTags,
+            ];
+        }
+
+        if ($pois === []) {
+            return [];
+        }
+
+        $values = \array_values($pois);
+        \usort(
+            $values,
+            static fn (array $a, array $b): int => $a['distanceMeters'] <=> $b['distanceMeters']
+        );
+
+        if (\count($values) > $limit) {
+            $values = \array_slice($values, 0, $limit);
+        }
+
+        return $values;
+    }
+
+    public function consumeLastUsedNetwork(): bool
+    {
+        $used = $this->lastUsedNetwork;
+        $this->lastUsedNetwork = false;
+
+        return $used;
+    }
+
+    private function buildQuery(float $lat, float $lon, int $radius, int $limit): string
+    {
+        $latS = \number_format($lat, 7, '.', '');
+        $lonS = \number_format($lon, 7, '.', '');
+        $radius = \max(1, $radius);
+        $limit = \max(1, $limit);
+
+        $query = \sprintf('[out:json][timeout:%d];(', $this->queryTimeout);
+        foreach (self::TAG_KEYS as $key) {
+            $query .= \sprintf('nwr(around:%d,%s,%s)["%s"];', $radius, $latS, $lonS, $key);
+        }
+        $query .= \sprintf(');out tags center %d;', $limit);
+
+        return $query;
+    }
+
+    private function elementId(array $element): ?string
+    {
+        $type = $this->stringOrNull($element['type'] ?? null);
+        $id = $element['id'] ?? null;
+
+        if ($type === null || (!\is_int($id) && !\is_string($id))) {
+            return null;
+        }
+
+        return $type.'/'.(string) $id;
+    }
+
+    /**
+     * @return array{lat: float, lon: float}|null
+     */
+    private function extractCoordinate(array $element): ?array
+    {
+        $lat = $element['lat'] ?? null;
+        $lon = $element['lon'] ?? null;
+
+        if (\is_numeric($lat) && \is_numeric($lon)) {
+            return [ 'lat' => (float) $lat, 'lon' => (float) $lon ];
+        }
+
+        $center = $element['center'] ?? null;
+        if (\is_array($center) && \is_numeric($center['lat'] ?? null) && \is_numeric($center['lon'] ?? null)) {
+            return [ 'lat' => (float) $center['lat'], 'lon' => (float) $center['lon'] ];
+        }
+
+        return null;
+    }
+
+    private function primaryTagKey(array $tags): ?string
+    {
+        foreach ($this->relevantTagKeys() as $key) {
+            if ($this->stringOrNull($tags[$key] ?? null) !== null) {
+                return $key;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function selectRelevantTags(array $tags): array
+    {
+        $selected = [];
+        foreach ($this->relevantTagKeys() as $key) {
+            $value = $this->stringOrNull($tags[$key] ?? null);
+            if ($value !== null) {
+                $selected[$key] = $value;
+            }
+        }
+
+        return $selected;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function relevantTagKeys(): array
+    {
+        return self::TAG_KEYS;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return \is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function userAgentWithContact(): string
+    {
+        $email = $this->contactEmail;
+        if ($email === null) {
+            return $this->userAgent;
+        }
+
+        $trimmed = \trim($email);
+        if ($trimmed === '') {
+            return $this->userAgent;
+        }
+
+        return $this->userAgent.' ('.$trimmed.')';
+    }
+}


### PR DESCRIPTION
## Summary
- extend the composite cluster scorer to compute a POI-specific subscore and include it in the weighted aggregate
- expose configurable POI scoring weights and category boosts so prominent venues receive consistent boosts during ranking

## Testing
- php -l src/Service/Clusterer/Scoring/CompositeClusterScorer.php

------
https://chatgpt.com/codex/tasks/task_e_68d53858e4e883238696e8e53f628683