### PR TITLE
Add global per-algorithm limit to memory feed

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -174,3 +174,4 @@ parameters:
     memories.feed.min_members: 4
     memories.feed.max_per_day: 6
     memories.feed.max_total: 60
+    memories.feed.max_per_algorithm: 12

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -776,6 +776,7 @@ services:
             $minMembers: '%memories.feed.min_members%'
             $maxPerDay: '%memories.feed.max_per_day%'
             $maxTotal: '%memories.feed.max_total%'
+            $maxPerAlgorithm: '%memories.feed.max_per_algorithm%'
 
     MagicSunday\Memories\Service\Feed\FeedBuilderInterface:
         alias: MagicSunday\Memories\Service\Feed\MemoryFeedBuilder

--- a/src/Command/FeedExportHtmlCommand.php
+++ b/src/Command/FeedExportHtmlCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Export a static HTML page that previews the "Für dich" feed.
  * Copies (or symlinks) thumbnails into an export folder and uses lazy-loading.
+ * Greift dabei auf die globale Algorithmus-Begrenzung des Feed-Builders zurück.
  */
 #[AsCommand(
     name: 'memories:feed:export-html',

--- a/src/Command/FeedPreviewCommand.php
+++ b/src/Command/FeedPreviewCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Preview a "Für dich" feed in the console from persisted clusters.
+ * Beachtet dabei die globale Limitierung pro Algorithmus aus dem Feed-Builder.
  */
 #[AsCommand(
     name: 'memories:feed:preview',

--- a/src/Service/Feed/MemoryFeedBuilder.php
+++ b/src/Service/Feed/MemoryFeedBuilder.php
@@ -28,7 +28,8 @@ final class MemoryFeedBuilder implements FeedBuilderInterface
         private readonly float $minScore = 0.35,
         private readonly int $minMembers = 4,
         private readonly int $maxPerDay = 6,
-        private readonly int $maxTotal = 60
+        private readonly int $maxTotal = 60,
+        private readonly int $maxPerAlgorithm = 12
     ) {
     }
 
@@ -66,6 +67,8 @@ final class MemoryFeedBuilder implements FeedBuilderInterface
         $seenPlace = [];
         /** @var array<string,int> $seenAlg */
         $seenAlg = [];
+        /** @var array<string,int> $algCount */
+        $algCount = [];
 
         $result = [];
 
@@ -85,6 +88,14 @@ final class MemoryFeedBuilder implements FeedBuilderInterface
 
             $place = $c->getParams()['place'] ?? null;
             $alg   = $c->getAlgorithm();
+
+            if (!\is_string($alg)) {
+                continue;
+            }
+
+            if (($algCount[$alg] ?? 0) >= $this->maxPerAlgorithm) {
+                continue;
+            }
 
             // simple diversity: limit repeats
             if (\is_string($place)) {
@@ -125,6 +136,7 @@ final class MemoryFeedBuilder implements FeedBuilderInterface
                 $seenPlace[\sprintf('%s|%s', $dayKey, $place)] = ($seenPlace[\sprintf('%s|%s', $dayKey, $place)] ?? 0) + 1;
             }
             $seenAlg[$algKey] = ($seenAlg[$algKey] ?? 0) + 1;
+            $algCount[$alg] = ($algCount[$alg] ?? 0) + 1;
         }
 
         return $result;


### PR DESCRIPTION
## Summary
- add a configurable per-algorithm cap to `MemoryFeedBuilder` and enforce it while building the feed
- expose the new `memories.feed.max_per_algorithm` parameter and wire it into the feed builder service
- document the global algorithm cap in the feed preview and export command descriptions

## Testing
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d90926ddcc8323adb3294037df46e4