### PR TITLE
Update vacation cluster distance metric

### DIFF
--- a/test/Unit/Clusterer/VacationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VacationClusterStrategyTest.php
@@ -21,6 +21,7 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Clusterer\Scoring\HolidayResolverInterface;
 use MagicSunday\Memories\Test\TestCase;
 use MagicSunday\Memories\Utility\LocationHelper;
+use MagicSunday\Memories\Utility\MediaMath;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 
@@ -215,6 +216,17 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertSame(', Italy', $params['place_country']);
         self::assertArrayHasKey('place', $params);
         self::assertNotSame('', $params['place']);
+
+        $centroid = $cluster->getCentroid();
+        $expectedDistanceKm = MediaMath::haversineDistanceInMeters(
+            52.5200,
+            13.4050,
+            $centroid['lat'],
+            $centroid['lon'],
+        ) / 1000.0;
+
+        self::assertEqualsWithDelta($expectedDistanceKm, $params['max_distance_km'], 0.1);
+        self::assertGreaterThanOrEqual($params['max_distance_km'], $params['max_observed_distance_km']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- compute vacation cluster centroid before scoring and use its distance to home for scoring
- export both centroid-home distance and raw maximum observation in cluster parameters
- assert the new distance metric in the vacation cluster unit test

## Testing
- composer ci:test *(fails: `bin/php` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db98821ed08323a3f6e29d96b435ca