### PR TITLE
Fix DST handling in vacation clustering

### DIFF
--- a/src/Clusterer/Support/ConsecutiveDaysTrait.php
+++ b/src/Clusterer/Support/ConsecutiveDaysTrait.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer\Support;
 
-use function strtotime;
+use DateTimeImmutable;
+use DateTimeZone;
 
 /**
  * Helper trait providing utilities for working with consecutive day strings.
@@ -20,13 +21,15 @@ trait ConsecutiveDaysTrait
 {
     private function isNextDay(string $a, string $b): bool
     {
-        $ta = strtotime($a . ' 00:00:00');
-        $tb = strtotime($b . ' 00:00:00');
+        $timezone = new DateTimeZone('UTC');
 
-        if ($ta === false || $tb === false) {
+        $first = DateTimeImmutable::createFromFormat('!Y-m-d', $a, $timezone);
+        $second = DateTimeImmutable::createFromFormat('!Y-m-d', $b, $timezone);
+
+        if ($first === false || $second === false) {
             return false;
         }
 
-        return ($tb - $ta) === 86400;
+        return $first->modify('+1 day')->format('Y-m-d') === $second->format('Y-m-d');
     }
 }


### PR DESCRIPTION
## Summary
- normalise consecutive-day detection against UTC to avoid DST breaks when grouping vacation segments
- cover DST transitions in vacation clustering tests and expose `isNextDay` behaviour through reflection
- ensure existing home-configuration test provides a holiday resolver stub

## Testing
- `vendor/bin/phpunit test/Unit/Clusterer/VacationClusterStrategyTest.php`
- `composer ci:test` *(fails: `bin/php` not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db009a74208323976a702f56b64f0e