### PR TITLE
Fix cluster strategies default dependencies

### DIFF
--- a/src/Clusterer/VacationClusterStrategy.php
+++ b/src/Clusterer/VacationClusterStrategy.php
@@ -20,6 +20,7 @@ use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Clusterer\Scoring\HolidayResolverInterface;
+use MagicSunday\Memories\Service\Clusterer\Scoring\NullHolidayResolver;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
 
@@ -84,8 +85,8 @@ final readonly class VacationClusterStrategy implements ClusterStrategyInterface
     private const float WEEKEND_OR_HOLIDAY_BONUS = 0.35;
 
     public function __construct(
-        private LocationHelper $locationHelper,
-        private HolidayResolverInterface $holidayResolver,
+        private LocationHelper $locationHelper = new LocationHelper(),
+        private HolidayResolverInterface $holidayResolver = new NullHolidayResolver(),
         private string $timezone = 'Europe/Berlin',
         private float $defaultHomeRadiusKm = 15.0,
         private float $minAwayDistanceKm = 120.0,

--- a/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
+++ b/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
@@ -44,7 +44,7 @@ final readonly class WeekendGetawaysOverYearsClusterStrategy implements ClusterS
     use MediaFilterTrait;
 
     public function __construct(
-        private LocationHelper $locHelper,
+        private LocationHelper $locHelper = new LocationHelper(),
         private string $timezone = 'Europe/Berlin',
         private int $minNights = 1,
         private int $maxNights = 3,
@@ -296,7 +296,7 @@ final readonly class WeekendGetawaysOverYearsClusterStrategy implements ClusterS
 
         $runLocality = $this->majorityLocalityKey($run['items']);
         if ($runLocality === null) {
-            return false;
+            return true;
         }
 
         $firstDay = $runDays[0];
@@ -307,25 +307,17 @@ final readonly class WeekendGetawaysOverYearsClusterStrategy implements ClusterS
         $nextDay = $this->nextDayKey($sortedDays, $lastDay);
 
         if ($prevDay === null || $nextDay === null) {
-            return false;
+            return true;
         }
 
         $prevLocality = $dayLocality[$prevDay] ?? null;
         $nextLocality = $dayLocality[$nextDay] ?? null;
 
         if ($prevLocality === null || $nextLocality === null) {
-            return false;
+            return true;
         }
 
-        if ($prevLocality === $runLocality) {
-            return false;
-        }
-
-        if ($nextLocality === $runLocality) {
-            return false;
-        }
-
-        return true;
+        return $prevLocality !== $runLocality && $nextLocality !== $runLocality;
     }
 
     /**

--- a/src/Service/Clusterer/Scoring/NullHolidayResolver.php
+++ b/src/Service/Clusterer/Scoring/NullHolidayResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer\Scoring;
+
+use DateTimeImmutable;
+
+/**
+ * Fallback resolver that treats every day as a non-holiday.
+ */
+final class NullHolidayResolver implements HolidayResolverInterface
+{
+    public function isHoliday(DateTimeImmutable $day): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- allow vacation and weekend cluster strategies to instantiate without explicit helpers by providing sensible defaults
- relax weekend getaway locality guard to handle missing neighbour or locality data gracefully
- add a null holiday resolver fallback for unit tests and default wiring

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: bin/php vendor binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db7514973c83239c9b579a09611df1