### PR TITLE
Refactor index command to use locator and pipeline services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -119,6 +119,26 @@ services:
         alias: MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor
 
     ########################################
+    # Indexing
+    ########################################
+
+    MagicSunday\Memories\Service\Indexing\DefaultMediaFileLocator:
+        arguments:
+            $imageExtensions: '%memories.index.image_ext%'
+            $videoExtensions: '%memories.index.video_ext%'
+
+    MagicSunday\Memories\Service\Indexing\MediaFileLocatorInterface:
+        alias: MagicSunday\Memories\Service\Indexing\DefaultMediaFileLocator
+
+    MagicSunday\Memories\Service\Indexing\DefaultMediaIngestionPipeline:
+        arguments:
+            $imageExtensions: '%memories.index.image_ext%'
+            $videoExtensions: '%memories.index.video_ext%'
+
+    MagicSunday\Memories\Service\Indexing\MediaIngestionPipelineInterface:
+        alias: MagicSunday\Memories\Service\Indexing\DefaultMediaIngestionPipeline
+
+    ########################################
     # Geocoding
     ########################################
 

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -11,14 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Command;
 
-use Doctrine\ORM\EntityManagerInterface;
-use FilesystemIterator;
-use finfo;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface;
-use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
+use MagicSunday\Memories\Service\Indexing\MediaFileLocatorInterface;
+use MagicSunday\Memories\Service\Indexing\MediaIngestionPipelineInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -27,25 +22,18 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Throwable;
 
 use function count;
-use function filesize;
-use function hash_file;
-use function in_array;
 use function is_dir;
 use function is_numeric;
-use function is_string;
-use function mime_content_type;
-use function pathinfo;
-use function preg_match;
-use function strtolower;
+use function iterator_to_array;
+use function sprintf;
 
 /**
  * Index media files: extract metadata and persist to DB.
  *
  * - Uses a fast extension whitelist to collect files.
- * - MIME detection is centralized via a single \finfo instance (with safe fallback).
+ * - MIME detection is centralized via the ingestion pipeline.
  * - Thumbnails are generated only if --thumbnails is provided.
  * - Existing entries are skipped unless --force is used (then they are updated).
  * - Progress bar can be disabled with --no-progress.
@@ -56,31 +44,13 @@ use function strtolower;
 )]
 final class IndexCommand extends Command
 {
-    /** @var string[] */
-    private readonly array $imageExt;
-
-    /** @var string[] */
-    private readonly array $videoExt;
-
     public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly MetadataExtractorInterface $metadataExtractor,
-        private readonly ThumbnailServiceInterface $thumbnailService,
+        private readonly MediaFileLocatorInterface $locator,
+        private readonly MediaIngestionPipelineInterface $pipeline,
         #[Autowire(env: 'MEMORIES_MEDIA_DIR')]
         private readonly string $defaultMediaDir,
-        #[Autowire(param: 'memories.index.image_ext')] ?array $imageExt = null,
-        #[Autowire(param: 'memories.index.video_ext')] ?array $videoExt = null,
     ) {
         parent::__construct();
-
-        // Sensible defaults if parameters are not provided via services.yaml
-        $this->imageExt = $imageExt ?? [
-            'jpg', 'jpeg', 'jpe', 'jxl', 'avif', 'heic', 'heif', 'png', 'webp', 'gif', 'bmp', 'tiff', 'tif',
-            'cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng',
-        ];
-        $this->videoExt = $videoExt ?? [
-            'mp4', 'm4v', 'mov', '3gp', '3g2', 'avi', 'mkv', 'webm',
-        ];
     }
 
     protected function configure(): void
@@ -117,8 +87,7 @@ final class IndexCommand extends Command
             $output->writeln('<comment>Strikter MIME-Check ist aktiv.</comment>');
         }
 
-        // Collect files using extension whitelist (fast)
-        $files = $this->collectMediaFilesByExtension($path, $maxFiles);
+        $files = iterator_to_array($this->locator->locate($path, $maxFiles));
         $total = count($files);
 
         if ($total === 0) {
@@ -127,10 +96,6 @@ final class IndexCommand extends Command
             return Command::SUCCESS;
         }
 
-        // Shared finfo instance for this run
-        $finfo = new finfo(FILEINFO_MIME_TYPE);
-
-        // Optional progress bar
         $progress = null;
         if ($noProgress === false) {
             $progress = new ProgressBar($output, $total);
@@ -140,105 +105,33 @@ final class IndexCommand extends Command
         }
 
         $count = 0;
-        $batch = 0;
 
         foreach ($files as $filepath) {
             if ($progress instanceof ProgressBar) {
                 $progress->setMessage($filepath, 'filename');
             }
 
-            // MIME detection (shared finfo + fallback)
-            $detectedMime = $this->detectMime($filepath, $finfo);
-
-            // If strict MIME is enabled, enforce consistency with extension
-            if ($strictMime) {
-                $isImage = $this->isImageExt($filepath);
-                $isVideo = $this->isVideoExt($filepath);
-
-                if ($isImage && preg_match('#^image/#', $detectedMime) !== 1) {
-                    if ($progress instanceof ProgressBar) {
-                        $progress->advance();
-                    }
-
-                    continue;
-                }
-
-                if ($isVideo && preg_match('#^video/#', $detectedMime) !== 1) {
-                    if ($progress instanceof ProgressBar) {
-                        $progress->advance();
-                    }
-
-                    continue;
-                }
-            }
-
             $output->writeln('Verarbeite: ' . $filepath, OutputInterface::VERBOSITY_VERBOSE);
 
-            $checksum = @hash_file('sha256', $filepath);
-            if ($checksum === false) {
-                $output->writeln(sprintf('<error>Could not compute checksum for file: %s</error>', $filepath));
-                if ($progress instanceof ProgressBar) {
-                    $progress->advance();
-                }
+            $result = $this->pipeline->process(
+                $filepath,
+                $force,
+                $dryRun,
+                $withThumbs,
+                $strictMime,
+                $output,
+            );
 
-                continue;
+            if ($result instanceof Media) {
+                ++$count;
             }
 
-            /** @var Media|null $existing */
-            $existing = $this->em->getRepository(Media::class)->findOneBy(['checksum' => $checksum]);
-
-            if ($existing !== null && $force === false) {
-                $output->writeln(' -> Übersprungen (bereits indexiert)', OutputInterface::VERBOSITY_VERBOSE);
-                if ($progress instanceof ProgressBar) {
-                    $progress->advance();
-                }
-
-                continue;
-            }
-
-            $size  = filesize($filepath) ?: 0;
-            $media = $existing ?? new Media($filepath, $checksum, $size);
-            $media->setMime($detectedMime);
-
-            // Extract metadata (EXIF/ffprobe) – no raw JSON is persisted
-            try {
-                $media = $this->metadataExtractor->extract($filepath, $media);
-            } catch (Throwable $e) {
-                $output->writeln(sprintf('<error>Metadata extraction failed for %s: %s</error>', $filepath, $e->getMessage()));
-            }
-
-            // Thumbnails only when requested
-            if ($withThumbs) {
-                try {
-                    $thumbnails = $this->thumbnailService->generateAll($filepath, $media);
-                    $media->setThumbnails($thumbnails);
-                } catch (Throwable $e) {
-                    $output->writeln(sprintf('<error>Thumbnail generation failed for %s: %s</error>', $filepath, $e->getMessage()));
-                }
-            }
-
-            if ($dryRun === false) {
-                $this->em->persist($media);
-                ++$batch;
-
-                if ($batch >= 50) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $batch = 0;
-                }
-            } else {
-                $output->writeln(' (dry-run) ', OutputInterface::VERBOSITY_VERBOSE);
-            }
-
-            ++$count;
             if ($progress instanceof ProgressBar) {
                 $progress->advance();
             }
         }
 
-        if ($dryRun === false) {
-            $this->em->flush();
-        }
+        $this->pipeline->finalize($dryRun);
 
         if ($progress instanceof ProgressBar) {
             $progress->finish();
@@ -248,60 +141,6 @@ final class IndexCommand extends Command
         $output->writeln(sprintf('<info>Indexierung abgeschlossen. Insgesamt verarbeitete Dateien: %d</info>', $count));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * Collect image/video files from a base directory using a fast extension whitelist.
-     *
-     * @return list<string>
-     */
-    private function collectMediaFilesByExtension(string $baseDir, ?int $maxFiles): array
-    {
-        $rii = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($baseDir, FilesystemIterator::SKIP_DOTS)
-        );
-
-        $out = [];
-        foreach ($rii as $fileInfo) {
-            if (!$fileInfo->isFile()) {
-                continue;
-            }
-
-            $path = $fileInfo->getPathname();
-            if ($this->isSupportedByExtension($path) === false) {
-                continue;
-            }
-
-            $out[] = $path;
-            if ($maxFiles !== null && count($out) >= $maxFiles) {
-                break;
-            }
-        }
-
-        return $out;
-    }
-
-    private function isSupportedByExtension(string $path): bool
-    {
-        if ($this->isImageExt($path)) {
-            return true;
-        }
-
-        return $this->isVideoExt($path);
-    }
-
-    private function isImageExt(string $path): bool
-    {
-        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-
-        return $ext !== '' && in_array($ext, $this->imageExt, true);
-    }
-
-    private function isVideoExt(string $path): bool
-    {
-        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-
-        return $ext !== '' && in_array($ext, $this->videoExt, true);
     }
 
     private function toIntOrNull(mixed $v): ?int
@@ -315,30 +154,5 @@ final class IndexCommand extends Command
         }
 
         return null;
-    }
-
-    /**
-     * Determine MIME type using a shared finfo instance with a safe fallback.
-     */
-    private function detectMime(string $path, finfo $finfo): string
-    {
-        $mime = '';
-        try {
-            $m = @$finfo->file($path);
-            if (is_string($m) && $m !== '') {
-                $mime = $m;
-            }
-        } catch (Throwable) {
-            // ignore and try fallback
-        }
-
-        if ($mime === '') {
-            $m = @mime_content_type($path);
-            if (is_string($m) && $m !== '') {
-                $mime = $m;
-            }
-        }
-
-        return $mime !== '' ? $mime : 'application/octet-stream';
     }
 }

--- a/src/Service/Indexing/DefaultMediaFileLocator.php
+++ b/src/Service/Indexing/DefaultMediaFileLocator.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use function in_array;
+use function pathinfo;
+use function strtolower;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Default implementation locating image and video files by extension.
+ */
+final class DefaultMediaFileLocator implements MediaFileLocatorInterface
+{
+    /**
+     * @var list<string>
+     */
+    private readonly array $imageExtensions;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $videoExtensions;
+
+    private const DEFAULT_IMAGE_EXT = [
+        'jpg', 'jpeg', 'jpe', 'jxl', 'avif', 'heic', 'heif', 'png', 'webp', 'gif', 'bmp', 'tiff', 'tif',
+        'cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng',
+    ];
+
+    private const DEFAULT_VIDEO_EXT = [
+        'mp4', 'm4v', 'mov', '3gp', '3g2', 'avi', 'mkv', 'webm',
+    ];
+
+    /**
+     * @param list<string>|null $imageExtensions
+     * @param list<string>|null $videoExtensions
+     */
+    public function __construct(
+        ?array $imageExtensions = null,
+        ?array $videoExtensions = null,
+    ) {
+        $this->imageExtensions = $imageExtensions ?? self::DEFAULT_IMAGE_EXT;
+        $this->videoExtensions = $videoExtensions ?? self::DEFAULT_VIDEO_EXT;
+    }
+
+    public function locate(string $baseDir, ?int $maxFiles = null): iterable
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($baseDir, FilesystemIterator::SKIP_DOTS)
+        );
+
+        $count = 0;
+
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo->isFile() === false) {
+                continue;
+            }
+
+            $path = $fileInfo->getPathname();
+            if ($this->isSupported($path) === false) {
+                continue;
+            }
+
+            yield $path;
+
+            if ($maxFiles !== null) {
+                ++$count;
+
+                if ($count >= $maxFiles) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private function isSupported(string $path): bool
+    {
+        if ($this->isImage($path)) {
+            return true;
+        }
+
+        return $this->isVideo($path);
+    }
+
+    private function isImage(string $path): bool
+    {
+        $ext = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->imageExtensions, true);
+    }
+
+    private function isVideo(string $path): bool
+    {
+        $ext = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->videoExtensions, true);
+    }
+}

--- a/src/Service/Indexing/DefaultMediaIngestionPipeline.php
+++ b/src/Service/Indexing/DefaultMediaIngestionPipeline.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing;
+
+use Doctrine\ORM\EntityManagerInterface;
+use finfo;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface;
+use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function filesize;
+use function hash_file;
+use function in_array;
+use function is_string;
+use function mime_content_type;
+use function pathinfo;
+use function preg_match;
+use function sprintf;
+use function strtolower;
+
+use const FILEINFO_MIME_TYPE;
+use const PATHINFO_EXTENSION;
+
+final class DefaultMediaIngestionPipeline implements MediaIngestionPipelineInterface
+{
+    private const BATCH_SIZE = 50;
+
+    private readonly finfo $finfo;
+
+    private int $batchCount = 0;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $imageExtensions;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $videoExtensions;
+
+    private const DEFAULT_IMAGE_EXT = [
+        'jpg', 'jpeg', 'jpe', 'jxl', 'avif', 'heic', 'heif', 'png', 'webp', 'gif', 'bmp', 'tiff', 'tif',
+        'cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng',
+    ];
+
+    private const DEFAULT_VIDEO_EXT = [
+        'mp4', 'm4v', 'mov', '3gp', '3g2', 'avi', 'mkv', 'webm',
+    ];
+
+    /**
+     * @param list<string>|null $imageExtensions
+     * @param list<string>|null $videoExtensions
+     */
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MetadataExtractorInterface $metadataExtractor,
+        private readonly ThumbnailServiceInterface $thumbnailService,
+        ?array $imageExtensions = null,
+        ?array $videoExtensions = null,
+    ) {
+        $this->imageExtensions = $imageExtensions ?? self::DEFAULT_IMAGE_EXT;
+        $this->videoExtensions = $videoExtensions ?? self::DEFAULT_VIDEO_EXT;
+        $this->finfo          = new finfo(FILEINFO_MIME_TYPE);
+    }
+
+    public function process(
+        string $filepath,
+        bool $force,
+        bool $dryRun,
+        bool $withThumbnails,
+        bool $strictMime,
+        OutputInterface $output
+    ): ?Media {
+        $detectedMime = $this->detectMime($filepath);
+
+        if ($strictMime && $this->isMimeConsistent($filepath, $detectedMime) === false) {
+            return null;
+        }
+
+        $checksum = @hash_file('sha256', $filepath);
+        if ($checksum === false) {
+            $output->writeln(sprintf('<error>Could not compute checksum for file: %s</error>', $filepath));
+
+            return null;
+        }
+
+        $repository = $this->entityManager->getRepository(Media::class);
+        $existing   = $repository->findOneBy(['checksum' => $checksum]);
+
+        if ($existing instanceof Media && $force === false) {
+            $output->writeln(' -> Übersprungen (bereits indexiert)', OutputInterface::VERBOSITY_VERBOSE);
+
+            return null;
+        }
+
+        $size  = filesize($filepath) ?: 0;
+        $media = $existing ?? new Media($filepath, $checksum, $size);
+        $media->setMime($detectedMime);
+
+        try {
+            $media = $this->metadataExtractor->extract($filepath, $media);
+        } catch (Throwable $exception) {
+            $output->writeln(
+                sprintf('<error>Metadata extraction failed for %s: %s</error>', $filepath, $exception->getMessage())
+            );
+        }
+
+        if ($withThumbnails) {
+            try {
+                $media->setThumbnails($this->thumbnailService->generateAll($filepath, $media));
+            } catch (Throwable $exception) {
+                $output->writeln(
+                    sprintf('<error>Thumbnail generation failed for %s: %s</error>', $filepath, $exception->getMessage())
+                );
+            }
+        }
+
+        if ($dryRun) {
+            $output->writeln(' (dry-run) ', OutputInterface::VERBOSITY_VERBOSE);
+
+            return $media;
+        }
+
+        $this->entityManager->persist($media);
+        ++$this->batchCount;
+
+        if ($this->batchCount >= self::BATCH_SIZE) {
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+            $this->batchCount = 0;
+        }
+
+        return $media;
+    }
+
+    public function finalize(bool $dryRun): void
+    {
+        if ($dryRun) {
+            $this->batchCount = 0;
+
+            return;
+        }
+
+        $this->entityManager->flush();
+        $this->batchCount = 0;
+    }
+
+    private function detectMime(string $path): string
+    {
+        $mime = '';
+
+        try {
+            $m = @$this->finfo->file($path);
+            if (is_string($m) && $m !== '') {
+                $mime = $m;
+            }
+        } catch (Throwable) {
+            // ignore and try fallback
+        }
+
+        if ($mime === '') {
+            $m = @mime_content_type($path);
+            if (is_string($m) && $m !== '') {
+                $mime = $m;
+            }
+        }
+
+        return $mime !== '' ? $mime : 'application/octet-stream';
+    }
+
+    private function isMimeConsistent(string $filepath, string $detectedMime): bool
+    {
+        if ($this->isImageExt($filepath)) {
+            return preg_match('#^image/#', $detectedMime) === 1;
+        }
+
+        if ($this->isVideoExt($filepath)) {
+            return preg_match('#^video/#', $detectedMime) === 1;
+        }
+
+        return true;
+    }
+
+    private function isImageExt(string $filepath): bool
+    {
+        $ext = strtolower((string) pathinfo($filepath, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->imageExtensions, true);
+    }
+
+    private function isVideoExt(string $filepath): bool
+    {
+        $ext = strtolower((string) pathinfo($filepath, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->videoExtensions, true);
+    }
+}

--- a/src/Service/Indexing/MediaFileLocatorInterface.php
+++ b/src/Service/Indexing/MediaFileLocatorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing;
+
+/**
+ * Locate media files that should be processed by the ingestion pipeline.
+ */
+interface MediaFileLocatorInterface
+{
+    /**
+     * Locate supported files under the given base directory.
+     *
+     * @return iterable<array-key, string>
+     */
+    public function locate(string $baseDir, ?int $maxFiles = null): iterable;
+}

--- a/src/Service/Indexing/MediaIngestionPipelineInterface.php
+++ b/src/Service/Indexing/MediaIngestionPipelineInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing;
+
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface MediaIngestionPipelineInterface
+{
+    public function process(
+        string $filepath,
+        bool $force,
+        bool $dryRun,
+        bool $withThumbnails,
+        bool $strictMime,
+        OutputInterface $output
+    ): ?Media;
+
+    public function finalize(bool $dryRun): void;
+}

--- a/test/Unit/Command/IndexCommandTest.php
+++ b/test/Unit/Command/IndexCommandTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Command;
+
+use MagicSunday\Memories\Command\IndexCommand;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Indexing\MediaFileLocatorInterface;
+use MagicSunday\Memories\Service\Indexing\MediaIngestionPipelineInterface;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use SplFileInfo;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class IndexCommandTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDirectory($dir);
+        }
+
+        $this->tempDirs = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function executeFailsWhenPathIsMissing(): void
+    {
+        $locator = $this->createMock(MediaFileLocatorInterface::class);
+        $locator->expects(self::never())->method('locate');
+
+        $pipeline = $this->createMock(MediaIngestionPipelineInterface::class);
+        $pipeline->expects(self::never())->method('process');
+        $pipeline->expects(self::never())->method('finalize');
+
+        $command = new IndexCommand($locator, $pipeline, sys_get_temp_dir());
+        $tester  = new CommandTester($command);
+
+        $status = $tester->execute([
+            'path' => '/does/not/exist',
+        ]);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('Pfad existiert nicht', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeDelegatesToLocatorAndPipeline(): void
+    {
+        $baseDir = $this->createTempDir();
+        $fileOne = $baseDir . '/one.jpg';
+        $fileTwo = $baseDir . '/two.jpg';
+        file_put_contents($fileOne, 'one');
+        file_put_contents($fileTwo, 'two');
+
+        $locator = $this->createMock(MediaFileLocatorInterface::class);
+        $locator->expects(self::once())
+            ->method('locate')
+            ->with($baseDir, null)
+            ->willReturn([$fileOne, $fileTwo]);
+
+        $processedMedia = new Media($fileOne, 'checksum', 3);
+
+        $pipeline = $this->createMock(MediaIngestionPipelineInterface::class);
+        $callCount = 0;
+        $pipeline->expects(self::exactly(2))
+            ->method('process')
+            ->willReturnCallback(function (string $file, bool $force, bool $dryRun, bool $withThumbnails, bool $strictMime, OutputInterface $output) use (&$callCount, $fileOne, $fileTwo, $processedMedia): ?Media {
+                ++$callCount;
+
+                self::assertFalse($force);
+                self::assertFalse($dryRun);
+                self::assertFalse($withThumbnails);
+                self::assertFalse($strictMime);
+                self::assertInstanceOf(OutputInterface::class, $output);
+
+                if ($callCount === 1) {
+                    self::assertSame($fileOne, $file);
+
+                    return $processedMedia;
+                }
+
+                if ($callCount === 2) {
+                    self::assertSame($fileTwo, $file);
+
+                    return null;
+                }
+
+                throw new \RuntimeException('Unexpected pipeline invocation.');
+            });
+        $pipeline->expects(self::once())
+            ->method('finalize')
+            ->with(false);
+
+        $command = new IndexCommand($locator, $pipeline, $baseDir);
+        $tester  = new CommandTester($command);
+
+        $tester->execute([
+            'path'          => $baseDir,
+            '--no-progress' => true,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        self::assertStringContainsString('Insgesamt verarbeitete Dateien: 1', $tester->getDisplay());
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/memories-command-' . uniqid('', true);
+
+        if (!is_dir($dir) && !mkdir($dir) && !is_dir($dir)) {
+            throw new \RuntimeException('Unable to create temporary directory: ' . $dir);
+        }
+
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo instanceof SplFileInfo && $fileInfo->isDir()) {
+                rmdir($fileInfo->getPathname());
+
+                continue;
+            }
+
+            unlink($fileInfo->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/test/Unit/Service/Indexing/DefaultMediaFileLocatorTest.php
+++ b/test/Unit/Service/Indexing/DefaultMediaFileLocatorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing;
+
+use MagicSunday\Memories\Service\Indexing\DefaultMediaFileLocator;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function array_values;
+use function count;
+use function file_put_contents;
+use function is_dir;
+use function iterator_to_array;
+use function mkdir;
+use function rmdir;
+use function sort;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class DefaultMediaFileLocatorTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDirectory($dir);
+        }
+
+        $this->tempDirs = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function locateReturnsOnlyConfiguredExtensions(): void
+    {
+        $baseDir = $this->createTempDir();
+
+        file_put_contents($baseDir . '/keep.jpg', 'jpg');
+        file_put_contents($baseDir . '/clip.mov', 'mov');
+        file_put_contents($baseDir . '/ignore.txt', 'txt');
+
+        mkdir($baseDir . '/nested');
+        file_put_contents($baseDir . '/nested/also.png', 'png');
+        file_put_contents($baseDir . '/nested/skip.gif', 'gif');
+
+        $locator = new DefaultMediaFileLocator(['jpg', 'png'], ['mov']);
+
+        $result = array_values(iterator_to_array($locator->locate($baseDir)));
+        sort($result);
+
+        $expected = [
+            $baseDir . '/clip.mov',
+            $baseDir . '/keep.jpg',
+            $baseDir . '/nested/also.png',
+        ];
+        sort($expected);
+
+        self::assertSame($expected, $result);
+    }
+
+    #[Test]
+    public function locateRespectsMaxFilesLimit(): void
+    {
+        $baseDir = $this->createTempDir();
+
+        file_put_contents($baseDir . '/one.jpg', '1');
+        file_put_contents($baseDir . '/two.jpg', '2');
+        file_put_contents($baseDir . '/three.jpg', '3');
+
+        $locator = new DefaultMediaFileLocator(['jpg'], []);
+
+        $limited = iterator_to_array($locator->locate($baseDir, 2));
+
+        self::assertSame(2, count($limited));
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/memories-indexing-' . uniqid('', true);
+
+        if (!is_dir($dir) && !mkdir($dir) && !is_dir($dir)) {
+            throw new \RuntimeException('Unable to create temporary directory: ' . $dir);
+        }
+
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo instanceof SplFileInfo && $fileInfo->isDir()) {
+                rmdir($fileInfo->getPathname());
+
+                continue;
+            }
+
+            unlink($fileInfo->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/test/Unit/Service/Indexing/DefaultMediaIngestionPipelineTest.php
+++ b/test/Unit/Service/Indexing/DefaultMediaIngestionPipelineTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Indexing\DefaultMediaIngestionPipeline;
+use MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface;
+use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function file_put_contents;
+use function filesize;
+use function hash_file;
+use function is_file;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class DefaultMediaIngestionPipelineTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->tempFiles = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function processSkipsExistingMediaWhenForceDisabled(): void
+    {
+        $path     = $this->createTempFile('jpg', 'existing');
+        $checksum = (string) hash_file('sha256', $path);
+        $media    = new Media($path, $checksum, (int) filesize($path));
+        $output  = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE);
+
+        $repository = $this->getMockBuilder(EntityRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findOneBy'])
+            ->getMock();
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn($media);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(Media::class)
+            ->willReturn($repository);
+        $entityManager->expects(self::never())->method('persist');
+
+        $metadataExtractor = $this->createMock(MetadataExtractorInterface::class);
+        $metadataExtractor->expects(self::never())->method('extract');
+
+        $thumbnailService = $this->createMock(ThumbnailServiceInterface::class);
+        $thumbnailService->expects(self::never())->method('generateAll');
+
+        $pipeline = new DefaultMediaIngestionPipeline(
+            $entityManager,
+            $metadataExtractor,
+            $thumbnailService,
+        );
+
+        $result = $pipeline->process($path, false, false, false, false, $output);
+
+        self::assertNull($result);
+        self::assertStringContainsString('Übersprungen', $output->fetch());
+    }
+
+    #[Test]
+    public function processPersistsAndFlushesOnFinalize(): void
+    {
+        $path   = $this->createTempFile('jpg', 'content');
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE);
+
+        $repository = $this->getMockBuilder(EntityRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findOneBy'])
+            ->getMock();
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(Media::class)
+            ->willReturn($repository);
+        $entityManager->expects(self::once())->method('persist');
+        $entityManager->expects(self::once())->method('flush');
+        $entityManager->expects(self::never())->method('clear');
+
+        $metadataExtractor = $this->createMock(MetadataExtractorInterface::class);
+        $metadataExtractor->expects(self::once())
+            ->method('extract')
+            ->willReturnCallback(static fn (string $file, Media $media): Media => $media);
+
+        $thumbnailService = $this->createMock(ThumbnailServiceInterface::class);
+        $thumbnailService->expects(self::never())->method('generateAll');
+
+        $pipeline = new DefaultMediaIngestionPipeline(
+            $entityManager,
+            $metadataExtractor,
+            $thumbnailService,
+        );
+
+        $result = $pipeline->process($path, false, false, false, false, $output);
+        $pipeline->finalize(false);
+
+        self::assertInstanceOf(Media::class, $result);
+    }
+
+    #[Test]
+    public function processHonoursStrictMimeValidation(): void
+    {
+        $path   = $this->createTempFile('jpg', 'plain text');
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('getRepository');
+        $entityManager->expects(self::never())->method('persist');
+
+        $metadataExtractor = $this->createMock(MetadataExtractorInterface::class);
+        $metadataExtractor->expects(self::never())->method('extract');
+
+        $thumbnailService = $this->createMock(ThumbnailServiceInterface::class);
+        $thumbnailService->expects(self::never())->method('generateAll');
+
+        $pipeline = new DefaultMediaIngestionPipeline(
+            $entityManager,
+            $metadataExtractor,
+            $thumbnailService,
+            ['jpg'],
+            [],
+        );
+
+        $result = $pipeline->process($path, false, false, false, true, $output);
+
+        self::assertNull($result);
+    }
+
+    private function createTempFile(string $extension, string $content): string
+    {
+        $path = sys_get_temp_dir() . '/memories-pipeline-' . uniqid('', true) . '.' . $extension;
+        file_put_contents($path, $content);
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- extract media file discovery into a dedicated media file locator service
- encapsulate ingestion, metadata, and thumbnail processing in a media pipeline and simplify the index command
- register the new services and add focused unit tests for the locator, pipeline, and command orchestration

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dbe0c3506c8323b77abf2f2244f64f