### PR TITLE
Fix weather observation schema initialization

### DIFF
--- a/src/Doctrine/EntityManagerFactory.php
+++ b/src/Doctrine/EntityManagerFactory.php
@@ -20,6 +20,7 @@ use MagicSunday\Memories\Entity\Cluster;
 use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Entity\Memory;
+use MagicSunday\Memories\Entity\WeatherObservation;
 use Throwable;
 use function class_exists;
 use function count;
@@ -72,6 +73,7 @@ final class EntityManagerFactory
             Cluster::class,
             Memory::class,
             Location::class,
+            WeatherObservation::class,
         ];
 
         $metadata = [];


### PR DESCRIPTION
## Summary
- include the WeatherObservation entity when syncing the Doctrine schema so the table is created during boot

## Testing
- composer ci:test *(fails: `bin/php` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d960df0e088323b9a9a14b5093d915