### PR TITLE
Fix geocode POI refresh handling

### DIFF
--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -75,6 +75,10 @@ final class GeocodeCommand extends Command
         $missingPois = (bool) $input->getOption('missing-pois');
         $refreshPois = (bool) $input->getOption('refresh-pois');
 
+        if ($refreshPois) {
+            $all = true;
+        }
+
         $io->title('🗺️  Orte ermitteln');
 
         if ($missingPois) {
@@ -126,7 +130,7 @@ final class GeocodeCommand extends Command
         $batchSize = 10; // kleinerer Batch verringert Datenverlust bei Fehlern
         foreach ($medias as $m) {
             $bar->setMessage('Rückwärtssuche');
-            $loc = $this->linker->link($m, 'de');
+            $loc = $this->linker->link($m, 'de', $refreshPois);
 
             if ($loc instanceof Location) {
                 ++$linked;

--- a/src/Service/Geocoding/MediaLocationLinker.php
+++ b/src/Service/Geocoding/MediaLocationLinker.php
@@ -35,7 +35,7 @@ final class MediaLocationLinker
     ) {
     }
 
-    public function link(Media $media, string $acceptLanguage = 'de'): ?Location
+    public function link(Media $media, string $acceptLanguage = 'de', bool $forceRefreshPois = false): ?Location
     {
         $this->lastNetworkCalls = 0;
 
@@ -50,7 +50,7 @@ final class MediaLocationLinker
         // 1) in-run cache first
         if (isset($this->cellCache[$cell])) {
             $loc = $this->cellCache[$cell];
-            $this->ensurePois($loc);
+            $this->ensurePois($loc, $forceRefreshPois);
             $media->setLocation($loc);
 
             return $loc;
@@ -60,7 +60,7 @@ final class MediaLocationLinker
         $fromIndex = $this->cellIndex->findByCell($cell);
         if ($fromIndex instanceof Location) {
             $this->cellCache[$cell] = $fromIndex;
-            $this->ensurePois($fromIndex);
+            $this->ensurePois($fromIndex, $forceRefreshPois);
             $media->setLocation($fromIndex);
 
             return $fromIndex;
@@ -104,9 +104,9 @@ final class MediaLocationLinker
         return sprintf('%.4f,%.4f', $rlat, $rlon);
     }
 
-    private function ensurePois(Location $location): void
+    private function ensurePois(Location $location, bool $forceRefresh): void
     {
-        $this->resolver->ensurePois($location);
+        $this->resolver->ensurePois($location, $forceRefresh);
 
         if ($this->resolver->consumeLastUsedNetwork()) {
             ++$this->lastNetworkCalls;


### PR DESCRIPTION
## Summary
- ensure the `--refresh-pois` flag on the geocode command forces all GPS media to be processed
- allow the media location linker to refresh POI data when requested so cached locations are re-enriched

## Testing
- composer ci:test *(fails: `bin/php` not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9fb401608323b3f415ccde7ae589