### PR TITLE
Support localized POI names

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -24,3 +24,7 @@ FFPROBE_PATH=/usr/bin/ffprobe
 # Nominatim – bitte eigene Kontaktadresse angeben
 NOMINATIM_BASE_URL="https://nominatim.openstreetmap.org"
 NOMINATIM_EMAIL="you@example.com"
+
+# Locale
+MEMORIES_LOCALE_PREFERRED=de
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 [![CI](https://github.com/magicsunday/photo-memories/actions/workflows/ci.yml/badge.svg)](https://github.com/magicsunday/photo-memories/actions/workflows/ci.yml)
 
 # Photo Memories
+
+## Configuration
+
+### Preferred POI language
+
+Point of interest names returned by the Overpass API can now include
+localised variants. Set the `memories.locale.preferred` container parameter
+or the `MEMORIES_LOCALE_PREFERRED` environment variable (default `de`) to the
+desired locale (for example `de` or `en_GB`) to prefer the matching
+`name:<locale>` tag when rendering POI labels. You can override the default
+by adjusting `config/parameters.yaml` or supplying an environment-specific
+configuration.

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -21,6 +21,9 @@ parameters:
     memories.geocoding.overpass.radius_m: 250
     memories.geocoding.overpass.max_pois: 15
 
+    # Locale Defaults
+    memories.locale.preferred: '%env(default:de,string:MEMORIES_LOCALE_PREFERRED)%'
+
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -162,6 +162,10 @@ services:
         arguments:
             $cellDeg: 0.01
 
+    MagicSunday\Memories\Utility\LocationHelper:
+        arguments:
+            $preferredLocale: '%memories.locale.preferred%'
+
     MagicSunday\Memories\Command\GeocodeCommand:
         arguments:
             $delayMs: '%memories.geocoding.delay_ms%'

--- a/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
+++ b/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
@@ -58,6 +58,9 @@ final class LocationPoiEnricherTest extends TestCase
             'tourism' => 'attraction',
             'historic' => 'monument',
         ], $pois[0]['tags']);
+        self::assertSame([
+            'name' => 'Brandenburg Gate',
+        ], $pois[0]['names']);
     }
 
     #[Test]

--- a/test/Unit/Utility/LocationHelperTest.php
+++ b/test/Unit/Utility/LocationHelperTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Utility;
+
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\LocationHelper;
+use PHPUnit\Framework\Attributes\Test;
+
+final class LocationHelperTest extends TestCase
+{
+    #[Test]
+    public function displayLabelPrefersConfiguredLocale(): void
+    {
+        $location = $this->makeLocation('poi-1', 'Berlin', 52.52, 13.405, configure: static function ($loc): void {
+            $loc->setPois([
+                [
+                    'id' => 'node/1',
+                    'name' => 'Brandenburg Gate',
+                    'categoryKey' => 'tourism',
+                    'categoryValue' => 'attraction',
+                    'tags' => [
+                        'tourism' => 'attraction',
+                    ],
+                    'names' => [
+                        'name' => 'Brandenburg Gate',
+                        'name:de' => 'Brandenburger Tor',
+                    ],
+                ],
+            ]);
+        });
+
+        $helper = new LocationHelper('de');
+
+        self::assertSame('Brandenburger Tor', $helper->displayLabel($location));
+    }
+
+    #[Test]
+    public function displayLabelFallsBackToDefaultNameWhenLocaleMissing(): void
+    {
+        $location = $this->makeLocation('poi-2', 'London', 51.5074, -0.1278, configure: static function ($loc): void {
+            $loc->setPois([
+                [
+                    'id' => 'node/2',
+                    'name' => 'Tower Bridge',
+                    'categoryKey' => 'tourism',
+                    'categoryValue' => 'attraction',
+                    'tags' => [],
+                    'names' => [
+                        'name' => 'Tower Bridge',
+                    ],
+                ],
+            ]);
+        });
+
+        $helper = new LocationHelper('fr');
+
+        self::assertSame('Tower Bridge', $helper->displayLabel($location));
+    }
+
+    #[Test]
+    public function displayLabelFallsBackToAltName(): void
+    {
+        $location = $this->makeLocation('poi-3', 'Paris', 48.8566, 2.3522, configure: static function ($loc): void {
+            $loc->setPois([
+                [
+                    'id' => 'node/3',
+                    'categoryKey' => 'tourism',
+                    'categoryValue' => 'museum',
+                    'tags' => [],
+                    'names' => [
+                        'alt_name' => 'Musée d\'Orsay',
+                    ],
+                ],
+            ]);
+        });
+
+        $helper = new LocationHelper('it');
+
+        self::assertSame("Musée d'Orsay", $helper->displayLabel($location));
+    }
+}


### PR DESCRIPTION
## Summary
- enrich Overpass POI payloads with structured name data including locale-specific variants
- make the preferred POI locale configurable via parameters and the `MEMORIES_LOCALE_PREFERRED` environment variable, and adjust LocationHelper to use translated names when available
- document the new locale option and extend tests to cover localisation fallbacks

## Testing
- composer ci:test *(fails in container: bin/php not found)*
- vendor/bin/phpunit --colors=never test/Unit/Utility/LocationHelperTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d94795e5508323adaa98bf0e4e059b