### PR TITLE
Add missing POI enrichment flow

### DIFF
--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -39,6 +39,7 @@ final class GeocodeCommand extends Command
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximale Anzahl zu verarbeitender Medien', null)
             ->addOption('all', null, InputOption::VALUE_NONE, 'Alle Medien erneut geokodieren (auch bereits verknüpft)')
             ->addOption('city', null, InputOption::VALUE_REQUIRED, 'Orte nach Stadtnamen aktualisieren (z.B. "Paris")')
+            ->addOption('missing-pois', null, InputOption::VALUE_NONE, 'Orte ohne POI-Daten ergänzen')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Nur anzeigen, keine Änderungen speichern');
     }
 
@@ -50,8 +51,13 @@ final class GeocodeCommand extends Command
         $limitN = \is_string($limit) ? (int) $limit : null;
         $all    = (bool) $input->getOption('all');
         $city   = $input->getOption('city');
+        $missingPois = (bool) $input->getOption('missing-pois');
 
         $io->title('🗺️  Orte ermitteln');
+
+        if ($missingPois) {
+            return $this->reprocessLocationsMissingPois($dryRun, $io, $output);
+        }
 
         if (\is_string($city) && $city !== '') {
             return $this->reprocessLocationsByCity($city, $dryRun, $io, $output);
@@ -131,6 +137,78 @@ final class GeocodeCommand extends Command
         $io->writeln('');
         $io->writeln('');
         $io->writeln(\sprintf('✅ %d Medien verarbeitet, %d Orte verknüpft, %d Netzabfragen.', $processed, $linked, $netCalls));
+
+        if ($dryRun) {
+            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function reprocessLocationsMissingPois(bool $dryRun, SymfonyStyle $io, OutputInterface $output): int
+    {
+        $io->section('📍 Orte ohne POI-Daten ergänzen');
+
+        $repo = $this->em->getRepository(Location::class);
+        $qb   = $repo->createQueryBuilder('l');
+
+        $qb->where('l.pois IS NULL')
+            ->orderBy('l.id', 'ASC');
+
+        /** @var list<Location> $locations */
+        $locations = $qb->getQuery()->getResult();
+
+        $count = \count($locations);
+        if ($count < 1) {
+            $io->writeln('Keine Orte ohne POI-Daten gefunden.');
+
+            return Command::SUCCESS;
+        }
+
+        $bar = new ProgressBar($output, $count);
+        $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% | Dauer: %elapsed:6s% | ETA: %estimated:-6s% | %message%');
+        $bar->setMessage('Starte …');
+        $bar->start();
+
+        $processed = 0;
+        $updated   = 0;
+        $netCalls  = 0;
+        $batchSize = 100;
+
+        foreach ($locations as $location) {
+            $label = $location->getDisplayName() ?? $location->getCity() ?? 'Unbenannter Ort';
+            $bar->setMessage($label);
+
+            $beforePois = $location->getPois();
+
+            $this->locationResolver->ensurePois($location);
+            if ($this->locationResolver->consumeLastUsedNetwork()) {
+                $netCalls++;
+            }
+
+            if ($beforePois !== $location->getPois()) {
+                $updated++;
+            }
+
+            $processed++;
+            $bar->advance();
+
+            if (($processed % $batchSize) === 0) {
+                if (!$dryRun) {
+                    $this->em->flush();
+                }
+            }
+        }
+
+        if (!$dryRun) {
+            $this->em->flush();
+        }
+
+        $bar->finish();
+
+        $io->writeln('');
+        $io->writeln('');
+        $io->writeln(\sprintf('✅ %d Orte verarbeitet, %d aktualisiert, %d Netzabfragen.', $processed, $updated, $netCalls));
 
         if ($dryRun) {
             $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');


### PR DESCRIPTION
## Summary
- add a `--missing-pois` switch to the geocode command
- implement a dedicated execution path to enrich locations without POI data while respecting dry-run mode
- reuse the existing progress and batching pattern when resolving POIs

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d93ea87150832382b486b40fd165d9