### PR TITLE
Fix weather configuration fallback for max past hours

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -182,5 +182,6 @@ parameters:
     memories.weather.enabled: '%env(default:false:bool:MEMORIES_WEATHER_ENABLED)%'
     memories.weather.openweather.base_url: '%env(default::string:OPENWEATHER_BASE_URL)%'
     memories.weather.openweather.api_key: '%env(default::string:OPENWEATHER_API_KEY)%'
-    memories.weather.openweather.max_past_hours: '%env(default:120:int:MEMORIES_WEATHER_MAX_PAST_HOURS)%'
+    memories.weather.openweather.max_past_hours_default: 120
+    memories.weather.openweather.max_past_hours: '%env(default:memories.weather.openweather.max_past_hours_default:int:MEMORIES_WEATHER_MAX_PAST_HOURS)%'
     memories.weather.openweather.source: '%env(default:openweather:string:MEMORIES_WEATHER_SOURCE)%'


### PR DESCRIPTION
## Summary
- add an explicit container parameter for the weather max past hours default
- use the new parameter as the fallback for the MEMORIES_WEATHER_MAX_PAST_HOURS env var so container compilation succeeds without the env var set

## Testing
- `composer ci:test` *(fails: bin/php vendor binary is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d951fdb5b08323a303d94c12b3d229