### PR TITLE
Fix refresh-pois command to skip media iteration

### DIFF
--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -78,10 +78,6 @@ final class GeocodeCommand extends Command
         $missingPois = (bool) $input->getOption('missing-pois');
         $refreshPois = (bool) $input->getOption('refresh-pois');
 
-        if ($refreshPois) {
-            $all = true;
-        }
-
         $io->title('🗺️  Orte ermitteln');
 
         if ($missingPois) {
@@ -105,7 +101,7 @@ final class GeocodeCommand extends Command
             ->where('m.gpsLat IS NOT NULL')
             ->andWhere('m.gpsLon IS NOT NULL');
 
-        if (!$all) {
+        if (!$all && !$refreshPois) {
             $qb->andWhere('m.location IS NULL');
         }
 


### PR DESCRIPTION
## Summary
- restore the refresh-pois shortcut so that the command refreshes stored locations instead of reprocessing every medium
- keep the media iteration path available for limited runs by skipping the location-is-null filter when refresh-pois is active

## Testing
- composer ci:test *(fails: bin/php not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac2e945a08323a652be63562a36a2