### PR TITLE
Add city filter to geocode command

### DIFF
--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Geocoding\LocationCellIndex;
+use MagicSunday\Memories\Service\Geocoding\LocationResolver;
 use MagicSunday\Memories\Service\Geocoding\MediaLocationLinker;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -24,6 +26,7 @@ final class GeocodeCommand extends Command
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly MediaLocationLinker $linker,
+        private readonly LocationResolver $locationResolver,
         private readonly LocationCellIndex $cellIndex,
         private readonly int $delayMs = 1200 // be polite to Nominatim
     ) {
@@ -35,6 +38,7 @@ final class GeocodeCommand extends Command
         $this
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximale Anzahl zu verarbeitender Medien', null)
             ->addOption('all', null, InputOption::VALUE_NONE, 'Alle Medien erneut geokodieren (auch bereits verknüpft)')
+            ->addOption('city', null, InputOption::VALUE_REQUIRED, 'Orte nach Stadtnamen aktualisieren (z.B. "Paris")')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Nur anzeigen, keine Änderungen speichern');
     }
 
@@ -45,8 +49,13 @@ final class GeocodeCommand extends Command
         $limit  = $input->getOption('limit');
         $limitN = \is_string($limit) ? (int) $limit : null;
         $all    = (bool) $input->getOption('all');
+        $city   = $input->getOption('city');
 
         $io->title('🗺️  Orte ermitteln');
+
+        if (\is_string($city) && $city !== '') {
+            return $this->reprocessLocationsByCity($city, $dryRun, $io, $output);
+        }
 
         $loaded = $this->cellIndex->warmUpFromDb();
         $io->writeln(\sprintf('🔎 %d bekannte Zellen vorab geladen.', $loaded));
@@ -122,6 +131,83 @@ final class GeocodeCommand extends Command
         $io->writeln('');
         $io->writeln('');
         $io->writeln(\sprintf('✅ %d Medien verarbeitet, %d Orte verknüpft, %d Netzabfragen.', $processed, $linked, $netCalls));
+
+        if ($dryRun) {
+            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function reprocessLocationsByCity(string $city, bool $dryRun, SymfonyStyle $io, OutputInterface $output): int
+    {
+        $normalizedCity = \mb_strtolower($city);
+
+        $io->section(\sprintf('🏙️  Orte mit Stadtnamen "%s" aktualisieren', $city));
+
+        $repo = $this->em->getRepository(Location::class);
+        $qb   = $repo->createQueryBuilder('l');
+
+        $qb->where('LOWER(l.city) = :city')
+            ->orWhere('LOWER(l.displayName) LIKE :cityLike')
+            ->setParameter('city', $normalizedCity)
+            ->setParameter('cityLike', '%' . $normalizedCity . '%')
+            ->orderBy('l.id', 'ASC');
+
+        /** @var list<Location> $locations */
+        $locations = $qb->getQuery()->getResult();
+
+        $count = \count($locations);
+        if ($count < 1) {
+            $io->writeln('Keine passenden Orte gefunden.');
+
+            return Command::SUCCESS;
+        }
+
+        $bar = new ProgressBar($output, $count);
+        $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% | Dauer: %elapsed:6s% | ETA: %estimated:-6s% | %message%');
+        $bar->setMessage('Starte …');
+        $bar->start();
+
+        $processed = 0;
+        $updated   = 0;
+        $netCalls  = 0;
+        $batchSize = 100;
+
+        foreach ($locations as $location) {
+            $label = $location->getDisplayName() ?? $location->getCity() ?? 'Unbenannter Ort';
+            $bar->setMessage($label);
+
+            $beforePois = $location->getPois();
+
+            $this->locationResolver->ensurePois($location);
+            if ($this->locationResolver->consumeLastUsedNetwork()) {
+                $netCalls++;
+            }
+
+            if ($beforePois !== $location->getPois()) {
+                $updated++;
+            }
+
+            $processed++;
+            $bar->advance();
+
+            if (($processed % $batchSize) === 0) {
+                if (!$dryRun) {
+                    $this->em->flush();
+                }
+            }
+        }
+
+        if (!$dryRun) {
+            $this->em->flush();
+        }
+
+        $bar->finish();
+
+        $io->writeln('');
+        $io->writeln('');
+        $io->writeln(\sprintf('✅ %d Orte verarbeitet, %d aktualisiert, %d Netzabfragen.', $processed, $updated, $netCalls));
 
         if ($dryRun) {
             $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');


### PR DESCRIPTION
## Summary
- add a `--city` option to `memories:geocode` that refreshes locations by city name
- inject the location resolver so POIs can be enriched without GPS-based lookups

## Testing
- composer ci:test *(fails: `bin/php: not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d93ac628f483238024e465b951aa66