### PR TITLE
Add missing environment variables to template

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,6 +1,12 @@
 # Memories CLI configuration (.env.dist)
 # Copy to .env and adjust values. Lines starting with # are comments.
 
+# --- Application runtime ---
+# Symfony environment name that determines which configuration files are loaded.
+APP_ENV=prod
+# Set to 1 to enable verbose debug output and detailed error traces, 0 for normal operation.
+APP_DEBUG=0
+
 # Numeric user identifier used when running Docker containers or generated files.
 USERID=1000
 # Numeric group identifier matching USERID.
@@ -22,6 +28,8 @@ DB_PASS=memories
 MEMORIES_HOME_LAT=
 # Longitude of your home location (used for distance-based features).
 MEMORIES_HOME_LON=
+# Radius around the home location (in kilometres) that still counts as being at home.
+MEMORIES_HOME_RADIUS_KM=15
 
 # --- Directories ---
 # Absolute path where original media files are stored.


### PR DESCRIPTION
## Summary
- add the runtime environment variables APP_ENV and APP_DEBUG to the example configuration
- document the MEMORIES_HOME_RADIUS_KM setting alongside its description in the template

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db7b38e3d88323b91cb0cceb1d1455