### PR TITLE
docs: document .env defaults

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,36 +1,56 @@
 # Memories CLI configuration (.env.dist)
 # Copy to .env and adjust values. Lines starting with # are comments.
 
+# Numeric user identifier used when running Docker containers or generated files.
 USERID=1000
+# Numeric group identifier matching USERID.
 GROUPID=1000
 
 # --- Database ---
+# Hostname or IP of the MySQL/MariaDB instance that stores metadata.
 DB_HOST=127.0.0.1
+# TCP port of the database server.
 DB_PORT=3306
+# Database schema name used by Photo Memories.
 DB_NAME=memories
+# Database login username.
 DB_USER=memories
+# Database login password.
 DB_PASS=memories
 
+# Latitude of your home location (used for distance-based features).
 MEMORIES_HOME_LAT=
+# Longitude of your home location (used for distance-based features).
 MEMORIES_HOME_LON=
 
-# Verzeichnisse
+# --- Directories ---
+# Absolute path where original media files are stored.
 MEMORIES_MEDIA_DIR=/var/lib/memories/media
+# Absolute path where generated thumbnails will be written.
 MEMORIES_THUMBNAIL_DIR=/var/lib/memories/thumbnails
 
-# Spracheinstellungen
+# --- Locale ---
+# Preferred locale for CLI output and formatting (ISO language code).
 MEMORIES_PREFERRED_LOCALE=DE
 
-# Tools
+# --- External tools ---
+# Location of the ffprobe binary used for video metadata extraction.
 FFPROBE_PATH=/usr/bin/ffprobe
 
-# Nominatim – bitte eigene Kontaktadresse angeben
+# --- Nominatim (reverse geocoding) ---
+# Base URL of the Nominatim API endpoint.
 NOMINATIM_BASE_URL="https://nominatim.openstreetmap.org"
+# Contact email address sent with Nominatim requests (required by usage policy).
 NOMINATIM_EMAIL="you@example.com"
 
-# Wetter-Hinweise
+# --- Weather hints ---
+# Set to 1 to enable weather hint enrichment for memories, 0 to disable.
 MEMORIES_WEATHER_ENABLED=0
+# Base URL for the OpenWeather timemachine endpoint.
 OPENWEATHER_BASE_URL="https://api.openweathermap.org/data/3.0/onecall/timemachine"
+# API key used for OpenWeather requests.
 OPENWEATHER_API_KEY=
+# Maximum age of media (in hours) for which weather data will be requested; 0 disables the limit.
 MEMORIES_WEATHER_MAX_PAST_HOURS=120
+# Identifier for the weather provider to use.
 MEMORIES_WEATHER_SOURCE=openweather


### PR DESCRIPTION
## Summary
- add English descriptions for each environment variable in `.env.dist`

## Testing
- composer ci:test *(fails: `bin/php` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da178d7afc8323b93a4a82e4196ee9