### PR TITLE
Expose visited countries and timezones in vacation clusters

### DIFF
--- a/src/Clusterer/VacationClusterStrategy.php
+++ b/src/Clusterer/VacationClusterStrategy.php
@@ -40,12 +40,14 @@ use function log;
 use function max;
 use function min;
 use function round;
+use function sort;
 use function sprintf;
 use function sqrt;
 use function str_contains;
 use function strtolower;
 use function usort;
 
+use const SORT_NUMERIC;
 use const SORT_STRING;
 
 /**
@@ -1040,6 +1042,18 @@ final readonly class VacationClusterStrategy implements ClusterStrategyInterface
             }
         }
 
+        $countries = [];
+        if ($countryCodes !== []) {
+            $countries = array_keys($countryCodes);
+            sort($countries, SORT_STRING);
+        }
+
+        $timezones = [];
+        if ($timezoneOffsets !== []) {
+            $timezones = array_keys($timezoneOffsets);
+            sort($timezones, SORT_NUMERIC);
+        }
+
         $airportFlag = false;
         $firstDay = $days[$dayKeys[0]];
         $lastDay  = $days[$dayKeys[$dayCount - 1]];
@@ -1130,6 +1144,8 @@ final readonly class VacationClusterStrategy implements ClusterStrategyInterface
             'spot_exploration_bonus' => round($explorationBonus, 2),
             'weekend_holiday_days' => $weekendHolidayDays,
             'weekend_holiday_bonus' => round($weekendHolidayBonus, 2),
+            'countries'            => $countries,
+            'timezones'            => $timezones,
         ];
 
         if ($place !== null) {

--- a/test/Unit/Clusterer/VacationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VacationClusterStrategyTest.php
@@ -204,6 +204,8 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertArrayHasKey('spot_cluster_days', $params);
         self::assertArrayHasKey('spot_dwell_hours', $params);
         self::assertArrayHasKey('spot_exploration_bonus', $params);
+        self::assertSame(['it'], $params['countries']);
+        self::assertSame([120], $params['timezones']);
     }
 
     #[Test]
@@ -411,6 +413,8 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertArrayHasKey('spot_exploration_bonus', $params);
         self::assertSame(2, $params['weekend_holiday_days']);
         self::assertGreaterThan(0.0, $params['weekend_holiday_bonus']);
+        self::assertSame(['de'], $params['countries']);
+        self::assertSame([120], $params['timezones']);
     }
 
     #[Test]
@@ -518,6 +522,8 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertSame(3, $params['weekend_holiday_days']);
         self::assertSame(1.05, $params['weekend_holiday_bonus']);
         self::assertGreaterThanOrEqual(8.0, $params['score']);
+        self::assertSame(['de'], $params['countries']);
+        self::assertSame([60], $params['timezones']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- include ordered lists of visited countries and timezones in the vacation cluster draft output
- extend the vacation cluster strategy unit coverage to assert the new params for international, regional, and holiday trips

## Testing
- composer ci:test *(fails: `bin/php` is missing in the container image)*
- composer ci:test:php:unit *(fails: `bin/php` is missing in the container image)*
- php vendor/bin/phpunit --configuration .build/phpunit.xml --filter classifiesRegionalWeekendAsShortTrip
- php vendor/bin/phpunit --configuration .build/phpunit.xml --filter awardsHolidayBonusOnWeekdays

------
https://chatgpt.com/codex/tasks/task_e_68db9005d35c832389b418cabbb42e7b