### PR TITLE
Add CLI option to refresh stored POI data

### DIFF
--- a/src/Service/Geocoding/LocationResolver.php
+++ b/src/Service/Geocoding/LocationResolver.php
@@ -124,15 +124,20 @@ final class LocationResolver
      * Ensures that a previously stored Location eventually receives POI data.
      *
      * This is used when we re-use Locations from the cell cache/index without
-     * going through the full reverse-geocoding pipeline again.
+     * going through the full reverse-geocoding pipeline again. When
+     * $forceRefresh is true, existing POI data is cleared before the re-fetch.
      */
-    public function ensurePois(Location $location): void
+    public function ensurePois(Location $location, bool $forceRefresh = false): void
     {
-        if ($location->getPois() !== null) {
+        if (!($this->poiEnricher instanceof LocationPoiEnricher)) {
             return;
         }
 
-        if (!($this->poiEnricher instanceof LocationPoiEnricher)) {
+        if ($forceRefresh && $location->getPois() !== null) {
+            $location->setPois(null);
+        }
+
+        if ($location->getPois() !== null) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- add a `--refresh-pois` flag to the geocode command to allow targeted POI refreshes via CLI help
- allow `LocationResolver::ensurePois()` to reset existing POI payloads when a refresh is requested so the enricher refetches data

## Testing
- composer ci:test *(fails: bin/php not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93f578928832380ea51e765e5f598