### PR TITLE
Add keyword best day over years strategy tests

### DIFF
--- a/test/Unit/Clusterer/AnniversaryClusterStrategyTest.php
+++ b/test/Unit/Clusterer/AnniversaryClusterStrategyTest.php
@@ -16,195 +16,104 @@ use PHPUnit\Framework\TestCase;
 final class AnniversaryClusterStrategyTest extends TestCase
 {
     #[Test]
-    public function clustersMediaSharingSameMonthDayAcrossYears(): void
+    public function keepsHighestScoringAnniversariesWithinLimit(): void
     {
-        $strategy = new AnniversaryClusterStrategy(new LocationHelper());
+        $strategy = new AnniversaryClusterStrategy(
+            locHelper: new LocationHelper(),
+            minItems: 3,
+            minDistinctYears: 2,
+            maxClusters: 1,
+        );
 
-        $location = $this->createLocation(city: 'Berlin');
+        $berlin = $this->createLocation('berlin');
+        $munich = $this->createLocation('munich');
+
         $mediaItems = [
-            $this->createMedia(
-                id: 10,
-                takenAt: '2020-05-10 09:00:00',
-                lat: 52.5200,
-                lon: 13.4050,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 11,
-                takenAt: '2021-05-10 10:15:00',
-                lat: 52.5205,
-                lon: 13.4045,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 12,
-                takenAt: '2022-05-10 08:30:00',
-                lat: 52.5195,
-                lon: 13.4055,
-                location: $location,
-            ),
+            // Jan-05 group (4 items across 3 years) -> higher score
+            $this->createMedia(1001, '2019-01-05 09:00:00', $berlin, 52.5200, 13.4050),
+            $this->createMedia(1002, '2020-01-05 09:05:00', $berlin, 52.5202, 13.4052),
+            $this->createMedia(1003, '2020-01-05 09:06:00', $berlin, 52.5201, 13.4051),
+            $this->createMedia(1004, '2021-01-05 09:10:00', $berlin, 52.5203, 13.4053),
+            // Mar-10 group (3 items across 3 years) -> lower score, should be dropped by maxClusters
+            $this->createMedia(1101, '2018-03-10 11:00:00', $munich, 48.1371, 11.5753),
+            $this->createMedia(1102, '2019-03-10 11:05:00', $munich, 48.1372, 11.5754),
+            $this->createMedia(1103, '2020-03-10 11:10:00', $munich, 48.1373, 11.5755),
         ];
 
         $clusters = $strategy->cluster($mediaItems);
 
         self::assertCount(1, $clusters);
         $cluster = $clusters[0];
+
         self::assertInstanceOf(ClusterDraft::class, $cluster);
         self::assertSame('anniversary', $cluster->getAlgorithm());
-        self::assertSame([10, 11, 12], $cluster->getMembers());
+        self::assertSame([1001, 1002, 1003, 1004], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame('Berlin', $params['place']);
 
         $expectedRange = [
-            'from' => (new DateTimeImmutable('2020-05-10 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
-            'to'   => (new DateTimeImmutable('2022-05-10 08:30:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'from' => (new DateTimeImmutable('2019-01-05 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2021-01-05 09:10:00', new DateTimeZone('UTC')))->getTimestamp(),
         ];
-        self::assertSame($expectedRange, $cluster->getParams()['time_range']);
-        self::assertSame('Berlin', $cluster->getParams()['place']);
+        self::assertSame($expectedRange, $params['time_range']);
 
         $centroid = $cluster->getCentroid();
-        self::assertEqualsWithDelta(52.52, $centroid['lat'], 0.0005);
-        self::assertEqualsWithDelta(13.405, $centroid['lon'], 0.0005);
+        self::assertEqualsWithDelta(52.52015, $centroid['lat'], 0.0001);
+        self::assertEqualsWithDelta(13.40515, $centroid['lon'], 0.0001);
     }
 
     #[Test]
-    public function skipsGroupsWithLessThanThreeMedia(): void
+    public function returnsEmptyWhenAnniversaryLacksDistinctYears(): void
     {
-        $strategy = new AnniversaryClusterStrategy(new LocationHelper());
+        $strategy = new AnniversaryClusterStrategy(
+            locHelper: new LocationHelper(),
+            minItems: 3,
+            minDistinctYears: 3,
+            maxClusters: 0,
+        );
 
-        $location = $this->createLocation(city: 'Hamburg');
+        $location = $this->createLocation('hamburg');
+
         $mediaItems = [
-            $this->createMedia(
-                id: 20,
-                takenAt: '2020-03-15 12:00:00',
-                lat: 53.5511,
-                lon: 9.9937,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 21,
-                takenAt: '2021-03-15 12:00:00',
-                lat: 53.5512,
-                lon: 9.9936,
-                location: $location,
-            ),
-        ];
-
-        $clusters = $strategy->cluster($mediaItems);
-
-        self::assertSame([], $clusters);
-    }
-
-    #[Test]
-    public function enforcesMinimumDistinctYears(): void
-    {
-        $strategy = new AnniversaryClusterStrategy(new LocationHelper(), minItems: 3, minDistinctYears: 3);
-
-        $location = $this->createLocation(city: 'Munich');
-        $mediaItems = [
-            $this->createMedia(
-                id: 30,
-                takenAt: '2020-07-04 09:00:00',
-                lat: 48.1371,
-                lon: 11.5754,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 31,
-                takenAt: '2021-07-04 10:00:00',
-                lat: 48.1372,
-                lon: 11.5755,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 32,
-                takenAt: '2021-07-04 11:00:00',
-                lat: 48.1373,
-                lon: 11.5756,
-                location: $location,
-            ),
+            $this->createMedia(2001, '2022-07-04 10:00:00', $location, 53.5511, 9.9937),
+            $this->createMedia(2002, '2022-07-04 10:02:00', $location, 53.5512, 9.9938),
+            $this->createMedia(2003, '2023-07-04 10:05:00', $location, 53.5513, 9.9939),
         ];
 
         self::assertSame([], $strategy->cluster($mediaItems));
-
-        $mediaItems[] = $this->createMedia(
-            id: 33,
-            takenAt: '2022-07-04 09:30:00',
-            lat: 48.1374,
-            lon: 11.5753,
-            location: $location,
-        );
-
-        $clusters = $strategy->cluster($mediaItems);
-        self::assertCount(1, $clusters);
-        self::assertSame([30, 31, 32, 33], $clusters[0]->getMembers());
     }
 
     #[Test]
-    public function limitsClustersToConfiguredMaximum(): void
+    public function skipsGroupsBelowMinimumItemCount(): void
     {
-        $strategy = new AnniversaryClusterStrategy(new LocationHelper(), minItems: 3, minDistinctYears: 1, maxClusters: 1);
+        $strategy = new AnniversaryClusterStrategy(
+            locHelper: new LocationHelper(),
+            minItems: 4,
+            minDistinctYears: 2,
+            maxClusters: 0,
+        );
 
-        $location = $this->createLocation(city: 'Cologne');
+        $location = $this->createLocation('berlin');
+
         $mediaItems = [
-            $this->createMedia(
-                id: 40,
-                takenAt: '2018-01-01 08:00:00',
-                lat: 50.9375,
-                lon: 6.9603,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 41,
-                takenAt: '2019-01-01 08:15:00',
-                lat: 50.9376,
-                lon: 6.9604,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 42,
-                takenAt: '2020-01-01 08:30:00',
-                lat: 50.9377,
-                lon: 6.9605,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 43,
-                takenAt: '2021-01-01 08:45:00',
-                lat: 50.9378,
-                lon: 6.9606,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 44,
-                takenAt: '2018-02-02 08:00:00',
-                lat: 50.9375,
-                lon: 6.9603,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 45,
-                takenAt: '2019-02-02 08:15:00',
-                lat: 50.9376,
-                lon: 6.9604,
-                location: $location,
-            ),
-            $this->createMedia(
-                id: 46,
-                takenAt: '2020-02-02 08:30:00',
-                lat: 50.9377,
-                lon: 6.9605,
-                location: $location,
-            ),
+            $this->createMedia(3001, '2020-09-15 12:00:00', $location, 52.5201, 13.4049),
+            $this->createMedia(3002, '2021-09-15 12:05:00', $location, 52.5202, 13.4050),
+            $this->createMedia(3003, '2022-09-15 12:10:00', $location, 52.5203, 13.4051),
         ];
 
-        $clusters = $strategy->cluster($mediaItems);
-        self::assertCount(1, $clusters);
-        self::assertSame([40, 41, 42, 43], $clusters[0]->getMembers());
+        self::assertSame([], $strategy->cluster($mediaItems));
     }
 
-    private function createMedia(int $id, string $takenAt, float $lat, float $lon, Location $location): Media
-    {
+    private function createMedia(
+        int $id,
+        string $takenAt,
+        Location $location,
+        float $lat,
+        float $lon,
+    ): Media {
         $media = new Media(
-            path: __DIR__."/fixtures/media-{$id}.jpg",
+            path: __DIR__ . "/fixtures/anniversary-{$id}.jpg",
             checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
             size: 1024,
         );
@@ -218,19 +127,24 @@ final class AnniversaryClusterStrategyTest extends TestCase
         return $media;
     }
 
-    private function createLocation(string $city): Location
+    private function createLocation(string $key): Location
     {
+        $city = match ($key) {
+            'berlin' => 'Berlin',
+            'munich' => 'Munich',
+            default => 'Hamburg',
+        };
+
         $location = new Location(
             provider: 'osm',
-            providerPlaceId: 'place-'.$city,
-            displayName: $city,
-            lat: 0.0,
-            lon: 0.0,
-            cell: 'cell-'.$city,
+            providerPlaceId: $key,
+            displayName: ucfirst($key),
+            lat: 50.0,
+            lon: 8.0,
+            cell: 'cell-' . $key,
         );
 
         $location->setCity($city);
-        $location->setCountry('Germany');
 
         return $location;
     }

--- a/test/Unit/Clusterer/BurstClusterStrategyTest.php
+++ b/test/Unit/Clusterer/BurstClusterStrategyTest.php
@@ -14,22 +14,15 @@ use PHPUnit\Framework\TestCase;
 final class BurstClusterStrategyTest extends TestCase
 {
     #[Test]
-    public function groupsBurstWithinThresholds(): void
+    public function clustersSequentialShotsWithinGapAndDistance(): void
     {
-        $strategy = new BurstClusterStrategy(
-            maxGapSeconds: 60,
-            maxMoveMeters: 30.0,
-            minItems: 3,
-        );
+        $strategy = new BurstClusterStrategy(maxGapSeconds: 120, maxMoveMeters: 100.0, minItems: 3);
 
         $mediaItems = [
-            $this->createMedia(2003, '2022-06-15 10:02:00', lat: 52.52010, lon: 13.40480),
-            $this->createMedia(2001, '2022-06-15 10:00:10', lat: 52.52000, lon: 13.40470),
-            $this->createMedia(2004, '2022-06-15 10:02:45', lat: 52.52020, lon: 13.40485),
-            $this->createMedia(2002, '2022-06-15 10:01:05', lat: 52.52005, lon: 13.40475),
-            // Gap too large for another burst
-            $this->createMedia(2010, '2022-06-15 11:30:00', lat: 52.53000, lon: 13.41000),
-            $this->createMedia(2011, '2022-06-15 11:32:00', lat: 52.53010, lon: 13.41010),
+            $this->createMedia(3001, '2023-04-15 10:01:10', 52.5201, 13.4051),
+            $this->createMedia(3002, '2023-04-15 10:00:05', 52.5200, 13.4050),
+            $this->createMedia(3003, '2023-04-15 10:02:20', 52.5202, 13.4052),
+            $this->createMedia(3004, '2023-04-15 10:03:00', 52.5203, 13.4053),
         ];
 
         $clusters = $strategy->cluster($mediaItems);
@@ -39,62 +32,68 @@ final class BurstClusterStrategyTest extends TestCase
 
         self::assertInstanceOf(ClusterDraft::class, $cluster);
         self::assertSame('burst', $cluster->getAlgorithm());
+        self::assertSame([3002, 3001, 3003, 3004], $cluster->getMembers());
 
-        $expectedMembers = [2001, 2002, 2003, 2004];
-        self::assertSame($expectedMembers, $cluster->getMembers());
-
+        $params = $cluster->getParams();
         $expectedRange = [
-            'from' => (new DateTimeImmutable('2022-06-15 10:00:10', new DateTimeZone('UTC')))->getTimestamp(),
-            'to'   => (new DateTimeImmutable('2022-06-15 10:02:45', new DateTimeZone('UTC')))->getTimestamp(),
+            'from' => (new DateTimeImmutable('2023-04-15 10:00:05', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-04-15 10:03:00', new DateTimeZone('UTC')))->getTimestamp(),
         ];
-        self::assertSame($expectedRange, $cluster->getParams()['time_range']);
+        self::assertSame($expectedRange, $params['time_range']);
 
         $centroid = $cluster->getCentroid();
-        self::assertEqualsWithDelta(52.5200875, $centroid['lat'], 0.00001);
-        self::assertEqualsWithDelta(13.404775, $centroid['lon'], 0.00001);
+        self::assertEqualsWithDelta(52.52015, $centroid['lat'], 0.0001);
+        self::assertEqualsWithDelta(13.40515, $centroid['lon'], 0.0001);
     }
 
     #[Test]
-    public function returnsEmptyWhenBurstsAreTooSmall(): void
+    public function breaksSequenceWhenGapExceedsThreshold(): void
     {
-        $strategy = new BurstClusterStrategy(
-            maxGapSeconds: 45,
-            maxMoveMeters: 25.0,
-            minItems: 3,
-        );
+        $strategy = new BurstClusterStrategy(maxGapSeconds: 60, maxMoveMeters: 100.0, minItems: 3);
 
         $mediaItems = [
-            $this->createMedia(2101, '2022-07-01 09:00:00', lat: 48.1370, lon: 11.5750),
-            $this->createMedia(2102, '2022-07-01 09:05:00', lat: 48.1371, lon: 11.5751),
-            $this->createMedia(2103, '2022-07-01 09:55:00', lat: 48.1372, lon: 11.5752),
+            $this->createMedia(4001, '2023-04-15 09:00:00', 40.7127, -74.0061),
+            $this->createMedia(4002, '2023-04-15 09:00:30', 40.7128, -74.0060),
+            $this->createMedia(4003, '2023-04-15 09:01:00', 40.7129, -74.0059),
+            // Gap > 60s, so new session but below minItems and thus discarded
+            $this->createMedia(4004, '2023-04-15 09:05:10', 40.7130, -74.0058),
+            $this->createMedia(4005, '2023-04-15 09:06:20', 40.7131, -74.0057),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame([4001, 4002, 4003], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoBurstReachesMinimumSize(): void
+    {
+        $strategy = new BurstClusterStrategy(maxGapSeconds: 90, maxMoveMeters: 50.0, minItems: 4);
+
+        $mediaItems = [
+            $this->createMedia(5001, '2023-07-20 14:00:00', 34.0521, -118.2436),
+            $this->createMedia(5002, '2023-07-20 14:00:40', 34.0522, -118.2435),
+            $this->createMedia(5003, '2023-07-20 14:01:15', 34.0523, -118.2434),
         ];
 
         self::assertSame([], $strategy->cluster($mediaItems));
     }
 
-    private function createMedia(
-        int $id,
-        string $takenAt,
-        ?string $path = null,
-        ?float $lat = null,
-        ?float $lon = null,
-    ): Media {
+    private function createMedia(int $id, string $takenAt, float $lat, float $lon): Media
+    {
         $media = new Media(
-            path: $path ?? __DIR__ . "/fixtures/burst-{$id}.jpg",
+            path: __DIR__ . "/fixtures/burst-{$id}.jpg",
             checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
             size: 1024,
         );
 
         $this->assignId($media, $id);
         $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
-
-        if ($lat !== null) {
-            $media->setGpsLat($lat);
-        }
-
-        if ($lon !== null) {
-            $media->setGpsLon($lon);
-        }
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
 
         return $media;
     }

--- a/test/Unit/Clusterer/CityscapeNightClusterStrategyTest.php
+++ b/test/Unit/Clusterer/CityscapeNightClusterStrategyTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\CityscapeNightClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CityscapeNightClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function buildsNighttimeUrbanCluster(): void
+    {
+        $strategy = new CityscapeNightClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 1800,
+            radiusMeters: 400.0,
+            minItems: 5,
+        );
+
+        $base = new DateTimeImmutable('2023-05-20 20:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 5; $i++) {
+            $media[] = $this->createMedia(
+                500 + $i,
+                $base->modify('+' . ($i * 20) . ' minutes'),
+                "city-skyline-{$i}.jpg",
+                48.1351 + $i * 0.0002,
+                11.5820 + $i * 0.0002,
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('cityscape_night', $cluster->getAlgorithm());
+        self::assertSame([500, 501, 502, 503, 504], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function ignoresDaytimeScenes(): void
+    {
+        $strategy = new CityscapeNightClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 1800,
+            radiusMeters: 400.0,
+            minItems: 5,
+        );
+
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createMedia(
+                600 + $i,
+                new DateTimeImmutable('2023-05-21 12:00:00', new DateTimeZone('UTC')),
+                "city-skyline-{$i}.jpg",
+                48.13 + $i * 0.001,
+                11.58 + $i * 0.001,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $filename, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $filename,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/CrossDimensionClusterStrategyTest.php
+++ b/test/Unit/Clusterer/CrossDimensionClusterStrategyTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\CrossDimensionClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CrossDimensionClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersMediaWhenTimeAndDistanceConstraintsAreSatisfied(): void
+    {
+        $strategy = new CrossDimensionClusterStrategy(
+            timeGapSeconds: 900,
+            radiusMeters: 150.0,
+            minItems: 4,
+        );
+
+        $mediaItems = [
+            $this->createMedia(1201, '2023-08-15 10:00:00', 40.7128, -74.0060),
+            $this->createMedia(1202, '2023-08-15 10:05:00', 40.7129, -74.0059),
+            $this->createMedia(1203, '2023-08-15 10:08:00', 40.7127, -74.0061),
+            $this->createMedia(1204, '2023-08-15 10:12:00', 40.7129, -74.0060),
+            // Separate run due to large time gap
+            $this->createMedia(1205, '2023-08-15 13:00:00', 40.7300, -74.0000),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('cross_dimension', $cluster->getAlgorithm());
+        self::assertSame([1201, 1202, 1203, 1204], $cluster->getMembers());
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2023-08-15 10:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-08-15 10:12:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $cluster->getParams()['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(40.712825, $centroid['lat'], 0.00001);
+        self::assertEqualsWithDelta(-74.0060, $centroid['lon'], 0.00001);
+    }
+
+    #[Test]
+    public function skipsRunsThatExceedRadiusConstraint(): void
+    {
+        $strategy = new CrossDimensionClusterStrategy(
+            timeGapSeconds: 900,
+            radiusMeters: 80.0,
+            minItems: 4,
+        );
+
+        $mediaItems = [
+            $this->createMedia(1301, '2023-09-10 15:00:00', 34.0522, -118.2437),
+            $this->createMedia(1302, '2023-09-10 15:05:00', 34.0523, -118.2438),
+            $this->createMedia(1303, '2023-09-10 15:08:00', 34.0524, -118.2439),
+            // Farther away -> centroid distance > radiusMeters
+            $this->createMedia(1304, '2023-09-10 15:10:00', 34.0600, -118.2500),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/cross-dimension-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/DayAlbumClusterStrategyTest.php
+++ b/test/Unit/Clusterer/DayAlbumClusterStrategyTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\DayAlbumClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DayAlbumClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function groupsMediaByLocalCalendarDay(): void
+    {
+        $strategy = new DayAlbumClusterStrategy(timezone: 'America/Los_Angeles', minItems: 2);
+
+        $mediaItems = [
+            $this->createMedia(101, '2022-06-01 23:30:00', 34.0522, -118.2437),
+            $this->createMedia(102, '2022-06-02 00:15:00', 34.0524, -118.2439),
+            // Falls below the minimum for its own day
+            $this->createMedia(103, '2022-06-02 07:30:00', 34.0526, -118.2441),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('day_album', $cluster->getAlgorithm());
+        self::assertSame([101, 102], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame(2022, $params['year']);
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2022-06-01 23:30:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2022-06-02 00:15:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(34.0523, $centroid['lat'], 0.0001);
+        self::assertEqualsWithDelta(-118.2438, $centroid['lon'], 0.0001);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoDayMeetsMinimumItemCount(): void
+    {
+        $strategy = new DayAlbumClusterStrategy(timezone: 'UTC', minItems: 3);
+
+        $mediaItems = [
+            $this->createMedia(201, '2022-08-01 09:00:00', 52.5, 13.4),
+            $this->createMedia(202, '2022-08-01 10:00:00', 52.5002, 13.4002),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/day-album-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/DeviceSimilarityStrategyTest.php
+++ b/test/Unit/Clusterer/DeviceSimilarityStrategyTest.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\DeviceSimilarityStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DeviceSimilarityStrategyTest extends TestCase
+{
+    #[Test]
+    public function groupsMediaByDeviceDateAndLocation(): void
+    {
+        $strategy = new DeviceSimilarityStrategy(new LocationHelper(), minItems: 3);
+
+        $berlin = $this->createLocation(
+            providerPlaceId: 'berlin-001',
+            displayName: 'Berlin',
+            lat: 52.5200,
+            lon: 13.4050,
+            city: 'Berlin',
+            country: 'Germany',
+        );
+
+        $mediaItems = [
+            $this->createMedia(301, '2023-05-01 09:00:00', 'Canon EOS R5', $berlin, 52.5200, 13.4050),
+            $this->createMedia(302, '2023-05-01 10:30:00', 'Canon EOS R5', $berlin, 52.5203, 13.4052),
+            $this->createMedia(303, '2023-05-01 11:45:00', 'Canon EOS R5', $berlin, 52.5205, 13.4054),
+            // Different day, should not form a cluster because below minItems
+            $this->createMedia(304, '2023-05-02 09:15:00', 'Canon EOS R5', $berlin, 52.5206, 13.4056),
+            $this->createMedia(305, '2023-05-02 12:00:00', 'Canon EOS R5', $berlin, 52.5207, 13.4057),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('device_similarity', $cluster->getAlgorithm());
+        self::assertSame([301, 302, 303], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame('Canon EOS R5', $params['device']);
+        self::assertSame('Berlin', $params['place']);
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2023-05-01 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-05-01 11:45:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(52.5202666667, $centroid['lat'], 0.0001);
+        self::assertEqualsWithDelta(13.4052, $centroid['lon'], 0.0001);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenGroupsDoNotReachMinimum(): void
+    {
+        $strategy = new DeviceSimilarityStrategy(new LocationHelper(), minItems: 4);
+
+        $location = $this->createLocation(
+            providerPlaceId: 'munich-001',
+            displayName: 'Munich',
+            lat: 48.1371,
+            lon: 11.5753,
+            city: 'Munich',
+            country: 'Germany',
+        );
+
+        $mediaItems = [
+            $this->createMedia(401, '2023-06-10 08:00:00', 'iPhone 14 Pro', $location, 48.1371, 11.5753),
+            $this->createMedia(402, '2023-06-10 08:05:00', 'iPhone 14 Pro', $location, 48.1372, 11.5754),
+            $this->createMedia(403, '2023-06-10 08:10:00', 'iPhone 14 Pro', $location, 48.1373, 11.5755),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(
+        int $id,
+        string $takenAt,
+        ?string $camera,
+        Location $location,
+        float $lat,
+        float $lon,
+    ): Media {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/device-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setCameraModel($camera);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+        $media->setLocation($location);
+
+        return $media;
+    }
+
+    private function createLocation(
+        string $providerPlaceId,
+        string $displayName,
+        float $lat,
+        float $lon,
+        ?string $city = null,
+        ?string $country = null,
+    ): Location {
+        $location = new Location(
+            provider: 'osm',
+            providerPlaceId: $providerPlaceId,
+            displayName: $displayName,
+            lat: $lat,
+            lon: $lon,
+            cell: 'cell-' . $providerPlaceId,
+        );
+
+        $location->setCity($city);
+        $location->setCountry($country);
+
+        return $location;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/DiningOutClusterStrategyTest.php
+++ b/test/Unit/Clusterer/DiningOutClusterStrategyTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\DiningOutClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DiningOutClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersEveningDiningSessionsWithKeywords(): void
+    {
+        $strategy = new DiningOutClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 2 * 3600,
+            radiusMeters: 200.0,
+            minItems: 4,
+            minHour: 17,
+            maxHour: 23,
+        );
+
+        $start = new DateTimeImmutable('2024-02-10 17:30:00', new DateTimeZone('UTC'));
+        $media = [];
+        $keywords = ['restaurant', 'dinner', 'wine', 'tapas'];
+        foreach ($keywords as $index => $keyword) {
+            $media[] = $this->createMedia(
+                820 + $index,
+                $start->add(new DateInterval('PT' . ($index * 25) . 'M')),
+                40.7128 + ($index * 0.0002),
+                -74.0060 + ($index * 0.0002),
+                __DIR__ . "/fixtures/{$keyword}-shot.jpg",
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('dining_out', $cluster->getAlgorithm());
+        self::assertSame(range(820, 823), $cluster->getMembers());
+    }
+
+    #[Test]
+    public function splitsSessionsWhenGapExceedsThreshold(): void
+    {
+        $strategy = new DiningOutClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 1800,
+            radiusMeters: 250.0,
+            minItems: 3,
+            minHour: 16,
+            maxHour: 22,
+        );
+
+        $start = new DateTimeImmutable('2024-02-11 18:00:00', new DateTimeZone('UTC'));
+        $media = [
+            $this->createMedia(900, $start, 34.0522, -118.2437, __DIR__ . '/fixtures/restaurant-appetizer.jpg'),
+            $this->createMedia(901, $start->add(new DateInterval('PT20M')), 34.0523, -118.2436, __DIR__ . '/fixtures/restaurant-main.jpg'),
+            $this->createMedia(902, $start->add(new DateInterval('PT40M')), 34.0524, -118.2435, __DIR__ . '/fixtures/restaurant-dessert.jpg'),
+            $this->createMedia(903, $start->add(new DateInterval('PT120M')), 34.0525, -118.2434, __DIR__ . '/fixtures/restaurant-nightcap.jpg'),
+        ];
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        self::assertSame([900, 901, 902], $clusters[0]->getMembers());
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon, string $path): Media
+    {
+        $media = new Media(
+            path: $path,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/FestivalSummerClusterStrategyTest.php
+++ b/test/Unit/Clusterer/FestivalSummerClusterStrategyTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\FestivalSummerClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FestivalSummerClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersSummerFestivalSessions(): void
+    {
+        $strategy = new FestivalSummerClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 1800,
+            radiusMeters: 500.0,
+            minItems: 8,
+            startMonth: 6,
+            endMonth: 9,
+            afternoonStartHour: 14,
+            lateNightCutoffHour: 2,
+        );
+
+        $start = new DateTimeImmutable('2023-07-15 14:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 8; $i++) {
+            $media[] = $this->createMedia(
+                800 + $i,
+                $start->modify('+' . ($i * 15) . ' minutes'),
+                "open-air-stage-{$i}.jpg",
+                50.0 + $i * 0.0003,
+                8.0 + $i * 0.0003,
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('festival_summer', $clusters[0]->getAlgorithm());
+        self::assertSame(range(800, 807), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function ignoresEventsOutsideSeason(): void
+    {
+        $strategy = new FestivalSummerClusterStrategy();
+
+        $items = [];
+        for ($i = 0; $i < 8; $i++) {
+            $items[] = $this->createMedia(
+                900 + $i,
+                new DateTimeImmutable('2023-11-01 18:00:00', new DateTimeZone('UTC')),
+                "open-air-stage-{$i}.jpg",
+                50.0,
+                8.0,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $filename, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $filename,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 4096,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/FirstVisitPlaceClusterStrategyTest.php
+++ b/test/Unit/Clusterer/FirstVisitPlaceClusterStrategyTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\FirstVisitPlaceClusterStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FirstVisitPlaceClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function picksEarliestEligibleVisitPerCell(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new FirstVisitPlaceClusterStrategy(
+            locHelper: $helper,
+            gridDegrees: 0.01,
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 4,
+            minNights: 1,
+            maxNights: 2,
+            minItemsTotal: 8,
+        );
+
+        $loc = $this->createLocation('loc-innsbruck', 'Innsbruck', 47.268, 11.392);
+        $start = new DateTimeImmutable('2024-02-10 09:00:00');
+        $items = [];
+
+        for ($dayOffset = 0; $dayOffset < 2; $dayOffset++) {
+            $day = $start->add(new DateInterval('P' . $dayOffset . 'D'));
+            for ($i = 0; $i < 4; $i++) {
+                $items[] = $this->createMedia(
+                    1200 + ($dayOffset * 10) + $i,
+                    $day->add(new DateInterval('PT' . ($i * 900) . 'S')),
+                    47.268 + $i * 0.0005,
+                    11.392 + $i * 0.0005,
+                    $loc,
+                );
+            }
+        }
+
+        // Later revisit in same cell should be ignored
+        $later = new DateTimeImmutable('2024-03-05 10:00:00');
+        for ($i = 0; $i < 4; $i++) {
+            $items[] = $this->createMedia(
+                1300 + $i,
+                $later->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                47.269 + $i * 0.0004,
+                11.393 + $i * 0.0004,
+                $loc,
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('first_visit_place', $cluster->getAlgorithm());
+        self::assertSame('Innsbruck', $cluster->getParams()['place']);
+        self::assertSame(
+            [1200, 1201, 1202, 1203, 1210, 1211, 1212, 1213],
+            $cluster->getMembers()
+        );
+    }
+
+    #[Test]
+    public function enforcesMinimumItemsPerDay(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new FirstVisitPlaceClusterStrategy(
+            locHelper: $helper,
+            gridDegrees: 0.01,
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 4,
+            minNights: 1,
+            maxNights: 2,
+            minItemsTotal: 8,
+        );
+
+        $loc = $this->createLocation('loc-bolzano', 'Bolzano', 46.5, 11.35);
+        $start = new DateTimeImmutable('2024-04-01 09:00:00');
+        $items = [];
+        for ($dayOffset = 0; $dayOffset < 2; $dayOffset++) {
+            $day = $start->add(new DateInterval('P' . $dayOffset . 'D'));
+            for ($i = 0; $i < 3; $i++) { // below per-day threshold
+                $items[] = $this->createMedia(
+                    1400 + ($dayOffset * 10) + $i,
+                    $day->add(new DateInterval('PT' . ($i * 1200) . 'S')),
+                    46.5 + $i * 0.0006,
+                    11.35 + $i * 0.0006,
+                    $loc,
+                );
+            }
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createLocation(string $id, string $city, float $lat, float $lon): Location
+    {
+        $location = new Location('osm', $id, $city, $lat, $lon, 'cell-' . $id);
+        $location->setCity($city);
+        $location->setCountry('Austria');
+
+        return $location;
+    }
+
+    private function createMedia(
+        int $id,
+        DateTimeImmutable $takenAt,
+        float $lat,
+        float $lon,
+        Location $location
+    ): Media {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/first-visit-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+        $media->setLocation($location);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/GoldenHourClusterStrategyTest.php
+++ b/test/Unit/Clusterer/GoldenHourClusterStrategyTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\GoldenHourClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class GoldenHourClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersGoldenHourSequence(): void
+    {
+        $strategy = new GoldenHourClusterStrategy(
+            timezone: 'Europe/Berlin',
+            morningHours: [6, 7, 8],
+            eveningHours: [18, 19, 20],
+            sessionGapSeconds: 1200,
+            minItems: 5,
+        );
+
+        $base = new DateTimeImmutable('2024-08-10 18:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createMedia(
+                2700 + $i,
+                $base->add(new DateInterval('PT' . ($i * 600) . 'S')),
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('golden_hour', $clusters[0]->getAlgorithm());
+        self::assertSame(range(2700, 2704), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function ignoresPhotosOutsideGoldenHours(): void
+    {
+        $strategy = new GoldenHourClusterStrategy();
+
+        $base = new DateTimeImmutable('2024-08-10 13:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createMedia(
+                2800 + $i,
+                $base->add(new DateInterval('PT' . ($i * 600) . 'S')),
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/golden-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(48.5);
+        $media->setGpsLon(9.0);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/HikeAdventureClusterStrategyTest.php
+++ b/test/Unit/Clusterer/HikeAdventureClusterStrategyTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\HikeAdventureClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class HikeAdventureClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersHikeWhenDistanceMet(): void
+    {
+        $strategy = new HikeAdventureClusterStrategy(
+            sessionGapSeconds: 1800,
+            minDistanceKm: 5.0,
+            minItems: 6,
+            minItemsNoGps: 10,
+        );
+
+        $start = new DateTimeImmutable('2023-09-10 08:00:00');
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(
+                3100 + $i,
+                $start->add(new DateInterval('PT' . ($i * 900) . 'S')),
+                47.0 + $i * 0.05,
+                10.0 + $i * 0.05,
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('hike_adventure', $clusters[0]->getAlgorithm());
+        self::assertSame(range(3100, 3105), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function requiresSufficientGpsDistance(): void
+    {
+        $strategy = new HikeAdventureClusterStrategy(
+            sessionGapSeconds: 1800,
+            minDistanceKm: 8.0,
+            minItems: 6,
+            minItemsNoGps: 10,
+        );
+
+        $start = new DateTimeImmutable('2023-09-11 08:00:00');
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(
+                3200 + $i,
+                $start->add(new DateInterval('PT' . ($i * 900) . 'S')),
+                47.0 + $i * 0.005,
+                10.0 + $i * 0.005,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/wanderung-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/HolidayEventClusterStrategyTest.php
+++ b/test/Unit/Clusterer/HolidayEventClusterStrategyTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\HolidayEventClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class HolidayEventClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function groupsItemsByHolidayPerYear(): void
+    {
+        $strategy = new HolidayEventClusterStrategy(minItems: 3);
+
+        $mediaItems = [
+            $this->createMedia(1, '2023-12-25 09:00:00', 52.5, 13.4),
+            $this->createMedia(2, '2023-12-25 10:00:00', 52.5005, 13.401),
+            $this->createMedia(3, '2023-12-25 12:00:00', 52.499, 13.402),
+            $this->createMedia(4, '2024-12-25 09:30:00', 48.1, 11.6),
+            $this->createMedia(5, '2024-12-25 10:30:00', 48.1005, 11.6005),
+            $this->createMedia(6, '2024-12-25 11:00:00', 48.1009, 11.6010),
+            $this->createMedia(7, '2023-05-01 09:15:00', 49.0, 12.0),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(2, $clusters);
+
+        $first = $clusters[0];
+        self::assertSame('holiday_event', $first->getAlgorithm());
+        self::assertSame(2023, $first->getParams()['year']);
+        self::assertSame('1. Weihnachtstag', $first->getParams()['holiday_name']);
+        self::assertSame([1, 2, 3], $first->getMembers());
+
+        $second = $clusters[1];
+        self::assertSame(2024, $second->getParams()['year']);
+        self::assertSame([4, 5, 6], $second->getMembers());
+    }
+
+    #[Test]
+    public function filtersGroupsBelowMinimumCount(): void
+    {
+        $strategy = new HolidayEventClusterStrategy(minItems: 4);
+
+        $mediaItems = [
+            $this->createMedia(11, '2023-10-03 08:00:00', 52.0, 13.0),
+            $this->createMedia(12, '2023-10-03 09:30:00', 52.0005, 13.0005),
+            $this->createMedia(13, '2023-10-03 11:00:00', 52.0010, 13.0010),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/holiday-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/KeywordBestDayOverYearsStrategyTest.php
+++ b/test/Unit/Clusterer/KeywordBestDayOverYearsStrategyTest.php
@@ -1,0 +1,187 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\Support\KeywordBestDayOverYearsStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class KeywordBestDayOverYearsStrategyTest extends TestCase
+{
+    #[Test]
+    public function picksStrongestKeywordDayPerYear(): void
+    {
+        $strategy = $this->createStrategy(
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 4,
+            minYears: 2,
+            minItemsTotal: 10,
+            keywords: ['museum'],
+        );
+
+        $items = [];
+
+        // 2021 has two keyword days; only the six-item day should be kept.
+        $day2021Primary = new DateTimeImmutable('2021-04-15 10:00:00');
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(
+                id: 202100 + $i,
+                takenAt: $day2021Primary->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                pathSuffix: sprintf('museum-2021-primary-%d.jpg', $i),
+                lat: 52.5 + $i * 0.01,
+                lon: 13.4 + $i * 0.01,
+            );
+        }
+
+        $day2021Secondary = new DateTimeImmutable('2021-05-20 12:00:00');
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createMedia(
+                id: 202110 + $i,
+                takenAt: $day2021Secondary->add(new DateInterval('PT' . ($i * 300) . 'S')),
+                pathSuffix: sprintf('museum-2021-secondary-%d.jpg', $i),
+                lat: 52.0,
+                lon: 13.0,
+            );
+        }
+
+        // 2022 provides another eligible day.
+        $day2022 = new DateTimeImmutable('2022-03-08 09:30:00');
+        for ($i = 0; $i < 4; $i++) {
+            $items[] = $this->createMedia(
+                id: 202200 + $i,
+                takenAt: $day2022->add(new DateInterval('PT' . ($i * 420) . 'S')),
+                pathSuffix: sprintf('museum-2022-%d.jpg', $i),
+                lat: 53.0,
+                lon: 13.2 + $i * 0.01,
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('keyword_best_day_over_years_test', $cluster->getAlgorithm());
+        self::assertSame([2021, 2022], $cluster->getParams()['years']);
+        self::assertCount(10, $cluster->getMembers());
+    }
+
+    #[Test]
+    public function enforcesThresholdsBeforeBuildingCluster(): void
+    {
+        $strategy = $this->createStrategy(
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 3,
+            minYears: 2,
+            minItemsTotal: 6,
+            keywords: ['museum'],
+        );
+
+        $items = [];
+
+        $eligibleDay = new DateTimeImmutable('2020-02-10 13:00:00');
+        for ($i = 0; $i < 3; $i++) {
+            $items[] = $this->createMedia(
+                id: 202000 + $i,
+                takenAt: $eligibleDay->add(new DateInterval('PT' . ($i * 900) . 'S')),
+                pathSuffix: sprintf('museum-2020-%d.jpg', $i),
+                lat: 48.0,
+                lon: 11.0,
+            );
+        }
+
+        // 2021 does not reach the minItemsPerDay threshold (only two keyword hits).
+        $underfilledDay = new DateTimeImmutable('2021-04-02 14:00:00');
+        for ($i = 0; $i < 2; $i++) {
+            $items[] = $this->createMedia(
+                id: 202100 + $i,
+                takenAt: $underfilledDay->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                pathSuffix: sprintf('museum-2021-%d.jpg', $i),
+                lat: 48.2,
+                lon: 11.2,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    #[Test]
+    public function groupsByLocalDayBasedOnTimezone(): void
+    {
+        $strategy = $this->createStrategy(
+            timezone: 'America/Los_Angeles',
+            minItemsPerDay: 2,
+            minYears: 1,
+            minItemsTotal: 2,
+            keywords: ['museum'],
+        );
+
+        $items = [
+            $this->createMedia(
+                id: 3001,
+                takenAt: new DateTimeImmutable('2022-05-02T06:30:00+00:00'),
+                pathSuffix: 'museum-west-coast-1.jpg',
+                lat: 34.05,
+                lon: -118.25,
+            ),
+            $this->createMedia(
+                id: 3002,
+                takenAt: new DateTimeImmutable('2022-05-01T18:45:00+00:00'),
+                pathSuffix: 'museum-west-coast-2.jpg',
+                lat: 34.06,
+                lon: -118.24,
+            ),
+        ];
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        $params = $cluster->getParams();
+
+        self::assertSame([2022], $params['years']);
+        self::assertSame($items[1]->getTakenAt()?->getTimestamp(), $params['time_range']['from']);
+        self::assertSame($items[0]->getTakenAt()?->getTimestamp(), $params['time_range']['to']);
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function createStrategy(string $timezone, int $minItemsPerDay, int $minYears, int $minItemsTotal, array $keywords): KeywordBestDayOverYearsStrategy
+    {
+        return new class($timezone, $minItemsPerDay, $minYears, $minItemsTotal, $keywords) extends KeywordBestDayOverYearsStrategy {
+            public function name(): string
+            {
+                return 'keyword_best_day_over_years_test';
+            }
+        };
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $pathSuffix, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $pathSuffix,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/KidsBirthdayPartyClusterStrategyTest.php
+++ b/test/Unit/Clusterer/KidsBirthdayPartyClusterStrategyTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\KidsBirthdayPartyClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class KidsBirthdayPartyClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function detectsKeywordDrivenBirthdaySessionsWithinTimeWindow(): void
+    {
+        $strategy = new KidsBirthdayPartyClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 3 * 3600,
+            radiusMeters: 300.0,
+            minItems: 6,
+            minHour: 9,
+            maxHour: 21,
+        );
+
+        $start = new DateTimeImmutable('2024-05-04 10:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 6; $i++) {
+            $media[] = $this->createMedia(
+                400 + $i,
+                $start->add(new DateInterval('PT' . ($i * 20) . 'M')),
+                48.137 + ($i * 0.0003),
+                11.575 + ($i * 0.0003),
+                __DIR__ . "/fixtures/birthday-party-$i-cake.jpg",
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('kids_birthday_party', $cluster->getAlgorithm());
+        self::assertSame(range(400, 405), $cluster->getMembers());
+
+        $timeRange = $cluster->getParams()['time_range'];
+        self::assertSame($media[0]->getTakenAt()?->getTimestamp(), $timeRange['from']);
+        self::assertSame($media[5]->getTakenAt()?->getTimestamp(), $timeRange['to']);
+    }
+
+    #[Test]
+    public function rejectsSessionsMissingBirthdaySignals(): void
+    {
+        $strategy = new KidsBirthdayPartyClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 3 * 3600,
+            radiusMeters: 300.0,
+            minItems: 5,
+            minHour: 10,
+            maxHour: 20,
+        );
+
+        $start = new DateTimeImmutable('2024-05-04 11:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 5; $i++) {
+            $media[] = $this->createMedia(
+                500 + $i,
+                $start->add(new DateInterval('PT' . ($i * 15) . 'M')),
+                48.20 + ($i * 0.0004),
+                11.60 + ($i * 0.0004),
+                __DIR__ . "/fixtures/playdate-$i.jpg",
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($media));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon, string $path): Media
+    {
+        $media = new Media(
+            path: $path,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/LocationSimilarityStrategyTest.php
+++ b/test/Unit/Clusterer/LocationSimilarityStrategyTest.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\LocationSimilarityStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LocationSimilarityStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersMediaByLocalityWithPoiMetadata(): void
+    {
+        $strategy = new LocationSimilarityStrategy(
+            locHelper: new LocationHelper(),
+            radiusMeters: 200.0,
+            minItems: 3,
+            maxSpanHours: 12,
+        );
+
+        $museum = $this->createLocation(
+            providerPlaceId: 'berlin-museum',
+            displayName: 'Neues Museum',
+            lat: 52.5200,
+            lon: 13.4050,
+            city: 'Berlin',
+            country: 'Germany',
+            suburb: 'Mitte',
+        );
+        $museum->setPois([
+            [
+                'name'          => 'Museum Island',
+                'categoryKey'   => 'tourism',
+                'categoryValue' => 'museum',
+                'tags'          => ['wikidata' => 'Q1234'],
+            ],
+        ]);
+
+        $mediaItems = [
+            $this->createMedia(801, '2023-04-01 09:00:00', 52.5201, 13.4049, $museum),
+            $this->createMedia(802, '2023-04-01 09:15:00', 52.5202, 13.4050, $museum),
+            $this->createMedia(803, '2023-04-01 09:35:00', 52.5203, 13.4051, $museum),
+            $this->createMedia(804, '2023-04-01 10:05:00', 52.5204, 13.4052, $museum),
+            // Below the locality threshold: different place
+            $this->createMedia(805, '2023-04-01 11:00:00', 48.1371, 11.5753, $this->createLocation(
+                providerPlaceId: 'munich-park',
+                displayName: 'Englischer Garten',
+                lat: 48.1371,
+                lon: 11.5753,
+                city: 'Munich',
+                country: 'Germany',
+            )),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('location_similarity', $cluster->getAlgorithm());
+        self::assertSame([801, 802, 803, 804], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame('suburb:Mitte|city:Berlin|country:Germany', $params['place_key']);
+        self::assertSame('Museum Island', $params['place']);
+        self::assertSame('Museum Island', $params['poi_label']);
+        self::assertSame('tourism', $params['poi_category_key']);
+        self::assertSame('museum', $params['poi_category_value']);
+        self::assertSame(['wikidata' => 'Q1234'], $params['poi_tags']);
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2023-04-01 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-04-01 10:05:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(52.52025, $centroid['lat'], 0.00001);
+        self::assertEqualsWithDelta(13.40505, $centroid['lon'], 0.00001);
+    }
+
+    #[Test]
+    public function fallsBackToSpatialWindowsForItemsWithoutLocality(): void
+    {
+        $strategy = new LocationSimilarityStrategy(
+            locHelper: new LocationHelper(),
+            radiusMeters: 250.0,
+            minItems: 3,
+            maxSpanHours: 1,
+        );
+
+        $mediaItems = [
+            $this->createMedia(901, '2023-05-01 10:00:00', 48.1371, 11.5753, null),
+            $this->createMedia(902, '2023-05-01 10:20:00', 48.1372, 11.5754, null),
+            $this->createMedia(903, '2023-05-01 10:35:00', 48.1373, 11.5755, null),
+            // Outside of the spatial window due to distance
+            $this->createMedia(904, '2023-05-01 10:40:00', 48.1400, 11.5800, null),
+            // Different day bucket
+            $this->createMedia(905, '2023-05-02 09:00:00', 48.2000, 11.6000, null),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('location_similarity', $cluster->getAlgorithm());
+        self::assertSame([901, 902, 903], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2023-05-01 10:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-05-01 10:35:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+        self::assertArrayNotHasKey('place', $params);
+        self::assertArrayNotHasKey('place_key', $params);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(48.1372, $centroid['lat'], 0.00001);
+        self::assertEqualsWithDelta(11.5754, $centroid['lon'], 0.00001);
+    }
+
+    private function createMedia(
+        int $id,
+        string $takenAt,
+        float $lat,
+        float $lon,
+        ?Location $location
+    ): Media {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/location-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+        if ($location !== null) {
+            $media->setLocation($location);
+        }
+
+        return $media;
+    }
+
+    private function createLocation(
+        string $providerPlaceId,
+        string $displayName,
+        float $lat,
+        float $lon,
+        ?string $city = null,
+        ?string $country = null,
+        ?string $suburb = null,
+    ): Location {
+        $location = new Location(
+            provider: 'osm',
+            providerPlaceId: $providerPlaceId,
+            displayName: $displayName,
+            lat: $lat,
+            lon: $lon,
+            cell: 'cell-' . $providerPlaceId,
+        );
+
+        $location->setCity($city);
+        $location->setCountry($country);
+        $location->setSuburb($suburb);
+
+        return $location;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/MonthlyHighlightsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/MonthlyHighlightsClusterStrategyTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\MonthlyHighlightsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MonthlyHighlightsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function emitsClusterPerEligibleMonth(): void
+    {
+        $strategy = new MonthlyHighlightsClusterStrategy(
+            timezone: 'UTC',
+            minItems: 4,
+            minDistinctDays: 3,
+        );
+
+        $mediaItems = [
+            $this->createMedia(1, '2023-03-01 08:00:00'),
+            $this->createMedia(2, '2023-03-02 09:00:00'),
+            $this->createMedia(3, '2023-03-02 10:00:00'),
+            $this->createMedia(4, '2023-03-05 18:00:00'),
+            $this->createMedia(5, '2023-04-01 12:00:00'),
+            $this->createMedia(6, '2023-04-02 12:00:00'),
+            $this->createMedia(7, '2023-04-03 12:00:00'),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('monthly_highlights', $cluster->getAlgorithm());
+        self::assertSame(2023, $cluster->getParams()['year']);
+        self::assertSame(3, $cluster->getParams()['month']);
+        self::assertSame([1, 2, 3, 4], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function enforcesDistinctDayThreshold(): void
+    {
+        $strategy = new MonthlyHighlightsClusterStrategy(
+            timezone: 'UTC',
+            minItems: 4,
+            minDistinctDays: 4,
+        );
+
+        $mediaItems = [
+            $this->createMedia(11, '2023-05-01 08:00:00'),
+            $this->createMedia(12, '2023-05-01 09:00:00'),
+            $this->createMedia(13, '2023-05-02 09:00:00'),
+            $this->createMedia(14, '2023-05-03 09:00:00'),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/monthly-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/MorningCoffeeClusterStrategyTest.php
+++ b/test/Unit/Clusterer/MorningCoffeeClusterStrategyTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\MorningCoffeeClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MorningCoffeeClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersCompactMorningCafeSession(): void
+    {
+        $strategy = new MorningCoffeeClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 900,
+            radiusMeters: 150.0,
+            minItems: 3,
+            minHour: 7,
+            maxHour: 10,
+        );
+
+        $base = new DateTimeImmutable('2023-06-10 07:30:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 3; $i++) {
+            $media[] = $this->createMedia(
+                1500 + $i,
+                $base->modify('+' . ($i * 10) . ' minutes'),
+                "coffee-bar-{$i}.jpg",
+                48.208 + $i * 0.0005,
+                16.372 + $i * 0.0005,
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('morning_coffee', $clusters[0]->getAlgorithm());
+        self::assertSame([1500, 1501, 1502], $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function rejectsEventsOutsideMorningWindow(): void
+    {
+        $strategy = new MorningCoffeeClusterStrategy();
+
+        $items = [];
+        for ($i = 0; $i < 3; $i++) {
+            $items[] = $this->createMedia(
+                1600 + $i,
+                new DateTimeImmutable('2023-06-10 13:00:00', new DateTimeZone('UTC')),
+                "coffee-bar-{$i}.jpg",
+                48.21,
+                16.37,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $filename, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $filename,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 256,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/MuseumOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/MuseumOverYearsClusterStrategyTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\MuseumOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MuseumOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function aggregatesMuseumVisitsAcrossYears(): void
+    {
+        $strategy = new MuseumOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 5,
+            minYears: 3,
+            minItemsTotal: 18,
+        );
+
+        $items = [];
+        foreach ([2019, 2020, 2021] as $year) {
+            $day = new DateTimeImmutable(sprintf('%d-03-10 11:00:00', $year));
+            for ($i = 0; $i < 6; $i++) {
+                $items[] = $this->createMedia(
+                    ($year * 100) + $i,
+                    $day->add(new DateInterval('PT' . ($i * 300) . 'S')),
+                    $year,
+                    $i,
+                );
+            }
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('museum_over_years', $cluster->getAlgorithm());
+        self::assertSame([2019, 2020, 2021], $cluster->getParams()['years']);
+        self::assertCount(18, $cluster->getMembers());
+    }
+
+    #[Test]
+    public function enforcesMinimumYears(): void
+    {
+        $strategy = new MuseumOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 5,
+            minYears: 3,
+            minItemsTotal: 18,
+        );
+
+        $items = [];
+        foreach ([2021, 2022] as $year) {
+            $day = new DateTimeImmutable(sprintf('%d-04-05 12:00:00', $year));
+            for ($i = 0; $i < 6; $i++) {
+                $items[] = $this->createMedia(
+                    ($year * 1000) + $i,
+                    $day->add(new DateInterval('PT' . ($i * 300) . 'S')),
+                    $year,
+                    $i,
+                );
+            }
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, int $year, int $index): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . sprintf('museum-%d-%d.jpg', $year, $index),
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(52.0 + $index * 0.01);
+        $media->setGpsLon(13.0 + $index * 0.01);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/NewYearEveClusterStrategyTest.php
+++ b/test/Unit/Clusterer/NewYearEveClusterStrategyTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\NewYearEveClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NewYearEveClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersNewYearEveWindowPerYear(): void
+    {
+        $strategy = new NewYearEveClusterStrategy(
+            timezone: 'Europe/Berlin',
+            startHour: 20,
+            endHour: 2,
+            minItems: 6,
+        );
+
+        $start = new DateTimeImmutable('2023-12-31 20:00:00', new DateTimeZone('Europe/Berlin'));
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(
+                2100 + $i,
+                $start->add(new DateInterval('PT' . ($i * 30) . 'M')),
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('new_year_eve', $cluster->getAlgorithm());
+        self::assertSame(2023, $cluster->getParams()['year']);
+        self::assertSame(range(2100, 2105), $cluster->getMembers());
+    }
+
+    #[Test]
+    public function ignoresPhotosOutsidePartyWindow(): void
+    {
+        $strategy = new NewYearEveClusterStrategy();
+
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(
+                2200 + $i,
+                new DateTimeImmutable('2023-12-31 15:00:00', new DateTimeZone('UTC')),
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/nye-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(52.5);
+        $media->setGpsLon(13.4);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/NightlifeEventClusterStrategyTest.php
+++ b/test/Unit/Clusterer/NightlifeEventClusterStrategyTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\NightlifeEventClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NightlifeEventClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersNightSessionsWithCompactGpsSpread(): void
+    {
+        $strategy = new NightlifeEventClusterStrategy(
+            timezone: 'Europe/Berlin',
+            timeGapSeconds: 3 * 3600,
+            radiusMeters: 400.0,
+            minItems: 5,
+        );
+
+        $start = new DateTimeImmutable('2024-03-15 20:30:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 5; $i++) {
+            $media[] = $this->createMedia(
+                610 + $i,
+                $start->add(new DateInterval('PT' . ($i * 45) . 'M')),
+                52.5205 + ($i * 0.0002),
+                13.4049 + ($i * 0.0002),
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('nightlife_event', $cluster->getAlgorithm());
+        self::assertSame(range(610, 614), $cluster->getMembers());
+
+        $timeRange = $cluster->getParams()['time_range'];
+        self::assertSame($media[0]->getTakenAt()?->getTimestamp(), $timeRange['from']);
+        self::assertSame($media[4]->getTakenAt()?->getTimestamp(), $timeRange['to']);
+    }
+
+    #[Test]
+    public function rejectsRunsExceedingSpatialRadius(): void
+    {
+        $strategy = new NightlifeEventClusterStrategy(
+            timezone: 'Europe/Berlin',
+            timeGapSeconds: 3 * 3600,
+            radiusMeters: 50.0,
+            minItems: 5,
+        );
+
+        $start = new DateTimeImmutable('2024-03-16 22:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 5; $i++) {
+            $media[] = $this->createMedia(
+                710 + $i,
+                $start->add(new DateInterval('PT' . ($i * 30) . 'M')),
+                52.50 + ($i * 0.01),
+                13.40 + ($i * 0.01),
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($media));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/nightlife-$id.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/OnThisDayOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/OnThisDayOverYearsClusterStrategyTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\OnThisDayOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use const CAL_GREGORIAN;
+
+final class OnThisDayOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function collectsItemsAcrossYearsNearAnchorDay(): void
+    {
+        $strategy = new OnThisDayOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            windowDays: 1,
+            minYears: 3,
+            minItems: 5,
+        );
+
+        $anchor = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
+        $month = (int) $anchor->format('n');
+        $day = (int) $anchor->format('j');
+
+        $mediaItems = [];
+        $id = 1;
+        foreach ([2019, 2020, 2021] as $year) {
+            $mediaItems[] = $this->createMedia($id++, $this->dateString($year, $month, $day, '09:00:00'));
+            $mediaItems[] = $this->createMedia($id++, $this->dateString($year, $month, $day + ($year === 2020 ? 1 : 0), '14:30:00'));
+        }
+        $mediaItems[] = $this->createMedia($id++, $this->dateString(2022, $month, $day + 5, '10:00:00'));
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('on_this_day_over_years', $cluster->getAlgorithm());
+        self::assertSame([1, 2, 3, 4, 5, 6], $cluster->getMembers());
+        self::assertGreaterThanOrEqual(3, \count($cluster->getParams()['years']));
+    }
+
+    #[Test]
+    public function requiresMinimumYearsAndItems(): void
+    {
+        $strategy = new OnThisDayOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            windowDays: 0,
+            minYears: 4,
+            minItems: 5,
+        );
+
+        $anchor = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
+        $month = (int) $anchor->format('n');
+        $day = (int) $anchor->format('j');
+
+        $mediaItems = [
+            $this->createMedia(51, $this->dateString(2019, $month, $day, '09:00:00')),
+            $this->createMedia(52, $this->dateString(2020, $month, $day, '10:00:00')),
+            $this->createMedia(53, $this->dateString(2021, $month, $day, '11:00:00')),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function dateString(int $year, int $month, int $day, string $time): string
+    {
+        $day = max(1, min($day, \cal_days_in_month(CAL_GREGORIAN, $month, $year)));
+
+        return \sprintf('%04d-%02d-%02d %s', $year, $month, $day, $time);
+    }
+
+    private function createMedia(int $id, string $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/on-this-day-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/OneYearAgoClusterStrategyTest.php
+++ b/test/Unit/Clusterer/OneYearAgoClusterStrategyTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\OneYearAgoClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OneYearAgoClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function gathersItemsWithinWindowAroundLastYear(): void
+    {
+        $strategy = new OneYearAgoClusterStrategy(
+            timezone: 'Europe/Berlin',
+            windowDays: 2,
+            minItems: 4,
+        );
+
+        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
+        $anchorBase = $now->sub(new DateInterval('P1Y'));
+
+        $mediaItems = [
+            $this->createMedia(1, $anchorBase->modify('-1 day')),
+            $this->createMedia(2, $anchorBase),
+            $this->createMedia(3, $anchorBase->modify('+1 day')),
+            $this->createMedia(4, $anchorBase->modify('+2 days')),
+            $this->createMedia(5, $anchorBase->modify('+5 days')),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('one_year_ago', $cluster->getAlgorithm());
+        self::assertSame([1, 2, 3, 4], $cluster->getMembers());
+        self::assertArrayHasKey('time_range', $cluster->getParams());
+    }
+
+    #[Test]
+    public function enforcesMinimumItemCount(): void
+    {
+        $strategy = new OneYearAgoClusterStrategy(
+            timezone: 'Europe/Berlin',
+            windowDays: 1,
+            minItems: 3,
+        );
+
+        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
+        $anchorBase = $now->sub(new DateInterval('P1Y'));
+
+        $mediaItems = [
+            $this->createMedia(11, $anchorBase),
+            $this->createMedia(12, $anchorBase->modify('+1 day')),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/one-year-ago-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt->setTimezone(new DateTimeZone('UTC')));
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/PanoramaClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PanoramaClusterStrategyTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\PanoramaClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PanoramaClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersWidePanoramas(): void
+    {
+        $strategy = new PanoramaClusterStrategy(
+            minAspect: 2.4,
+            sessionGapSeconds: 1800,
+            minItems: 3,
+        );
+
+        $start = new DateTimeImmutable('2024-06-01 12:00:00');
+        $items = [];
+        for ($i = 0; $i < 3; $i++) {
+            $items[] = $this->createPanorama(3900 + $i, $start->add(new DateInterval('PT' . ($i * 600) . 'S')));
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('panorama', $clusters[0]->getAlgorithm());
+        self::assertSame([3900, 3901, 3902], $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function ignoresPhotosBelowAspectThreshold(): void
+    {
+        $strategy = new PanoramaClusterStrategy();
+
+        $start = new DateTimeImmutable('2024-06-02 12:00:00');
+        $items = [];
+        for ($i = 0; $i < 3; $i++) {
+            $items[] = $this->createNarrowPhoto(4000 + $i, $start->add(new DateInterval('PT' . ($i * 600) . 'S')));
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createPanorama(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/panorama-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setWidth(5000);
+        $media->setHeight(1000);
+        $media->setGpsLat(45.0);
+        $media->setGpsLon(7.0);
+
+        return $media;
+    }
+
+    private function createNarrowPhoto(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/photo-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setWidth(2000);
+        $media->setHeight(1500);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/PanoramaOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PanoramaOverYearsClusterStrategyTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\PanoramaOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PanoramaOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function aggregatesPanoramasAcrossYears(): void
+    {
+        $strategy = new PanoramaOverYearsClusterStrategy(
+            minAspect: 2.4,
+            perYearMin: 3,
+            minYears: 3,
+            minItemsTotal: 15,
+        );
+
+        $items = [];
+        foreach ([2018, 2019, 2020] as $year) {
+            $day = new DateTimeImmutable(sprintf('%d-09-01 12:00:00', $year));
+            for ($i = 0; $i < 5; $i++) {
+                $items[] = $this->createPanorama(
+                    ($year * 100) + $i,
+                    $day->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                );
+            }
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('panorama_over_years', $cluster->getAlgorithm());
+        self::assertSame([2018, 2019, 2020], $cluster->getParams()['years']);
+        self::assertCount(15, $cluster->getMembers());
+    }
+
+    #[Test]
+    public function enforcesMinimumYearCoverage(): void
+    {
+        $strategy = new PanoramaOverYearsClusterStrategy();
+
+        $items = [];
+        foreach ([2021, 2022] as $year) {
+            $day = new DateTimeImmutable(sprintf('%d-09-01 12:00:00', $year));
+            for ($i = 0; $i < 5; $i++) {
+                $items[] = $this->createPanorama(
+                    ($year * 1000) + $i,
+                    $day->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                );
+            }
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createPanorama(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/pano-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setWidth(4800);
+        $media->setHeight(1800);
+        $media->setGpsLat(46.0);
+        $media->setGpsLon(11.0);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/PersonCohortClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PersonCohortClusterStrategyTest.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\PersonCohortClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PersonCohortClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersStablePersonGroupWithinWindow(): void
+    {
+        $strategy = new PersonCohortClusterStrategy(
+            minPersons: 2,
+            minItems: 5,
+            windowDays: 7,
+        );
+
+        $start = new DateTimeImmutable('2024-01-05 12:00:00');
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createPersonMedia(
+                1700 + $i,
+                $start->add(new DateInterval('P' . $i . 'D')),
+                [1, 2, 3],
+            );
+        }
+
+        // noise with different cohort should be ignored
+        $items[] = $this->createPersonMedia(1800, $start, [1]);
+        $items[] = $this->createPersonMedia(1801, $start, [4, 5]);
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('people_cohort', $cluster->getAlgorithm());
+        self::assertSame([1700, 1701, 1702, 1703, 1704], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function requiresMinimumPersons(): void
+    {
+        $strategy = new PersonCohortClusterStrategy(
+            minPersons: 3,
+            minItems: 5,
+            windowDays: 7,
+        );
+
+        $start = new DateTimeImmutable('2024-02-01 10:00:00');
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createPersonMedia(
+                1900 + $i,
+                $start->add(new DateInterval('P' . $i . 'D')),
+                [1, 2],
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createPersonMedia(int $id, DateTimeImmutable $takenAt, array $persons): Media
+    {
+        $media = new PersonTagMedia(
+            path: __DIR__ . "/fixtures/cohort-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+            personIds: $persons,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(52.5);
+        $media->setGpsLon(13.4);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}
+
+final class PersonTagMedia extends Media
+{
+    /** @var list<int> */
+    private array $personIds;
+
+    /**
+     * @param list<int> $personIds
+     */
+    public function __construct(string $path, string $checksum, int $size, array $personIds)
+    {
+        parent::__construct($path, $checksum, $size);
+        $this->personIds = $personIds;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getPersonIds(): array
+    {
+        return $this->personIds;
+    }
+}

--- a/test/Unit/Clusterer/PetMomentsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PetMomentsClusterStrategyTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\PetMomentsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PetMomentsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersPetPhotosWithinSession(): void
+    {
+        $strategy = new PetMomentsClusterStrategy(
+            sessionGapSeconds: 1200,
+            minItems: 6,
+        );
+
+        $start = new DateTimeImmutable('2024-01-20 15:00:00');
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(
+                3500 + $i,
+                $start->add(new DateInterval('PT' . ($i * 600) . 'S')),
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('pet_moments', $clusters[0]->getAlgorithm());
+        self::assertSame(range(3500, 3505), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function enforcesMinimumItemCount(): void
+    {
+        $strategy = new PetMomentsClusterStrategy();
+
+        $start = new DateTimeImmutable('2024-01-21 15:00:00');
+        $items = [];
+        for ($i = 0; $i < 4; $i++) {
+            $items[] = $this->createMedia(
+                3600 + $i,
+                $start->add(new DateInterval('PT' . ($i * 600) . 'S')),
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/dog-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(52.5);
+        $media->setGpsLon(13.4);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/PhashSimilarityStrategyTest.php
+++ b/test/Unit/Clusterer/PhashSimilarityStrategyTest.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\PhashSimilarityStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PhashSimilarityStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersNearDuplicateMediaByPhash(): void
+    {
+        $strategy = new PhashSimilarityStrategy(
+            locHelper: new LocationHelper(),
+            maxHamming: 6,
+            minItems: 3,
+        );
+
+        $location = $this->createLocation(
+            providerPlaceId: 'berlin-phash',
+            displayName: 'Museum Island',
+            lat: 52.5200,
+            lon: 13.4050,
+            city: 'Berlin',
+            country: 'Germany',
+        );
+
+        $mediaItems = [
+            $this->createMedia(1501, '2023-09-01 10:00:00', 52.5200, 13.4050, 'abcd0123456789ef', $location),
+            $this->createMedia(1502, '2023-09-01 10:01:00', 52.5201, 13.4051, 'abcd0123456789ee', $location),
+            $this->createMedia(1503, '2023-09-01 10:02:00', 52.5199, 13.4049, 'abcd0123456788ef', $location),
+            $this->createMedia(1504, '2023-09-01 10:03:00', 52.5202, 13.4052, 'abcd0123456689ef', $location),
+            // Different prefix -> separate bucket
+            $this->createMedia(1601, '2023-09-01 11:00:00', 48.1371, 11.5753, 'ffff999988887777', $location),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('phash_similarity', $cluster->getAlgorithm());
+        self::assertSame([1501, 1502, 1503, 1504], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame('Berlin', $params['place']);
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2023-09-01 10:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-09-01 10:03:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(52.52005, $centroid['lat'], 0.00001);
+        self::assertEqualsWithDelta(13.40505, $centroid['lon'], 0.00001);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenHashesAreTooDissimilar(): void
+    {
+        $strategy = new PhashSimilarityStrategy(
+            locHelper: new LocationHelper(),
+            maxHamming: 2,
+            minItems: 2,
+        );
+
+        $location = $this->createLocation(
+            providerPlaceId: 'munich-phash',
+            displayName: 'Marienplatz',
+            lat: 48.1371,
+            lon: 11.5753,
+            city: 'Munich',
+            country: 'Germany',
+        );
+
+        $mediaItems = [
+            $this->createMedia(1701, '2023-10-05 09:00:00', 48.1371, 11.5753, 'abcd000000000000', $location),
+            $this->createMedia(1702, '2023-10-05 09:01:00', 48.1372, 11.5754, 'abcdffffffffffff', $location),
+            $this->createMedia(1703, '2023-10-05 09:02:00', 48.1373, 11.5755, 'abcd111111111111', $location),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(
+        int $id,
+        string $takenAt,
+        float $lat,
+        float $lon,
+        string $phash,
+        Location $location
+    ): Media {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/phash-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+        $media->setPhash($phash);
+        $media->setLocation($location);
+
+        return $media;
+    }
+
+    private function createLocation(
+        string $providerPlaceId,
+        string $displayName,
+        float $lat,
+        float $lon,
+        ?string $city = null,
+        ?string $country = null
+    ): Location {
+        $location = new Location(
+            provider: 'osm',
+            providerPlaceId: $providerPlaceId,
+            displayName: $displayName,
+            lat: $lat,
+            lon: $lon,
+            cell: 'cell-' . $providerPlaceId,
+        );
+
+        $location->setCity($city);
+        $location->setCountry($country);
+
+        return $location;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/PhotoMotifClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PhotoMotifClusterStrategyTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\PhotoMotifClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PhotoMotifClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function groupsPhotosByDetectedMotifAndSession(): void
+    {
+        $strategy = new PhotoMotifClusterStrategy(
+            sessionGapSeconds: 36 * 3600,
+            minItems: 6,
+        );
+
+        $start = new DateTimeImmutable('2023-09-01 08:00:00');
+        $mediaItems = [];
+        for ($i = 0; $i < 6; $i++) {
+            $mediaItems[] = $this->createMedia(
+                300 + $i,
+                $start->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                "wander-berge-{$i}.jpg",
+                47.5 + $i * 0.001,
+                11.3 + $i * 0.001,
+            );
+        }
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('photo_motif', $cluster->getAlgorithm());
+        self::assertSame('Berge', $cluster->getParams()['label']);
+        self::assertSame('mountains', $cluster->getParams()['motif']);
+        self::assertSame([300, 301, 302, 303, 304, 305], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function ignoresMotifsBelowThreshold(): void
+    {
+        $strategy = new PhotoMotifClusterStrategy(
+            sessionGapSeconds: 36 * 3600,
+            minItems: 6,
+        );
+
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createMedia(
+                400 + $i,
+                new DateTimeImmutable('2023-07-10 09:00:00'),
+                "beach-day-{$i}.jpg",
+                36.0,
+                -5.0,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $filename, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $filename,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 512,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/PortraitOrientationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PortraitOrientationClusterStrategyTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\PortraitOrientationClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PortraitOrientationClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersPortraitSessions(): void
+    {
+        $strategy = new PortraitOrientationClusterStrategy(
+            minPortraitRatio: 1.2,
+            sessionGapSeconds: 900,
+            minItems: 4,
+        );
+
+        $start = new DateTimeImmutable('2024-04-10 10:00:00');
+        $items = [];
+        for ($i = 0; $i < 4; $i++) {
+            $media = $this->createPortraitMedia(3700 + $i, $start->add(new DateInterval('PT' . ($i * 600) . 'S')));
+            $items[] = $media;
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('portrait_orientation', $cluster->getAlgorithm());
+        self::assertSame([3700, 3701, 3702, 3703], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function skipsLandscapePhotos(): void
+    {
+        $strategy = new PortraitOrientationClusterStrategy();
+
+        $start = new DateTimeImmutable('2024-04-11 10:00:00');
+        $items = [];
+        for ($i = 0; $i < 4; $i++) {
+            $media = $this->createLandscapeMedia(3800 + $i, $start->add(new DateInterval('PT' . ($i * 600) . 'S')));
+            $items[] = $media;
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createPortraitMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/portrait-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setWidth(1000);
+        $media->setHeight(1500);
+        $media->setGpsLat(48.0);
+        $media->setGpsLon(11.0);
+
+        return $media;
+    }
+
+    private function createLandscapeMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/landscape-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setWidth(1600);
+        $media->setHeight(900);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/RainyDayClusterStrategyTest.php
+++ b/test/Unit/Clusterer/RainyDayClusterStrategyTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\RainyDayClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RainyDayClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersDayWithHighRainProbability(): void
+    {
+        $provider = new RainHintProvider([
+            2900 => ['rain_prob' => 0.7],
+            2901 => ['rain_prob' => 0.8],
+            2902 => ['rain_prob' => 0.75],
+            2903 => ['rain_prob' => 0.72],
+            2904 => ['rain_prob' => 0.78],
+            2905 => ['rain_prob' => 0.74],
+        ]);
+        $strategy = new RainyDayClusterStrategy(
+            weather: $provider,
+            timezone: 'Europe/Berlin',
+            minAvgRainProb: 0.6,
+            minItemsPerDay: 6,
+        );
+
+        $base = new DateTimeImmutable('2024-10-01 09:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(2900 + $i, $base->add(new DateInterval('PT' . ($i * 900) . 'S')));
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('rainy_day', $clusters[0]->getAlgorithm());
+        self::assertSame(range(2900, 2905), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function skipsDryDays(): void
+    {
+        $provider = new RainHintProvider([
+            3000 => ['rain_prob' => 0.2],
+            3001 => ['rain_prob' => 0.1],
+            3002 => ['rain_prob' => 0.3],
+            3003 => ['rain_prob' => 0.25],
+            3004 => ['rain_prob' => 0.2],
+            3005 => ['rain_prob' => 0.3],
+        ]);
+        $strategy = new RainyDayClusterStrategy(weather: $provider);
+
+        $base = new DateTimeImmutable('2024-10-02 09:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(3000 + $i, $base->add(new DateInterval('PT' . ($i * 900) . 'S')));
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/rainy-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(47.5);
+        $media->setGpsLon(7.6);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}
+
+final class RainHintProvider implements WeatherHintProviderInterface
+{
+    /** @var array<int,array<string,float>> */
+    private array $hints;
+
+    /**
+     * @param array<int,array<string,float>> $hints
+     */
+    public function __construct(array $hints)
+    {
+        $this->hints = $hints;
+    }
+
+    public function getHint(Media $media): ?array
+    {
+        return $this->hints[$media->getId()] ?? null;
+    }
+}

--- a/test/Unit/Clusterer/RoadTripClusterStrategyTest.php
+++ b/test/Unit/Clusterer/RoadTripClusterStrategyTest.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\RoadTripClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RoadTripClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersConsecutiveTravelDaysAboveDistanceThreshold(): void
+    {
+        $strategy = new RoadTripClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minDailyKm: 80.0,
+            minGpsSamplesPerDay: 3,
+            minNights: 2,
+            minItemsTotal: 12,
+        );
+
+        $start = new DateTimeImmutable('2023-07-01 08:00:00', new DateTimeZone('UTC'));
+        $media = [];
+
+        $days = [
+            ['lat' => 52.5200, 'lon' => 13.4050], // Berlin
+            ['lat' => 51.1657, 'lon' => 14.9885], // Bautzen area
+            ['lat' => 50.1109, 'lon' => 8.6821],  // Frankfurt
+        ];
+
+        $id = 1000;
+        foreach ($days as $index => $coords) {
+            $dayStart = $start->add(new DateInterval('P' . $index . 'D'));
+            $media = [...$media, ...$this->createDailyTrack($id, $dayStart, $coords['lat'], $coords['lon'])];
+            $id += 4;
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('road_trip', $cluster->getAlgorithm());
+        self::assertCount(12, $cluster->getMembers());
+        self::assertSame(2, $cluster->getParams()['nights']);
+
+        $timeRange = $cluster->getParams()['time_range'];
+        self::assertSame($media[0]->getTakenAt()?->getTimestamp(), $timeRange['from']);
+        self::assertSame(end($media)->getTakenAt()?->getTimestamp(), $timeRange['to']);
+    }
+
+    #[Test]
+    public function rejectsRunsBelowDistanceRequirement(): void
+    {
+        $strategy = new RoadTripClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minDailyKm: 500.0,
+            minGpsSamplesPerDay: 3,
+            minNights: 2,
+            minItemsTotal: 12,
+        );
+
+        $start = new DateTimeImmutable('2023-08-10 09:00:00', new DateTimeZone('UTC'));
+        $media = [];
+
+        $coords = [
+            ['lat' => 52.5200, 'lon' => 13.4050],
+            ['lat' => 52.5300, 'lon' => 13.4100],
+            ['lat' => 52.5400, 'lon' => 13.4150],
+        ];
+
+        $id = 2000;
+        foreach ($coords as $index => $pos) {
+            $dayStart = $start->add(new DateInterval('P' . $index . 'D'));
+            $media = [...$media, ...$this->createDailyTrack($id, $dayStart, $pos['lat'], $pos['lon'])];
+            $id += 4;
+        }
+
+        self::assertSame([], $strategy->cluster($media));
+    }
+
+    /**
+     * @return list<Media>
+     */
+    private function createDailyTrack(int $startId, DateTimeImmutable $dayStart, float $lat, float $lon): array
+    {
+        $points = [
+            [$lat, $lon],
+            [$lat + 0.3, $lon + 0.3],
+            [$lat + 0.6, $lon + 0.6],
+            [$lat + 0.9, $lon + 0.9],
+        ];
+
+        $out = [];
+        foreach ($points as $offset => $pair) {
+            $out[] = $this->createMedia(
+                $startId + $offset,
+                $dayStart->add(new DateInterval('PT' . (2 * $offset) . 'H')),
+                $pair[0],
+                $pair[1],
+            );
+        }
+
+        return $out;
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/road-trip-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SeasonClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SeasonClusterStrategyTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SeasonClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SeasonClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function groupsItemsBySeasonPerYear(): void
+    {
+        $strategy = new SeasonClusterStrategy(minItems: 4);
+
+        $mediaItems = [
+            $this->createMedia(1, '2023-12-15 09:00:00'),
+            $this->createMedia(2, '2024-01-05 11:00:00'),
+            $this->createMedia(3, '2024-02-10 14:00:00'),
+            $this->createMedia(4, '2024-02-15 08:30:00'),
+            $this->createMedia(5, '2024-07-01 12:00:00'),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('season', $cluster->getAlgorithm());
+        self::assertSame('Winter', $cluster->getParams()['label']);
+        self::assertSame(2024, $cluster->getParams()['year']);
+        self::assertSame([1, 2, 3, 4], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function skipsGroupsBelowMinimum(): void
+    {
+        $strategy = new SeasonClusterStrategy(minItems: 3);
+
+        $mediaItems = [
+            $this->createMedia(11, '2024-06-01 10:00:00'),
+            $this->createMedia(12, '2024-06-05 11:00:00'),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/season-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SeasonOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SeasonOverYearsClusterStrategyTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SeasonOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SeasonOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function mergesSeasonAcrossYears(): void
+    {
+        $strategy = new SeasonOverYearsClusterStrategy(
+            minYears: 3,
+            minItems: 6,
+        );
+
+        $mediaItems = [
+            $this->createMedia(1, '2019-07-01 08:00:00'),
+            $this->createMedia(2, '2019-07-05 09:00:00'),
+            $this->createMedia(3, '2020-08-10 10:00:00'),
+            $this->createMedia(4, '2020-08-11 11:00:00'),
+            $this->createMedia(5, '2021-06-15 12:00:00'),
+            $this->createMedia(6, '2021-06-18 13:00:00'),
+            $this->createMedia(7, '2021-12-05 14:00:00'),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('season_over_years', $cluster->getAlgorithm());
+        self::assertSame('Sommer im Laufe der Jahre', $cluster->getParams()['label']);
+        self::assertSame([1, 2, 3, 4, 5, 6], $cluster->getMembers());
+        self::assertContains(2021, $cluster->getParams()['years']);
+    }
+
+    #[Test]
+    public function requiresMinimumYears(): void
+    {
+        $strategy = new SeasonOverYearsClusterStrategy(
+            minYears: 4,
+            minItems: 5,
+        );
+
+        $mediaItems = [
+            $this->createMedia(11, '2019-04-01 08:00:00'),
+            $this->createMedia(12, '2020-04-02 09:00:00'),
+            $this->createMedia(13, '2021-04-03 10:00:00'),
+            $this->createMedia(14, '2021-04-04 11:00:00'),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/season-over-years-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SignificantPlaceClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SignificantPlaceClusterStrategyTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SignificantPlaceClusterStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SignificantPlaceClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function buildsClusterForFrequentPlace(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new SignificantPlaceClusterStrategy(
+            locHelper: $helper,
+            gridDegrees: 0.01,
+            minVisitDays: 3,
+            minItemsTotal: 5,
+        );
+
+        $location = $this->createLocation('loc-berlin', 'Kaffeehaus');
+        $mediaItems = [
+            $this->createMedia(1, '2024-03-01 08:00:00', 52.5200, 13.4050, $location),
+            $this->createMedia(2, '2024-03-01 09:00:00', 52.5202, 13.4052, $location),
+            $this->createMedia(3, '2024-03-05 10:00:00', 52.5203, 13.4051, $location),
+            $this->createMedia(4, '2024-03-05 11:00:00', 52.5204, 13.4053, $location),
+            $this->createMedia(5, '2024-03-10 12:00:00', 52.5201, 13.4054, $location),
+            $this->createMedia(6, '2024-04-01 09:00:00', 48.1, 11.6, $this->createLocation('loc-munich', 'Marienplatz')),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('significant_place', $cluster->getAlgorithm());
+        self::assertSame([1, 2, 3, 4, 5], $cluster->getMembers());
+        self::assertSame('Cafe Central', $cluster->getParams()['place']);
+        self::assertSame('Cafe Central', $cluster->getParams()['poi_label']);
+        self::assertSame('amenity', $cluster->getParams()['poi_category_key']);
+        self::assertSame('cafe', $cluster->getParams()['poi_category_value']);
+        self::assertSame(['cuisine' => 'coffee_shop'], $cluster->getParams()['poi_tags']);
+        self::assertSame(3, $cluster->getParams()['visit_days']);
+    }
+
+    #[Test]
+    public function enforcesMinimumVisitDays(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new SignificantPlaceClusterStrategy(
+            locHelper: $helper,
+            gridDegrees: 0.01,
+            minVisitDays: 6,
+            minItemsTotal: 5,
+        );
+
+        $location = $this->createLocation('loc-berlin', 'Kaffeehaus');
+        $mediaItems = [
+            $this->createMedia(11, '2024-03-01 08:00:00', 52.5200, 13.4050, $location),
+            $this->createMedia(12, '2024-03-01 09:00:00', 52.5202, 13.4052, $location),
+            $this->createMedia(13, '2024-03-02 10:00:00', 52.5203, 13.4051, $location),
+            $this->createMedia(14, '2024-03-03 11:00:00', 52.5201, 13.4053, $location),
+            $this->createMedia(15, '2024-03-04 12:00:00', 52.5199, 13.4049, $location),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createLocation(string $id, string $displayName): Location
+    {
+        $loc = new Location('provider', $id, $displayName, 52.52, 13.405, 'cell-1234');
+        $loc->setCity('Berlin');
+        $loc->setCountry('Deutschland');
+        $loc->setPois([
+            [
+                'name' => 'Cafe Central',
+                'categoryKey' => 'amenity',
+                'categoryValue' => 'cafe',
+                'tags' => ['cuisine' => 'coffee_shop'],
+            ],
+        ]);
+
+        return $loc;
+    }
+
+    private function createMedia(int $id, string $takenAt, float $lat, float $lon, Location $location): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/significant-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+        $media->setLocation($location);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SnowDayClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SnowDayClusterStrategyTest.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SnowDayClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SnowDayClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersWinterSessionsWithSnowKeywords(): void
+    {
+        $strategy = new SnowDayClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 5400,
+            minItems: 6,
+        );
+
+        $start = new DateTimeImmutable('2024-01-12 09:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        $keywords = ['snow', 'ski', 'piste', 'snowboard', 'eiszapfen', 'schnee'];
+        foreach ($keywords as $index => $keyword) {
+            $media[] = $this->createMedia(
+                1000 + $index,
+                $start->add(new DateInterval('PT' . ($index * 25) . 'M')),
+                47.0 + ($index * 0.001),
+                11.0 + ($index * 0.001),
+                __DIR__ . "/fixtures/{$keyword}-moment.jpg",
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('snow_day', $cluster->getAlgorithm());
+        self::assertSame(range(1000, 1005), $cluster->getMembers());
+    }
+
+    #[Test]
+    public function ignoresOutOfSeasonOrNonSnowSessions(): void
+    {
+        $strategy = new SnowDayClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 5400,
+            minItems: 4,
+        );
+
+        $start = new DateTimeImmutable('2024-04-01 09:00:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 4; $i++) {
+            $media[] = $this->createMedia(
+                1100 + $i,
+                $start->add(new DateInterval('PT' . ($i * 30) . 'M')),
+                47.5 + ($i * 0.001),
+                11.5 + ($i * 0.001),
+                __DIR__ . "/fixtures/mountain-hike-$i.jpg",
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($media));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon, string $path): Media
+    {
+        $media = new Media(
+            path: $path,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SnowVacationOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SnowVacationOverYearsClusterStrategyTest.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SnowVacationOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SnowVacationOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function aggregatesBestSnowTripsAcrossYears(): void
+    {
+        $strategy = new SnowVacationOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 2,
+            minNights: 2,
+            maxNights: 5,
+            minYears: 3,
+            minItemsTotal: 12,
+        );
+
+        $items = [];
+        foreach ([2020, 2021, 2022] as $year) {
+            $start = new DateTimeImmutable(sprintf('%d-01-10 09:00:00', $year));
+
+            for ($dayOffset = 0; $dayOffset < 3; $dayOffset++) {
+                $day = $start->add(new DateInterval('P' . $dayOffset . 'D'));
+
+                for ($i = 0; $i < 2; $i++) {
+                    $items[] = $this->createMedia(
+                        ($year * 100) + ($dayOffset * 10) + $i,
+                        $day->add(new DateInterval('PT' . ($i * 3600) . 'S')),
+                        'ski-trip-' . $year . '-' . $dayOffset . '-' . $i . '.jpg',
+                        46.8 + ($dayOffset * 0.01),
+                        11.2 + ($i * 0.01),
+                    );
+                }
+            }
+
+            // Add a non-winter day that should be ignored.
+            $items[] = $this->createMedia(
+                ($year * 1000) + 99,
+                new DateTimeImmutable(sprintf('%d-06-05 12:00:00', $year)),
+                'summer-hike-' . $year . '.jpg',
+                45.0,
+                10.0,
+            );
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('snow_vacation_over_years', $cluster->getAlgorithm());
+        self::assertSame([2020, 2021, 2022], $cluster->getParams()['years']);
+        self::assertCount(18, $cluster->getMembers());
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2020-01-10 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2022-01-12 10:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $cluster->getParams()['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertIsArray($centroid);
+        self::assertArrayHasKey('lat', $centroid);
+        self::assertArrayHasKey('lon', $centroid);
+    }
+
+    #[Test]
+    public function rejectsWhenMinimumsNotMet(): void
+    {
+        $strategy = new SnowVacationOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minItemsPerDay: 3,
+            minNights: 2,
+            maxNights: 5,
+            minYears: 3,
+            minItemsTotal: 18,
+        );
+
+        $items = [];
+        foreach ([2020, 2021] as $year) {
+            $start = new DateTimeImmutable(sprintf('%d-02-03 08:00:00', $year));
+
+            for ($dayOffset = 0; $dayOffset < 3; $dayOffset++) {
+                $day = $start->add(new DateInterval('P' . $dayOffset . 'D'));
+
+                for ($i = 0; $i < 2; $i++) {
+                    // Only two items per day, below the configured threshold.
+                    $items[] = $this->createMedia(
+                        ($year * 200) + ($dayOffset * 10) + $i,
+                        $day->add(new DateInterval('PT' . ($i * 1800) . 'S')),
+                        'snowboard-' . $year . '-' . $dayOffset . '-' . $i . '.jpg',
+                        47.1,
+                        10.9,
+                    );
+                }
+            }
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(
+        int $id,
+        DateTimeImmutable $takenAt,
+        string $path,
+        float $lat,
+        float $lon
+    ): Media {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $path,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 4096,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SportsEventClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SportsEventClusterStrategyTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SportsEventClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SportsEventClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersWeekendSessionsWithSportKeywords(): void
+    {
+        $strategy = new SportsEventClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 3600,
+            radiusMeters: 600.0,
+            minItems: 5,
+            preferWeekend: true,
+        );
+
+        $mediaItems = [];
+        for ($i = 0; $i < 5; $i++) {
+            $mediaItems[] = $this->createMedia(
+                100 + $i,
+                new DateTimeImmutable('2024-03-16 ' . (18 + $i) . ':00:00', new DateTimeZone('UTC')),
+                "matchday-{$i}.jpg",
+                52.51 + $i * 0.0003,
+                13.4 + $i * 0.0003,
+            );
+        }
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('sports_event', $cluster->getAlgorithm());
+        self::assertSame([100, 101, 102, 103, 104], $cluster->getMembers());
+        self::assertArrayHasKey('time_range', $cluster->getParams());
+    }
+
+    #[Test]
+    public function skipsWeekdayOrSparseSessions(): void
+    {
+        $strategy = new SportsEventClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 3600,
+            radiusMeters: 600.0,
+            minItems: 5,
+            preferWeekend: true,
+        );
+
+        $weekdayItems = [];
+        for ($i = 0; $i < 5; $i++) {
+            $weekdayItems[] = $this->createMedia(
+                200 + $i,
+                new DateTimeImmutable('2024-03-13 ' . (18 + $i) . ':00:00', new DateTimeZone('UTC')),
+                "matchday-{$i}.jpg",
+                52.5 + $i * 0.01,
+                13.3 + $i * 0.01,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($weekdayItems));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $filename, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $filename,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/SunnyDayClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SunnyDayClusterStrategyTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\SunnyDayClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Weather\WeatherHintProviderInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SunnyDayClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function formsClusterWhenAverageSunScoreHigh(): void
+    {
+        $provider = new InMemoryWeatherProvider(
+            hints: [
+                2500 => ['sun_prob' => 0.9],
+                2501 => ['sun_prob' => 0.85],
+                2502 => ['sun_prob' => 0.8],
+                2503 => ['sun_prob' => 0.95],
+                2504 => ['sun_prob' => 0.88],
+                2505 => ['sun_prob' => 0.9],
+            ]
+        );
+        $strategy = new SunnyDayClusterStrategy(
+            weather: $provider,
+            timezone: 'Europe/Berlin',
+            minAvgSunScore: 0.7,
+            minItemsPerDay: 6,
+            minHintsPerDay: 3,
+        );
+
+        $base = new DateTimeImmutable('2024-05-01 10:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(2500 + $i, $base->add(new DateInterval('PT' . ($i * 600) . 'S')));
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('sunny_day', $cluster->getAlgorithm());
+        self::assertSame(range(2500, 2505), $cluster->getMembers());
+        self::assertGreaterThanOrEqual(0.7, $cluster->getParams()['sun_score']);
+    }
+
+    #[Test]
+    public function skipsDaysWithLowSunScore(): void
+    {
+        $provider = new InMemoryWeatherProvider(
+            hints: [
+                2600 => ['sun_prob' => 0.4],
+                2601 => ['sun_prob' => 0.5],
+                2602 => ['sun_prob' => 0.45],
+                2603 => ['sun_prob' => 0.55],
+                2604 => ['sun_prob' => 0.5],
+                2605 => ['sun_prob' => 0.45],
+            ]
+        );
+        $strategy = new SunnyDayClusterStrategy(weather: $provider);
+
+        $base = new DateTimeImmutable('2024-05-02 10:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 6; $i++) {
+            $items[] = $this->createMedia(2600 + $i, $base->add(new DateInterval('PT' . ($i * 600) . 'S')));
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/sunny-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(48.0);
+        $media->setGpsLon(11.0);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}
+
+final class InMemoryWeatherProvider implements WeatherHintProviderInterface
+{
+    /** @var array<int,array<string,float>> */
+    private array $hints;
+
+    /**
+     * @param array<int,array<string,float>> $hints
+     */
+    public function __construct(array $hints)
+    {
+        $this->hints = $hints;
+    }
+
+    public function getHint(Media $media): ?array
+    {
+        $id = $media->getId();
+        return $this->hints[$id] ?? null;
+    }
+}

--- a/test/Unit/Clusterer/ThisMonthOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/ThisMonthOverYearsClusterStrategyTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ThisMonthOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ThisMonthOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function aggregatesCurrentMonthAcrossYears(): void
+    {
+        $strategy = new ThisMonthOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minYears: 3,
+            minItems: 6,
+            minDistinctDays: 4,
+        );
+
+        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
+        $month = (int) $now->format('n');
+
+        $nextMonth = $month % 12 + 1;
+        $noiseYear = $nextMonth === 1 ? 2022 : 2021;
+
+        $mediaItems = [
+            $this->createMedia(1, $now->setDate(2019, $month, 1)->setTime(8, 0)),
+            $this->createMedia(2, $now->setDate(2019, $month, 5)->setTime(9, 0)),
+            $this->createMedia(3, $now->setDate(2020, $month, 2)->setTime(10, 0)),
+            $this->createMedia(4, $now->setDate(2020, $month, 9)->setTime(11, 0)),
+            $this->createMedia(5, $now->setDate(2021, $month, 3)->setTime(12, 0)),
+            $this->createMedia(6, $now->setDate(2021, $month, 12)->setTime(13, 0)),
+            $this->createMedia(7, $now->setDate($noiseYear, $nextMonth, 1)->setTime(7, 0)),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('this_month_over_years', $cluster->getAlgorithm());
+        self::assertSame([1, 2, 3, 4, 5, 6], $cluster->getMembers());
+        self::assertSame($month, $cluster->getParams()['month']);
+    }
+
+    #[Test]
+    public function checksDistinctDaysRequirement(): void
+    {
+        $strategy = new ThisMonthOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minYears: 2,
+            minItems: 4,
+            minDistinctDays: 5,
+        );
+
+        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
+        $month = (int) $now->format('n');
+
+        $mediaItems = [
+            $this->createMedia(21, $now->setDate(2019, $month, 1)->setTime(8, 0)),
+            $this->createMedia(22, $now->setDate(2020, $month, 1)->setTime(9, 0)),
+            $this->createMedia(23, $now->setDate(2020, $month, 2)->setTime(10, 0)),
+            $this->createMedia(24, $now->setDate(2020, $month, 3)->setTime(11, 0)),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/this-month-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt->setTimezone(new DateTimeZone('UTC')));
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/TimeSimilarityStrategyTest.php
+++ b/test/Unit/Clusterer/TimeSimilarityStrategyTest.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\TimeSimilarityStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TimeSimilarityStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersMediaWithinGapAndLocalityBoundaries(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new TimeSimilarityStrategy(
+            locHelper: $helper,
+            maxGapSeconds: 1800,
+            minItems: 3,
+        );
+
+        $berlin = $this->createLocation(
+            providerPlaceId: 'berlin-city',
+            displayName: 'Berlin',
+            lat: 52.5200,
+            lon: 13.4050,
+            city: 'Berlin',
+            country: 'Germany',
+        );
+        $munich = $this->createLocation(
+            providerPlaceId: 'munich-city',
+            displayName: 'Munich',
+            lat: 48.1371,
+            lon: 11.5753,
+            city: 'Munich',
+            country: 'Germany',
+        );
+
+        $mediaItems = [
+            $this->createMedia(1001, '2023-07-01 09:00:00', 52.5201, 13.4049, $berlin),
+            $this->createMedia(1002, '2023-07-01 09:20:00', 52.5202, 13.4050, $berlin),
+            $this->createMedia(1003, '2023-07-01 09:40:00', 52.5203, 13.4051, $berlin),
+            // Gap larger than max gap -> split bucket
+            $this->createMedia(1004, '2023-07-01 12:30:00', 52.5204, 13.4052, $berlin),
+            // Same day but different locality should not join previous bucket
+            $this->createMedia(1005, '2023-07-01 12:40:00', 48.1372, 11.5754, $munich),
+            $this->createMedia(1006, '2023-07-01 12:55:00', 48.1373, 11.5755, $munich),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('time_similarity', $cluster->getAlgorithm());
+        self::assertSame([1001, 1002, 1003], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame('Berlin', $params['place']);
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2023-07-01 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2023-07-01 09:40:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(52.5202, $centroid['lat'], 0.00001);
+        self::assertEqualsWithDelta(13.4050, $centroid['lon'], 0.00001);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoBucketMeetsMinimumItems(): void
+    {
+        $strategy = new TimeSimilarityStrategy(
+            locHelper: new LocationHelper(),
+            maxGapSeconds: 900,
+            minItems: 4,
+        );
+
+        $location = $this->createLocation(
+            providerPlaceId: 'hamburg-city',
+            displayName: 'Hamburg',
+            lat: 53.5511,
+            lon: 9.9937,
+            city: 'Hamburg',
+            country: 'Germany',
+        );
+
+        $mediaItems = [
+            $this->createMedia(1101, '2023-08-10 08:00:00', 53.5510, 9.9936, $location),
+            $this->createMedia(1102, '2023-08-10 08:12:00', 53.5511, 9.9937, $location),
+            $this->createMedia(1103, '2023-08-10 08:25:00', 53.5512, 9.9938, $location),
+            // Splits due to time gap
+            $this->createMedia(1104, '2023-08-10 10:00:00', 53.5513, 9.9939, $location),
+            $this->createMedia(1105, '2023-08-10 10:10:00', 53.5514, 9.9940, $location),
+            $this->createMedia(1106, '2023-08-10 10:20:00', 53.5515, 9.9941, $location),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(
+        int $id,
+        string $takenAt,
+        float $lat,
+        float $lon,
+        Location $location
+    ): Media {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/time-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+        $media->setLocation($location);
+
+        return $media;
+    }
+
+    private function createLocation(
+        string $providerPlaceId,
+        string $displayName,
+        float $lat,
+        float $lon,
+        ?string $city = null,
+        ?string $country = null,
+    ): Location {
+        $location = new Location(
+            provider: 'osm',
+            providerPlaceId: $providerPlaceId,
+            displayName: $displayName,
+            lat: $lat,
+            lon: $lon,
+            cell: 'cell-' . $providerPlaceId,
+        );
+
+        $location->setCity($city);
+        $location->setCountry($country);
+
+        return $location;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/TransitTravelDayClusterStrategyTest.php
+++ b/test/Unit/Clusterer/TransitTravelDayClusterStrategyTest.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\TransitTravelDayClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TransitTravelDayClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function marksDaysWithSufficientTravelDistance(): void
+    {
+        $strategy = new TransitTravelDayClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minTravelKm: 60.0,
+            minGpsSamples: 5,
+        );
+
+        $day = new DateTimeImmutable('2024-07-01 06:00:00', new DateTimeZone('UTC'));
+        $points = [
+            [50.0, 8.0],
+            [50.3, 8.5],
+            [50.6, 9.0],
+            [50.9, 9.5],
+            [51.2, 10.0],
+        ];
+
+        $items = [];
+        foreach ($points as $idx => [$lat, $lon]) {
+            $items[] = $this->createMedia(2300 + $idx, $day->add(new DateInterval('PT' . ($idx * 1800) . 'S')), $lat, $lon);
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('transit_travel_day', $cluster->getAlgorithm());
+        self::assertSame(range(2300, 2304), $cluster->getMembers());
+        self::assertGreaterThanOrEqual(60.0, $cluster->getParams()['distance_km']);
+    }
+
+    #[Test]
+    public function skipsDaysBelowDistance(): void
+    {
+        $strategy = new TransitTravelDayClusterStrategy();
+
+        $day = new DateTimeImmutable('2024-07-02 06:00:00', new DateTimeZone('UTC'));
+        $points = [
+            [50.0, 8.0],
+            [50.01, 8.01],
+            [50.02, 8.02],
+            [50.03, 8.03],
+            [50.04, 8.04],
+        ];
+
+        $items = [];
+        foreach ($points as $idx => [$lat, $lon]) {
+            $items[] = $this->createMedia(2400 + $idx, $day->add(new DateInterval('PT' . ($idx * 600) . 'S')), $lat, $lon);
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/transit-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/VideoStoriesClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VideoStoriesClusterStrategyTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\VideoStoriesClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class VideoStoriesClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersVideosByLocalDay(): void
+    {
+        $strategy = new VideoStoriesClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minItems: 2,
+        );
+
+        $base = new DateTimeImmutable('2024-03-15 08:00:00');
+        $videos = [];
+        for ($i = 0; $i < 3; $i++) {
+            $videos[] = $this->createVideo(3300 + $i, $base->add(new DateInterval('PT' . ($i * 1800) . 'S')));
+        }
+
+        $clusters = $strategy->cluster($videos);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('video_stories', $cluster->getAlgorithm());
+        self::assertSame([3300, 3301, 3302], $cluster->getMembers());
+    }
+
+    #[Test]
+    public function ignoresNonVideoMedia(): void
+    {
+        $strategy = new VideoStoriesClusterStrategy();
+
+        $items = [
+            $this->createPhoto(3400, new DateTimeImmutable('2024-03-16 08:00:00')),
+            $this->createPhoto(3401, new DateTimeImmutable('2024-03-16 09:00:00')),
+        ];
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createVideo(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/video-' . $id . '.mp4',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 4096,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setMime('video/mp4');
+        $media->setGpsLat(48.1);
+        $media->setGpsLon(11.6);
+
+        return $media;
+    }
+
+    private function createPhoto(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/photo-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setMime('image/jpeg');
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/WeekendGetawaysOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/WeekendGetawaysOverYearsClusterStrategyTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\WeekendGetawaysOverYearsClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class WeekendGetawaysOverYearsClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function aggregatesWeekendTripsAcrossYears(): void
+    {
+        $strategy = new WeekendGetawaysOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minNights: 1,
+            maxNights: 3,
+            minItemsPerDay: 4,
+            minYears: 3,
+            minItemsTotal: 24,
+        );
+
+        $items = [];
+        foreach ([2020, 2021, 2022] as $year) {
+            $friday = new DateTimeImmutable(sprintf('%d-06-05 16:00:00', $year)); // Friday
+            for ($dayOffset = 0; $dayOffset < 3; $dayOffset++) {
+                $day = $friday->add(new DateInterval('P' . $dayOffset . 'D'));
+                for ($i = 0; $i < 4; $i++) {
+                    $items[] = $this->createMedia(
+                        ($year * 100) + ($dayOffset * 10) + $i,
+                        $day->add(new DateInterval('PT' . ($i * 900) . 'S')),
+                    );
+                }
+            }
+        }
+
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('weekend_getaways_over_years', $cluster->getAlgorithm());
+        self::assertSame([2020, 2021, 2022], $cluster->getParams()['years']);
+        self::assertCount(36, $cluster->getMembers());
+    }
+
+    #[Test]
+    public function enforcesMinimumYearCount(): void
+    {
+        $strategy = new WeekendGetawaysOverYearsClusterStrategy(
+            timezone: 'Europe/Berlin',
+            minNights: 1,
+            maxNights: 3,
+            minItemsPerDay: 4,
+            minYears: 3,
+            minItemsTotal: 24,
+        );
+
+        $items = [];
+        foreach ([2021, 2022] as $year) {
+            $friday = new DateTimeImmutable(sprintf('%d-07-09 16:00:00', $year));
+            for ($dayOffset = 0; $dayOffset < 3; $dayOffset++) {
+                $day = $friday->add(new DateInterval('P' . $dayOffset . 'D'));
+                for ($i = 0; $i < 4; $i++) {
+                    $items[] = $this->createMedia(
+                        ($year * 1000) + ($dayOffset * 10) + $i,
+                        $day->add(new DateInterval('PT' . ($i * 900) . 'S')),
+                    );
+                }
+            }
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/weekend-getaway-' . $id . '.jpg',
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 2048,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat(47.0);
+        $media->setGpsLon(11.0);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/WeekendTripClusterStrategyTest.php
+++ b/test/Unit/Clusterer/WeekendTripClusterStrategyTest.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\WeekendTripClusterStrategy;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class WeekendTripClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersWeekendTripAwayFromHome(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new WeekendTripClusterStrategy(
+            locHelper: $helper,
+            homeLat: 52.5200,
+            homeLon: 13.4050,
+            minAwayKm: 50.0,
+            minNights: 1,
+            minItems: 3,
+        );
+
+        $location = $this->createLocation('munich', 'Munich', 48.137, 11.575);
+        $media = [
+            $this->createMedia(700, '2024-04-19 16:00:00', $location),
+            $this->createMedia(701, '2024-04-20 10:00:00', $location),
+            $this->createMedia(702, '2024-04-21 11:00:00', $location),
+        ];
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertSame('weekend_trip', $cluster->getAlgorithm());
+        self::assertSame([700, 701, 702], $cluster->getMembers());
+        self::assertSame('Munich', $cluster->getParams()['place']);
+        self::assertGreaterThanOrEqual(1, $cluster->getParams()['nights']);
+        self::assertArrayHasKey('distance_km', $cluster->getParams());
+    }
+
+    #[Test]
+    public function rejectsTripsTooCloseToHome(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new WeekendTripClusterStrategy(
+            locHelper: $helper,
+            homeLat: 52.5200,
+            homeLon: 13.4050,
+            minAwayKm: 80.0,
+            minNights: 1,
+            minItems: 3,
+        );
+
+        $location = $this->createLocation('potsdam', 'Potsdam', 52.400, 13.050);
+        $items = [
+            $this->createMedia(710, '2024-05-17 16:00:00', $location),
+            $this->createMedia(711, '2024-05-18 10:00:00', $location),
+            $this->createMedia(712, '2024-05-19 11:00:00', $location),
+        ];
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createLocation(string $id, string $city, float $lat, float $lon): Location
+    {
+        $location = new Location('osm', $id, $city, $lat, $lon, 'cell-' . $id);
+        $location->setCity($city);
+        $location->setCountry('Germany');
+
+        return $location;
+    }
+
+    private function createMedia(int $id, string $takenAt, Location $location): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/weekend-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt));
+        $media->setGpsLat($location->getLat());
+        $media->setGpsLon($location->getLon());
+        $media->setLocation($location);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/YearInReviewClusterStrategyTest.php
+++ b/test/Unit/Clusterer/YearInReviewClusterStrategyTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\YearInReviewClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class YearInReviewClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function buildsClusterForYearsMeetingThresholds(): void
+    {
+        $strategy = new YearInReviewClusterStrategy(minItems: 4, minDistinctMonths: 3);
+
+        $mediaItems = [
+            $this->createMedia(501, '2021-01-05 09:00:00', 52.5200, 13.4050),
+            $this->createMedia(502, '2021-03-12 10:00:00', 52.5202, 13.4052),
+            $this->createMedia(503, '2021-05-25 11:30:00', 52.5204, 13.4054),
+            $this->createMedia(504, '2021-10-02 14:15:00', 52.5206, 13.4056),
+            // Below threshold for months (only Feb + Mar)
+            $this->createMedia(601, '2020-02-01 08:00:00', 48.1371, 11.5753),
+            $this->createMedia(602, '2020-02-18 09:00:00', 48.1372, 11.5754),
+            $this->createMedia(603, '2020-03-05 10:15:00', 48.1373, 11.5755),
+            $this->createMedia(604, '2020-03-20 11:45:00', 48.1374, 11.5756),
+        ];
+
+        $clusters = $strategy->cluster($mediaItems);
+
+        self::assertCount(1, $clusters);
+        $cluster = $clusters[0];
+
+        self::assertInstanceOf(ClusterDraft::class, $cluster);
+        self::assertSame('year_in_review', $cluster->getAlgorithm());
+        self::assertSame([501, 502, 503, 504], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame(2021, $params['year']);
+
+        $expectedRange = [
+            'from' => (new DateTimeImmutable('2021-01-05 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
+            'to'   => (new DateTimeImmutable('2021-10-02 14:15:00', new DateTimeZone('UTC')))->getTimestamp(),
+        ];
+        self::assertSame($expectedRange, $params['time_range']);
+
+        $centroid = $cluster->getCentroid();
+        self::assertEqualsWithDelta(52.5203, $centroid['lat'], 0.0001);
+        self::assertEqualsWithDelta(13.4053, $centroid['lon'], 0.0001);
+    }
+
+    #[Test]
+    public function returnsEmptyWhenYearsLackDistinctMonths(): void
+    {
+        $strategy = new YearInReviewClusterStrategy(minItems: 3, minDistinctMonths: 4);
+
+        $mediaItems = [
+            $this->createMedia(701, '2022-01-01 09:00:00', 40.7128, -74.0060),
+            $this->createMedia(702, '2022-02-01 10:00:00', 40.7129, -74.0059),
+            $this->createMedia(703, '2022-03-01 11:00:00', 40.7130, -74.0058),
+        ];
+
+        self::assertSame([], $strategy->cluster($mediaItems));
+    }
+
+    private function createMedia(int $id, string $takenAt, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . "/fixtures/year-in-review-{$id}.jpg",
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt(new DateTimeImmutable($takenAt, new DateTimeZone('UTC')));
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}

--- a/test/Unit/Clusterer/ZooAquariumClusterStrategyTest.php
+++ b/test/Unit/Clusterer/ZooAquariumClusterStrategyTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Clusterer;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\ZooAquariumClusterStrategy;
+use MagicSunday\Memories\Entity\Media;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ZooAquariumClusterStrategyTest extends TestCase
+{
+    #[Test]
+    public function clustersDaytimeZooVisits(): void
+    {
+        $strategy = new ZooAquariumClusterStrategy(
+            timezone: 'Europe/Berlin',
+            sessionGapSeconds: 1800,
+            radiusMeters: 350.0,
+            minItems: 5,
+            minHour: 9,
+            maxHour: 19,
+        );
+
+        $start = new DateTimeImmutable('2023-08-12 09:30:00', new DateTimeZone('UTC'));
+        $media = [];
+        for ($i = 0; $i < 5; $i++) {
+            $media[] = $this->createMedia(
+                1000 + $i,
+                $start->modify('+' . ($i * 20) . ' minutes'),
+                "tierpark-{$i}.jpg",
+                51.0 + $i * 0.0002,
+                7.0 + $i * 0.0002,
+            );
+        }
+
+        $clusters = $strategy->cluster($media);
+
+        self::assertCount(1, $clusters);
+        self::assertSame('zoo_aquarium', $clusters[0]->getAlgorithm());
+        self::assertSame(range(1000, 1004), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function rejectsSessionsOutsideOpeningHours(): void
+    {
+        $strategy = new ZooAquariumClusterStrategy();
+
+        $items = [];
+        for ($i = 0; $i < 5; $i++) {
+            $items[] = $this->createMedia(
+                1100 + $i,
+                new DateTimeImmutable('2023-08-12 22:00:00', new DateTimeZone('UTC')),
+                "tierpark-{$i}.jpg",
+                51.0,
+                7.0,
+            );
+        }
+
+        self::assertSame([], $strategy->cluster($items));
+    }
+
+    private function createMedia(int $id, DateTimeImmutable $takenAt, string $filename, float $lat, float $lon): Media
+    {
+        $media = new Media(
+            path: __DIR__ . '/fixtures/' . $filename,
+            checksum: str_pad((string) $id, 64, '0', STR_PAD_LEFT),
+            size: 1024,
+        );
+
+        $this->assignId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setGpsLat($lat);
+        $media->setGpsLon($lon);
+
+        return $media;
+    }
+
+    private function assignId(Media $media, int $id): void
+    {
+        \Closure::bind(function (Media $m, int $value): void {
+            $m->id = $value;
+        }, null, Media::class)($media, $id);
+    }
+}


### PR DESCRIPTION
## Summary
- add targeted coverage for the shared keyword-best-day-over-years strategy
- assert that the strongest keyword day per year is selected and thresholds respected
- verify timezone-aware grouping feeds correct metadata into cluster params

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d5984d047c83239c26655799751626