### PR TITLE
Remove calendar extension dependency from OnThisDay tests

### DIFF
--- a/test/Unit/Clusterer/ThisMonthOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/ThisMonthOverYearsClusterStrategyTest.php
@@ -22,30 +22,41 @@ final class ThisMonthOverYearsClusterStrategyTest extends TestCase
             minDistinctDays: 4,
         );
 
-        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
-        $month = (int) $now->format('n');
+        $this->runWithStableClock(
+            new DateTimeZone('Europe/Berlin'),
+            'Y-m',
+            function (DateTimeImmutable $anchor, callable $isStable) use ($strategy): bool {
+                $month = (int) $anchor->format('n');
 
-        $nextMonth = $month % 12 + 1;
-        $noiseYear = $nextMonth === 1 ? 2022 : 2021;
+                $nextMonth = $month % 12 + 1;
+                $noiseYear = $nextMonth === 1 ? 2022 : 2021;
 
-        $mediaItems = [
-            $this->createMedia(1, $now->setDate(2019, $month, 1)->setTime(8, 0)),
-            $this->createMedia(2, $now->setDate(2019, $month, 5)->setTime(9, 0)),
-            $this->createMedia(3, $now->setDate(2020, $month, 2)->setTime(10, 0)),
-            $this->createMedia(4, $now->setDate(2020, $month, 9)->setTime(11, 0)),
-            $this->createMedia(5, $now->setDate(2021, $month, 3)->setTime(12, 0)),
-            $this->createMedia(6, $now->setDate(2021, $month, 12)->setTime(13, 0)),
-            $this->createMedia(7, $now->setDate($noiseYear, $nextMonth, 1)->setTime(7, 0)),
-        ];
+                $mediaItems = [
+                    $this->createMedia(1, $anchor->setDate(2019, $month, 1)->setTime(8, 0)),
+                    $this->createMedia(2, $anchor->setDate(2019, $month, 5)->setTime(9, 0)),
+                    $this->createMedia(3, $anchor->setDate(2020, $month, 2)->setTime(10, 0)),
+                    $this->createMedia(4, $anchor->setDate(2020, $month, 9)->setTime(11, 0)),
+                    $this->createMedia(5, $anchor->setDate(2021, $month, 3)->setTime(12, 0)),
+                    $this->createMedia(6, $anchor->setDate(2021, $month, 12)->setTime(13, 0)),
+                    $this->createMedia(7, $anchor->setDate($noiseYear, $nextMonth, 1)->setTime(7, 0)),
+                ];
 
-        $clusters = $strategy->cluster($mediaItems);
+                $clusters = $strategy->cluster($mediaItems);
 
-        self::assertCount(1, $clusters);
-        $cluster = $clusters[0];
+                if (!$isStable()) {
+                    return false;
+                }
 
-        self::assertSame('this_month_over_years', $cluster->getAlgorithm());
-        self::assertSame([1, 2, 3, 4, 5, 6], $cluster->getMembers());
-        self::assertSame($month, $cluster->getParams()['month']);
+                self::assertCount(1, $clusters);
+                $cluster = $clusters[0];
+
+                self::assertSame('this_month_over_years', $cluster->getAlgorithm());
+                self::assertSame([1, 2, 3, 4, 5, 6], $cluster->getMembers());
+                self::assertSame($month, $cluster->getParams()['month']);
+
+                return true;
+            }
+        );
     }
 
     #[Test]
@@ -58,17 +69,28 @@ final class ThisMonthOverYearsClusterStrategyTest extends TestCase
             minDistinctDays: 5,
         );
 
-        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
-        $month = (int) $now->format('n');
+        $this->runWithStableClock(
+            new DateTimeZone('Europe/Berlin'),
+            'Y-m',
+            function (DateTimeImmutable $anchor, callable $isStable) use ($strategy): bool {
+                $month = (int) $anchor->format('n');
 
-        $mediaItems = [
-            $this->createMedia(21, $now->setDate(2019, $month, 1)->setTime(8, 0)),
-            $this->createMedia(22, $now->setDate(2020, $month, 1)->setTime(9, 0)),
-            $this->createMedia(23, $now->setDate(2020, $month, 2)->setTime(10, 0)),
-            $this->createMedia(24, $now->setDate(2020, $month, 3)->setTime(11, 0)),
-        ];
+                $mediaItems = [
+                    $this->createMedia(21, $anchor->setDate(2019, $month, 1)->setTime(8, 0)),
+                    $this->createMedia(22, $anchor->setDate(2020, $month, 1)->setTime(9, 0)),
+                    $this->createMedia(23, $anchor->setDate(2020, $month, 2)->setTime(10, 0)),
+                    $this->createMedia(24, $anchor->setDate(2020, $month, 3)->setTime(11, 0)),
+                ];
 
-        self::assertSame([], $strategy->cluster($mediaItems));
+                if (!$isStable()) {
+                    return false;
+                }
+
+                self::assertSame([], $strategy->cluster($mediaItems));
+
+                return true;
+            }
+        );
     }
 
     private function createMedia(int $id, DateTimeImmutable $takenAt): Media


### PR DESCRIPTION
## Summary
- compute month lengths in the OnThisDay strategy tests using DateTimeImmutable instead of cal_days_in_month
- drop the unused CAL_GREGORIAN constant import now that the calendar extension is no longer required

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: bin/php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d901744c2483238cdb2036f18d6a60