### PR TITLE
Remove redundant caching from OpenWeather provider

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -181,7 +181,5 @@ parameters:
     memories.weather.enabled: '%env(default:false:bool:MEMORIES_WEATHER_ENABLED)%'
     memories.weather.openweather.base_url: '%env(default::string:OPENWEATHER_BASE_URL)%'
     memories.weather.openweather.api_key: '%env(default::string:OPENWEATHER_API_KEY)%'
-    memories.weather.openweather.cache_ttl: '%env(default:43200:int:MEMORIES_WEATHER_CACHE_TTL)%'
     memories.weather.openweather.max_past_hours: '%env(default:120:int:MEMORIES_WEATHER_MAX_PAST_HOURS)%'
     memories.weather.openweather.source: '%env(default:openweather:string:MEMORIES_WEATHER_SOURCE)%'
-    memories.weather.cache_namespace: '%env(default:memories_weather:string:MEMORIES_WEATHER_CACHE_NAMESPACE)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -784,23 +784,14 @@ services:
         alias: MagicSunday\Memories\Service\Feed\MemoryFeedBuilder
 
     # Weather
-    memories.weather.cache:
-        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
-        arguments:
-            - '%memories.weather.cache_namespace%'
-            - '%memories.weather.openweather.cache_ttl%'
-            - '%kernel.cache_dir%/weather'
-
     MagicSunday\Memories\Service\Weather\NullWeatherHintProvider: ~
 
     MagicSunday\Memories\Service\Weather\OpenWeatherHintProvider:
         arguments:
             $http: '@Symfony\Contracts\HttpClient\HttpClientInterface'
-            $cache: '@memories.weather.cache'
             $storage: '@MagicSunday\Memories\Service\Weather\WeatherObservationStorageInterface'
             $baseUrl: '%memories.weather.openweather.base_url%'
             $apiKey: '%memories.weather.openweather.api_key%'
-            $cacheTtl: '%memories.weather.openweather.cache_ttl%'
             $maxPastHours: '%memories.weather.openweather.max_past_hours%'
             $source: '%memories.weather.openweather.source%'
 


### PR DESCRIPTION
## Summary
- remove the Symfony cache dependency from the OpenWeather hint provider and persist fetched observations directly through storage
- drop the dedicated weather cache service parameters from the container configuration
- update the OpenWeather hint provider unit tests to reflect database-backed reuse of previously fetched observations

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php not found in container)*
- vendor/bin/phpunit test/Unit/Service/Weather/OpenWeatherHintProviderTest.php


------
https://chatgpt.com/codex/tasks/task_e_68d94e0a60288323939ee0096035ffa6