### PR TITLE
Fix weather enabled default fallback

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -179,8 +179,11 @@ parameters:
     memories.feed.max_per_algorithm: 12
 
     # Weather
-    memories.weather.enabled: '%env(default:false:bool:MEMORIES_WEATHER_ENABLED)%'
+    memories.weather.enabled_default: false
+    memories.weather.enabled: '%env(default:memories.weather.enabled_default:bool:MEMORIES_WEATHER_ENABLED)%'
     memories.weather.openweather.base_url: '%env(default::string:OPENWEATHER_BASE_URL)%'
     memories.weather.openweather.api_key: '%env(default::string:OPENWEATHER_API_KEY)%'
-    memories.weather.openweather.max_past_hours: '%env(default:120:int:MEMORIES_WEATHER_MAX_PAST_HOURS)%'
-    memories.weather.openweather.source: '%env(default:openweather:string:MEMORIES_WEATHER_SOURCE)%'
+    memories.weather.openweather.max_past_hours_default: 120
+    memories.weather.openweather.max_past_hours: '%env(default:memories.weather.openweather.max_past_hours_default:int:MEMORIES_WEATHER_MAX_PAST_HOURS)%'
+    memories.weather.openweather.source_default: 'openweather'
+    memories.weather.openweather.source: '%env(default:memories.weather.openweather.source_default:string:MEMORIES_WEATHER_SOURCE)%'


### PR DESCRIPTION
## Summary
- add a dedicated parameter storing the default weather toggle state
- use the new parameter as the fallback for MEMORIES_WEATHER_ENABLED to avoid missing parameter runtime errors

## Testing
- `composer ci:test` *(fails: bin/php vendor binary is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d951fdb5b08323a303d94c12b3d229