### PR TITLE
Refactor calendar enricher to use shared calendar helper

### DIFF
--- a/src/Service/Metadata/CalendarFeatureEnricher.php
+++ b/src/Service/Metadata/CalendarFeatureEnricher.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Metadata;
 
 use DateTimeImmutable;
-use DateTimeZone;
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\Calendar;
 
 use function sprintf;
 
@@ -75,12 +75,7 @@ final class CalendarFeatureEnricher implements SingleMetadataExtractorInterface
             return [true, $fixed[$md] . '-' . $y];
         }
 
-        $easter = $this->easterDate($y);
-        $tz     = new DateTimeZone('UTC');
-        $origin = DateTimeImmutable::createFromFormat('Y-m-d', $easter, $tz);
-        if (!$origin instanceof DateTimeImmutable) {
-            return [false, null];
-        }
+        $origin = Calendar::easterSunday($y);
 
         $rel = [
             -2  => 'de-goodfriday',
@@ -101,25 +96,5 @@ final class CalendarFeatureEnricher implements SingleMetadataExtractorInterface
         }
 
         return [false, null];
-    }
-
-    private function easterDate(int $y): string
-    {
-        $a     = $y % 19;
-        $b     = intdiv($y, 100);
-        $c     = $y % 100;
-        $d     = intdiv($b, 4);
-        $e     = $b % 4;
-        $f     = intdiv($b + 8, 25);
-        $g     = intdiv($b - $f + 1, 3);
-        $h     = (19 * $a + $b - $d - $g + 15) % 30;
-        $i     = intdiv($c, 4);
-        $k     = $c % 4;
-        $l     = (32 + 2 * $e + 2 * $i - $h - $k) % 7;
-        $m     = intdiv($a + 11 * $h + 22 * $l, 451);
-        $month = intdiv($h + $l - 7 * $m + 114, 31);
-        $day   = (($h + $l - 7 * $m + 114) % 31) + 1;
-
-        return sprintf('%04d-%02d-%02d', $y, $month, $day);
     }
 }

--- a/test/Unit/Service/Metadata/CalendarFeatureEnricherTest.php
+++ b/test/Unit/Service/Metadata/CalendarFeatureEnricherTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CalendarFeatureEnricherTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('germanHolidayProvider')]
+    public function marksGermanHolidays(DateTimeImmutable $date, string $expectedId): void
+    {
+        $media = $this->makeMedia(
+            id: 1,
+            path: '/fixtures/holiday.jpg',
+            takenAt: $date,
+        );
+
+        $enricher = new CalendarFeatureEnricher();
+        $result   = $enricher->extract($media->getPath(), $media);
+
+        $features = $result->getFeatures();
+
+        self::assertIsArray($features);
+        self::assertTrue($features['isHoliday']);
+        self::assertSame($expectedId, $features['holidayId']);
+    }
+
+    /**
+     * @return iterable<string, array{DateTimeImmutable, string}>
+     */
+    public static function germanHolidayProvider(): iterable
+    {
+        yield 'good friday' => [
+            new DateTimeImmutable('2024-03-29T10:00:00+00:00'),
+            'de-goodfriday-2024',
+        ];
+
+        yield 'easter monday' => [
+            new DateTimeImmutable('2024-04-01T09:30:00+00:00'),
+            'de-eastermon-2024',
+        ];
+
+        yield 'ascension day' => [
+            new DateTimeImmutable('2024-05-09T12:00:00+00:00'),
+            'de-ascension-2024',
+        ];
+
+        yield 'whit monday' => [
+            new DateTimeImmutable('2024-05-20T08:15:00+00:00'),
+            'de-whitmonday-2024',
+        ];
+
+        yield 'german unity day' => [
+            new DateTimeImmutable('2024-10-03T14:45:00+00:00'),
+            'de-unity-2024',
+        ];
+    }
+
+    #[Test]
+    public function leavesNonHolidayUnchanged(): void
+    {
+        $media = $this->makeMedia(
+            id: 2,
+            path: '/fixtures/plain-day.jpg',
+            takenAt: new DateTimeImmutable('2024-02-15T11:00:00+00:00'),
+        );
+
+        $enricher = new CalendarFeatureEnricher();
+        $result   = $enricher->extract($media->getPath(), $media);
+
+        $features = $result->getFeatures();
+
+        self::assertIsArray($features);
+        self::assertFalse($features['isHoliday']);
+        self::assertArrayNotHasKey('holidayId', $features);
+    }
+}


### PR DESCRIPTION
## Summary
- reuse the shared Calendar::easterSunday helper in the metadata enricher and drop the duplicate algorithm
- add focused unit coverage to ensure German holiday flags are still produced correctly

## Testing
- composer ci:test *(fails: bin/php not found in container)*
- vendor/bin/phpunit --configuration .build/phpunit.xml --filter CalendarFeatureEnricherTest

------
https://chatgpt.com/codex/tasks/task_e_68db73cd1b9c8323828f3b59153bbabf