### PR TITLE
Adjust Overpass POI fetch limit handling

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -20,6 +20,7 @@ parameters:
     memories.geocoding.overpass.timeout: 25
     memories.geocoding.overpass.radius_m: 250
     memories.geocoding.overpass.max_pois: 15
+    memories.geocoding.overpass.fetch_limit_multiplier: 3.0
 
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -150,6 +150,7 @@ services:
         arguments:
             $radiusMeters: '%memories.geocoding.overpass.radius_m%'
             $maxPois: '%memories.geocoding.overpass.max_pois%'
+            $fetchLimitMultiplier: '%memories.geocoding.overpass.fetch_limit_multiplier%'
 
     MagicSunday\Memories\Service\Geocoding\LocationCellIndex: ~
 


### PR DESCRIPTION
## Summary
- expand LocationPoiEnricher to request additional POIs, trim after distance sorting, and support unlimited Overpass queries when desired
- add a configurable fetch limit multiplier parameter that is wired through the service container
- update OverpassClient and unit tests to honour the new query limit behaviour

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php not found in container)*
- ./vendor/bin/phpunit test/Unit/Service/Geocoding/LocationPoiEnricherTest.php


------
https://chatgpt.com/codex/tasks/task_e_68d9477bd2b483238be4205b94881336