### PR TITLE
Add localized POI name handling

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -18,6 +18,9 @@ MEMORIES_HOME_LON=
 MEMORIES_MEDIA_DIR=/var/lib/memories/media
 MEMORIES_THUMBNAIL_DIR=/var/lib/memories/thumbnails
 
+# Spracheinstellungen
+MEMORIES_PREFERRED_LOCALE=DE
+
 # Tools
 FFPROBE_PATH=/usr/bin/ffprobe
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,23 @@
 [![CI](https://github.com/magicsunday/photo-memories/actions/workflows/ci.yml/badge.svg)](https://github.com/magicsunday/photo-memories/actions/workflows/ci.yml)
 
 # Photo Memories
+
+## Localised Points of Interest
+
+Photo Memories enriches locations with nearby points of interest fetched from the OpenStreetMap Overpass API. These POIs now
+capture all available `name:*` variants plus optional `alt_name` entries. The application stores them in a dedicated `names`
+structure alongside the legacy `name` field so consumers can choose the most appropriate label for their locale.
+
+To control which language is preferred when rendering titles or cluster labels, configure the new
+`MEMORIES_PREFERRED_LOCALE` environment variable (or its matching Symfony container parameter
+`memories.localization.preferred_locale`). When set, `LocationHelper::displayLabel()` and related helpers first attempt to use
+the matching `name:<locale>` value before falling back to the default name, other available translations, or alternative
+labels.
+
+Example `.env.local` snippet:
+
+```dotenv
+MEMORIES_PREFERRED_LOCALE=de
+```
+
+Leave the variable unset to retain the previous behaviour of using the generic `name` tag provided by Overpass.

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -21,6 +21,7 @@ parameters:
     memories.geocoding.overpass.radius_m: 250
     memories.geocoding.overpass.max_pois: 15
     memories.geocoding.overpass.fetch_limit_multiplier: 3.0
+    memories.localization.preferred_locale: '%env(default::string:MEMORIES_PREFERRED_LOCALE)%'
 
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,6 +25,10 @@ services:
         arguments:
             $commands: !tagged command
 
+    MagicSunday\Memories\Utility\LocationHelper:
+        arguments:
+            $preferredLocale: '%memories.localization.preferred_locale%'
+
     ########################################
     # Doctrine EntityManager (ORM 3.5+)
     ########################################

--- a/test/Unit/Clusterer/LocationSimilarityStrategyTest.php
+++ b/test/Unit/Clusterer/LocationSimilarityStrategyTest.php
@@ -37,6 +37,13 @@ final class LocationSimilarityStrategyTest extends TestCase
         $museum->setPois([
             [
                 'name'          => 'Museum Island',
+                'names'         => [
+                    'default' => 'Museum Island',
+                    'localized' => [
+                        'de' => 'Museumsinsel',
+                    ],
+                    'alternates' => [],
+                ],
                 'categoryKey'   => 'tourism',
                 'categoryValue' => 'museum',
                 'tags'          => ['wikidata' => 'Q1234'],

--- a/test/Unit/Clusterer/SignificantPlaceClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SignificantPlaceClusterStrategyTest.php
@@ -87,6 +87,13 @@ final class SignificantPlaceClusterStrategyTest extends TestCase
                 $location->setPois([
                     [
                         'name' => 'Cafe Central',
+                        'names' => [
+                            'default' => 'Cafe Central',
+                            'localized' => [
+                                'de' => 'Café Central',
+                            ],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'amenity',
                         'categoryValue' => 'cafe',
                         'tags' => ['cuisine' => 'coffee_shop'],

--- a/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
+++ b/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
@@ -31,6 +31,9 @@ final class LocationPoiEnricherTest extends TestCase
                     'lon' => 13.4049,
                     'tags' => [
                         'name' => 'Brandenburg Gate',
+                        'name:de' => 'Brandenburger Tor',
+                        'name:en' => 'Brandenburg Gate',
+                        'alt_name' => 'Porta Brandeburghese;Brandenburger Tor',
                         'tourism' => 'attraction',
                         'historic' => 'monument',
                         'wikidata' => 'Q82424',
@@ -52,6 +55,14 @@ final class LocationPoiEnricherTest extends TestCase
 
         self::assertSame('node/123', $pois[0]['id']);
         self::assertSame('Brandenburg Gate', $pois[0]['name']);
+        self::assertSame([
+            'default' => 'Brandenburg Gate',
+            'localized' => [
+                'de' => 'Brandenburger Tor',
+                'en' => 'Brandenburg Gate',
+            ],
+            'alternates' => ['Porta Brandeburghese', 'Brandenburger Tor'],
+        ], $pois[0]['names']);
         self::assertSame('tourism', $pois[0]['categoryKey']);
         self::assertSame('attraction', $pois[0]['categoryValue']);
         self::assertSame($expectedDistance, $pois[0]['distanceMeters']);
@@ -140,6 +151,11 @@ final class LocationPoiEnricherTest extends TestCase
             [
                 'id' => 'node/999',
                 'name' => 'Existing Museum',
+                'names' => [
+                    'default' => 'Existing Museum',
+                    'localized' => [],
+                    'alternates' => [],
+                ],
                 'categoryKey' => 'tourism',
                 'categoryValue' => 'museum',
                 'distanceMeters' => 10.0,

--- a/test/Unit/Utility/LocationHelperTest.php
+++ b/test/Unit/Utility/LocationHelperTest.php
@@ -25,6 +25,11 @@ final class LocationHelperTest extends TestCase
                     [
                         'id' => 'node/1',
                         'name' => 'Central Bakery',
+                        'names' => [
+                            'default' => 'Central Bakery',
+                            'localized' => [],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'shop',
                         'categoryValue' => 'bakery',
                         'distanceMeters' => 15.0,
@@ -35,6 +40,11 @@ final class LocationHelperTest extends TestCase
                     [
                         'id' => 'node/2',
                         'name' => 'City Museum',
+                        'names' => [
+                            'default' => 'City Museum',
+                            'localized' => [],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'tourism',
                         'categoryValue' => 'museum',
                         'distanceMeters' => 95.0,
@@ -65,6 +75,11 @@ final class LocationHelperTest extends TestCase
                     [
                         'id' => 'node/10',
                         'name' => 'Old Town Tower',
+                        'names' => [
+                            'default' => 'Old Town Tower',
+                            'localized' => [],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'man_made',
                         'categoryValue' => 'tower',
                         'distanceMeters' => 40.0,
@@ -76,6 +91,11 @@ final class LocationHelperTest extends TestCase
                     [
                         'id' => 'node/11',
                         'name' => 'Parking Lot',
+                        'names' => [
+                            'default' => 'Parking Lot',
+                            'localized' => [],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'amenity',
                         'categoryValue' => 'parking',
                         'distanceMeters' => 10.0,
@@ -97,6 +117,13 @@ final class LocationHelperTest extends TestCase
                     [
                         'id' => 'node/20',
                         'name' => 'City Museum',
+                        'names' => [
+                            'default' => 'City Museum',
+                            'localized' => [
+                                'de' => 'Stadtmuseum',
+                            ],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'tourism',
                         'categoryValue' => 'museum',
                         'distanceMeters' => 110.0,
@@ -108,6 +135,11 @@ final class LocationHelperTest extends TestCase
                     [
                         'id' => 'node/21',
                         'name' => 'Central Cafe',
+                        'names' => [
+                            'default' => 'Central Cafe',
+                            'localized' => [],
+                            'alternates' => [],
+                        ],
                         'categoryKey' => 'amenity',
                         'categoryValue' => 'cafe',
                         'distanceMeters' => 15.0,
@@ -132,5 +164,42 @@ final class LocationHelperTest extends TestCase
         self::assertArrayHasKey('tourism', $context['tags']);
         self::assertSame('museum', $context['tags']['tourism']);
         self::assertSame('Q1', $context['tags']['wikidata']);
+    }
+
+    #[Test]
+    public function displayLabelHonoursPreferredLocale(): void
+    {
+        $helper = new LocationHelper('de');
+
+        $location = $this->makeLocation(
+            providerPlaceId: 'poi-locale-1',
+            displayName: 'Test Location',
+            lat: 48.1,
+            lon: 11.5,
+            configure: static function (Location $loc): void {
+                $loc->setPois([
+                    [
+                        'id' => 'node/30',
+                        'name' => 'Old City Hall',
+                        'names' => [
+                            'default' => 'Old City Hall',
+                            'localized' => [
+                                'de' => 'Altes Rathaus',
+                                'en' => 'Old City Hall',
+                            ],
+                            'alternates' => ['Historisches Rathaus'],
+                        ],
+                        'categoryKey' => 'historic',
+                        'categoryValue' => 'building',
+                        'distanceMeters' => 20.0,
+                        'tags' => [
+                            'historic' => 'yes',
+                        ],
+                    ],
+                ]);
+            },
+        );
+
+        self::assertSame('Altes Rathaus', $helper->displayLabel($location));
     }
 }


### PR DESCRIPTION
## Summary
- extend the Overpass client to persist structured name metadata (default, localized and alternate labels) for each POI
- allow configuring a preferred locale and update `LocationHelper` to prioritise locale-specific names when rendering labels
- document the new localisation support and adapt tests to cover multi-language POI data

## Testing
- `composer ci:test` *(fails: project expects bin/php wrapper in this environment)*
- `php vendor/bin/phpunit --configuration .build/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68d94de2628c8323a5c57cd6315095dc