### PR TITLE
Restrict Overpass POIs to curated sightseeing categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Photo Memories enriches locations with nearby points of interest fetched from th
 capture all available `name:*` variants plus optional `alt_name` entries. The application stores them in a dedicated `names`
 structure alongside the legacy `name` field so consumers can choose the most appropriate label for their locale.
 
+By default the Overpass enrichment focuses on sightseeing-related categories to reduce noise. The whitelist currently includes:
+
+| Tag key   | Allowed values                      |
+|-----------|-------------------------------------|
+| `tourism` | `attraction`, `viewpoint`, `museum`, `gallery` |
+| `historic`| `monument`, `castle`, `memorial`     |
+| `man_made`| `tower`, `lighthouse`               |
+| `leisure` | `park`, `garden`                    |
+| `natural` | `peak`, `cliff`                     |
+
+You can extend this list without touching the code by overriding the Symfony parameter
+`memories.geocoding.overpass.allowed_pois` (e.g. in `config/parameters.local.yaml` or environment specific configuration).
+The entries are merged with the defaults so new keys or values become part of the Overpass query and validation pipeline.
+
 To control which language is preferred when rendering titles or cluster labels, configure the new
 `MEMORIES_PREFERRED_LOCALE` environment variable (or its matching Symfony container parameter
 `memories.localization.preferred_locale`). When set, `LocationHelper::displayLabel()` and related helpers first attempt to use

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -21,6 +21,7 @@ parameters:
     memories.geocoding.overpass.radius_m: 250
     memories.geocoding.overpass.max_pois: 15
     memories.geocoding.overpass.fetch_limit_multiplier: 3.0
+    memories.geocoding.overpass.allowed_pois: []
     memories.localization.preferred_locale: '%env(default::string:MEMORIES_PREFERRED_LOCALE)%'
 
     # Thumbnail-Größen (px)

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -149,6 +149,7 @@ services:
             $contactEmail: '%memories.geocoding.nominatim.email%'
             $queryTimeout: '%memories.geocoding.overpass.timeout%'
             $httpTimeout: '%memories.geocoding.overpass.timeout%'
+            $additionalAllowedTags: '%memories.geocoding.overpass.allowed_pois%'
 
     MagicSunday\Memories\Service\Geocoding\LocationPoiEnricher:
         arguments:

--- a/src/Utility/LocationHelper.php
+++ b/src/Utility/LocationHelper.php
@@ -63,10 +63,7 @@ final readonly class LocationHelper
         'leisure'  => 140,
         'natural'  => 140,
         'place'    => 130,
-        'amenity'  => 100,
-        'building' => 70,
         'sport'    => 60,
-        'shop'     => 40,
         'landuse'  => 25,
     ];
 
@@ -80,12 +77,9 @@ final readonly class LocationHelper
         'historic' => 180,
         'man_made' => 150,
         'leisure'  => 90,
-        'amenity'  => 80,
         'natural'  => 90,
         'place'    => 80,
-        'building' => 60,
         'sport'    => 50,
-        'shop'     => 40,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- add a curated allow-list of sightseeing Overpass tags and filter both queries and responses against it
- expose an optional configuration parameter for extending the allowed tags and adjust LocationHelper scoring
- refresh POI enrichment tests and documentation to cover museums, viewpoints and towers while excluding cafes

## Testing
- composer ci:test *(fails: bin/php is not available in the container)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter LocationPoiEnricherTest


------
https://chatgpt.com/codex/tasks/task_e_68da2308c94c8323b7abece593858f39