### PR TITLE
feat: support composite Overpass tag combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,31 @@ Photo Memories enriches locations with nearby points of interest fetched from th
 capture all available `name:*` variants plus optional `alt_name` entries. The application stores them in a dedicated `names`
 structure alongside the legacy `name` field so consumers can choose the most appropriate label for their locale.
 
-By default the Overpass enrichment focuses on sightseeing-related categories to reduce noise. The whitelist currently includes:
+By default the Overpass enrichment focuses on sightseeing-related categories to reduce noise. Each query block is described by a
+combination of tags that must match together. The bundled combinations are:
 
-| Tag key   | Allowed values                      |
-|-----------|-------------------------------------|
-| `tourism` | `attraction`, `viewpoint`, `museum`, `gallery` |
-| `historic`| `monument`, `castle`, `memorial`     |
-| `man_made`| `tower`, `lighthouse`               |
-| `leisure` | `park`, `garden`                    |
-| `natural` | `peak`, `cliff`                     |
+| Combination |
+|-------------|
+| `tourism` in {`attraction`, `viewpoint`, `museum`, `gallery`} |
+| `historic` in {`monument`, `castle`, `memorial`} |
+| `man_made` in {`tower`, `lighthouse`} |
+| `leisure` in {`park`, `garden`} |
+| `natural` in {`peak`, `cliff`} |
 
 You can extend this list without touching the code by overriding the Symfony parameter
 `memories.geocoding.overpass.allowed_pois` (e.g. in `config/parameters.local.yaml` or environment specific configuration).
-The entries are merged with the defaults so new keys or values become part of the Overpass query and validation pipeline.
+Provide it as a list of combinations, where each entry defines the required tags for one `nwr` block:
+
+```yaml
+memories.geocoding.overpass.allowed_pois:
+  -
+    tourism: [ 'attraction' ]
+    historic: [ 'castle', 'ruins' ]
+  -
+    tourism: [ 'theme_park' ]
+```
+
+Entries are merged with the defaults so new keys or values become part of both the Overpass query and the tag validation pipeline.
 
 To control which language is preferred when rendering titles or cluster labels, configure the new
 `MEMORIES_PREFERRED_LOCALE` environment variable (or its matching Symfony container parameter

--- a/test/Unit/Service/Geocoding/OverpassClientTest.php
+++ b/test/Unit/Service/Geocoding/OverpassClientTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\OverpassClient;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+final class OverpassClientTest extends TestCase
+{
+    #[Test]
+    public function buildsQueryUsingTagCombinations(): void
+    {
+        $response = new StaticJsonResponse(200, [
+            'elements' => [
+                [
+                    'type' => 'node',
+                    'id'   => 1,
+                    'lat'  => 1.23,
+                    'lon'  => 3.21,
+                    'tags' => [
+                        'name'    => 'Example Park',
+                        'tourism' => 'theme_park',
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = new RecordingHttpClient($response);
+
+        $overpass = new OverpassClient(
+            http: $client,
+            additionalAllowedTags: [
+                [
+                    'tourism' => ['attraction'],
+                    'historic' => ['castle', 'ruins'],
+                ],
+                [
+                    'tourism' => ['theme_park'],
+                ],
+            ],
+        );
+
+        $pois = $overpass->fetchPois(1.23, 3.21, 250, null);
+
+        self::assertNotSame('', $client->lastQuery);
+        self::assertStringContainsString('nwr(around:250,1.2300000,3.2100000)["tourism"="theme_park"]', $client->lastQuery);
+        self::assertStringContainsString('["tourism"="attraction"]["historic"~"^(castle|ruins)$"]', $client->lastQuery);
+
+        self::assertCount(1, $pois);
+        $firstPoi = $pois[0];
+
+        self::assertSame('tourism', $firstPoi['categoryKey']);
+        self::assertSame('theme_park', $firstPoi['categoryValue']);
+    }
+}
+
+final class RecordingHttpClient implements HttpClientInterface
+{
+    public string $lastQuery = '';
+
+    public function __construct(private readonly ResponseInterface $response)
+    {
+    }
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $data = $options['body']['data'] ?? null;
+        $this->lastQuery = is_string($data) ? $data : '';
+
+        return $this->response;
+    }
+
+    public function stream($responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function withOptions(array $options): static
+    {
+        return $this;
+    }
+}
+
+final readonly class StaticJsonResponse implements ResponseInterface
+{
+    public function __construct(
+        private int $statusCode,
+        private array $payload,
+    ) {
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        return [];
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        return '';
+    }
+
+    public function toArray(bool $throw = true): array
+    {
+        return $this->payload;
+    }
+
+    public function cancel(): void
+    {
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- restructure the Overpass client to keep default and configured tag combinations while preserving a flattened lookup map
- emit Overpass queries that include per-combination filters with either exact matches or regexes and support escaped values
- document the new configuration schema for `memories.geocoding.overpass.allowed_pois` and cover the behaviour with a dedicated unit test

## Testing
- composer ci:test:php:unit

------
https://chatgpt.com/codex/tasks/task_e_68da65a841a48323893fa295cd3010da