### PR TITLE
feat: allow configuring vacation home coordinates

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -407,6 +407,9 @@ services:
             $minAwayDistanceKm: 120.0
             $movementThresholdKm: 35.0
             $minItemsPerDay: 3
+            $homeLat: '%env(default::float:MEMORIES_HOME_LAT)%'
+            $homeLon: '%env(default::float:MEMORIES_HOME_LON)%'
+            $homeRadiusKm: '%env(default::float:MEMORIES_HOME_RADIUS_KM)%'
         tags:
             - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.vacation_cluster_strategy%' }
 

--- a/test/Unit/Clusterer/VacationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VacationClusterStrategyTest.php
@@ -21,9 +21,41 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Test\TestCase;
 use MagicSunday\Memories\Utility\LocationHelper;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
 
 final class VacationClusterStrategyTest extends TestCase
 {
+    #[Test]
+    public function returnsConfiguredHomeWhenCoordinatesAreProvided(): void
+    {
+        $helper = new LocationHelper();
+        $strategy = new VacationClusterStrategy(
+            locationHelper: $helper,
+            timezone: 'Europe/Berlin',
+            defaultHomeRadiusKm: 10.0,
+            minAwayDistanceKm: 60.0,
+            movementThresholdKm: 25.0,
+            minItemsPerDay: 2,
+            homeLat: 52.5200,
+            homeLon: 13.4050,
+            homeRadiusKm: 8.0,
+        );
+
+        $reflection = new ReflectionClass($strategy);
+        $method = $reflection->getMethod('determineHome');
+        $method->setAccessible(true);
+
+        /** @var array{lat:float,lon:float,radius_km:float,country:?string,timezone_offset:?int}|null $home */
+        $home = $method->invoke($strategy, []);
+
+        self::assertNotNull($home);
+        self::assertSame(52.5200, $home['lat']);
+        self::assertSame(13.4050, $home['lon']);
+        self::assertSame(8.0, $home['radius_km']);
+        self::assertSame('de', $home['country']);
+        self::assertIsInt($home['timezone_offset']);
+    }
+
     #[Test]
     public function classifiesExtendedInternationalVacation(): void
     {


### PR DESCRIPTION
## Summary
- allow VacationClusterStrategy to accept configured home coordinates and radius overrides
- respect environment-provided home coordinates in service wiring
- cover the coordinate override path with a dedicated unit test

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dafb62bd48832393305621b62d56b4