### PR TITLE
Reduce geocode batch size

### DIFF
--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -102,7 +102,7 @@ final class GeocodeCommand extends Command
         $linked    = 0;
         $netCalls  = 0;
 
-        $batchSize = 100; // größerer Batch ist OK
+        $batchSize = 10; // kleinerer Batch verringert Datenverlust bei Fehlern
         foreach ($medias as $m) {
             $bar->setMessage('Rückwärtssuche');
             $loc = $this->linker->link($m, 'de');
@@ -182,7 +182,7 @@ final class GeocodeCommand extends Command
         $processed = 0;
         $updated   = 0;
         $netCalls  = 0;
-        $batchSize = 100;
+        $batchSize = 10;
 
         foreach ($locations as $location) {
             $label = $location->getDisplayName() ?? $location->getCity() ?? 'Unbenannter Ort';
@@ -263,7 +263,7 @@ final class GeocodeCommand extends Command
         $processed = 0;
         $updated   = 0;
         $netCalls  = 0;
-        $batchSize = 100;
+        $batchSize = 10;
 
         foreach ($locations as $location) {
             $label = $location->getDisplayName() ?? $location->getCity() ?? 'Unbenannter Ort';


### PR DESCRIPTION
## Summary
- lower geocode command batch size from 100 to 10 to reduce potential data loss on failure

## Testing
- composer ci:test *(fails: missing bin/php executable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d941e1230c832394fa33c1b38b84e0