### PR TITLE
Refactor geocoding workflow into dedicated processors

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -188,10 +188,22 @@ services:
         arguments:
             $cellDeg: 0.01
 
-    MagicSunday\Memories\Command\GeocodeCommand:
+    MagicSunday\Memories\Service\Geocoding\MediaLocationLinkerInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\MediaLocationLinker
+
+    MagicSunday\Memories\Service\Geocoding\DefaultMediaGeocodingProcessor:
         arguments:
+            $locale: '%memories.localization.preferred_locale%'
             $delayMs: '%memories.geocoding.delay_ms%'
-        tags: ['console.command']
+
+    MagicSunday\Memories\Service\Geocoding\MediaGeocodingProcessorInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\DefaultMediaGeocodingProcessor
+
+    MagicSunday\Memories\Service\Geocoding\PoiUpdateProcessorInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\DefaultPoiUpdateProcessor
+
+    MagicSunday\Memories\Service\Geocoding\PoiEnsurerInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\LocationResolver
 
 
     ########################################

--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -11,34 +11,17 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Command;
 
-use Doctrine\ORM\EntityManagerInterface;
-use MagicSunday\Memories\Entity\Location;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Service\Geocoding\LocationCellIndex;
-use MagicSunday\Memories\Service\Geocoding\LocationResolver;
-use MagicSunday\Memories\Service\Geocoding\MediaLocationLinker;
+use MagicSunday\Memories\Service\Geocoding\DefaultGeocodingWorkflow;
+use MagicSunday\Memories\Service\Geocoding\GeocodeCommandOptions;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function array_filter;
-use function array_values;
-use function count;
-use function function_exists;
 use function is_string;
-use function mb_strimwidth;
-use function mb_strtolower;
-use function preg_replace;
-use function sprintf;
-use function strlen;
-use function spl_object_id;
-use function substr;
 use function trim;
-use function usleep;
 
 #[AsCommand(
     name: 'memories:geocode',
@@ -47,11 +30,7 @@ use function usleep;
 final class GeocodeCommand extends Command
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly MediaLocationLinker $linker,
-        private readonly LocationResolver $locationResolver,
-        private readonly LocationCellIndex $cellIndex,
-        private readonly int $delayMs = 1200, // be polite to Nominatim
+        private readonly DefaultGeocodingWorkflow $workflow,
     ) {
         parent::__construct();
     }
@@ -78,301 +57,17 @@ final class GeocodeCommand extends Command
         $missingPois = (bool) $input->getOption('missing-pois');
         $refreshPois = (bool) $input->getOption('refresh-pois');
 
-        $io->title('🗺️  Orte ermitteln');
+        $options = new GeocodeCommandOptions(
+            $dryRun,
+            $limitN,
+            $all,
+            is_string($city) && trim($city) !== '' ? $city : null,
+            $missingPois,
+            $refreshPois,
+        );
 
-        if ($missingPois) {
-            return $this->reprocessLocationsMissingPois($dryRun, $refreshPois, $io, $output);
-        }
-
-        if (is_string($city) && $city !== '') {
-            return $this->reprocessLocationsByCity($city, $dryRun, $refreshPois, $io, $output);
-        }
-
-        if ($refreshPois && !$all && $limitN === null) {
-            return $this->refreshAllPois($dryRun, $io, $output);
-        }
-
-        $loaded = $this->cellIndex->warmUpFromDb();
-        $io->writeln(sprintf('🔎 %d bekannte Zellen vorab geladen.', $loaded));
-
-        $qb = $this->em->createQueryBuilder()
-            ->select('m')
-            ->from(Media::class, 'm')
-            ->where('m.gpsLat IS NOT NULL')
-            ->andWhere('m.gpsLon IS NOT NULL');
-
-        if (!$all && !$refreshPois) {
-            $qb->andWhere('m.location IS NULL');
-        }
-
-        $qb->orderBy('m.takenAt', 'ASC');
-
-        if ($limitN !== null && $limitN > 0) {
-            $qb->setMaxResults($limitN);
-        }
-
-        /** @var list<Media> $medias */
-        $medias = $qb->getQuery()->getResult();
-
-        $count = count($medias);
-        if ($count < 1) {
-            $io->writeln('Nichts zu tun – keine Medien mit GPS gefunden.');
-
-            return Command::SUCCESS;
-        }
-
-        $bar = new ProgressBar($output, $count);
-        $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% | Dauer: %elapsed:6s% | ETA: %estimated:-6s% | %message%');
-        $bar->setMessage('Starte …');
-        $bar->start();
-
-        $processed = 0;
-        $linked    = 0;
-        $netCalls  = 0;
-        /** @var array<int,Location> $uniqueLocations */
-        $uniqueLocations = [];
-
-        $batchSize = 10; // kleinerer Batch verringert Datenverlust bei Fehlern
-        foreach ($medias as $m) {
-            $bar->setMessage('Rückwärtssuche');
-            $loc = $this->linker->link($m, 'de', $refreshPois);
-
-            if ($loc instanceof Location) {
-                ++$linked;
-                $uniqueLocations[spl_object_id($loc)] = $loc;
-            }
-
-            // nur schlafen, wenn wirklich ein Netz-Call stattfand
-            $networkCalls = $this->linker->consumeLastNetworkCalls();
-            if ($networkCalls > 0) {
-                $netCalls += $networkCalls;
-
-                if ($this->delayMs > 0) {
-                    for ($i = 0; $i < $networkCalls; ++$i) {
-                        usleep($this->delayMs * 1000);
-                    }
-                }
-            }
-
-            ++$processed;
-            $bar->advance();
-
-            if (($processed % $batchSize) === 0) {
-                // kein clear(): wir halten Location-Cache und managed Entities intakt
-                if (!$dryRun) {
-                    $this->em->flush();
-                }
-            }
-        }
-
-        if (!$dryRun) {
-            $this->em->flush();
-        }
-
-        $bar->finish();
-
-        $io->writeln('');
-        $io->writeln('');
-        $io->writeln(sprintf('✅ %d Medien verarbeitet, %d Orte verknüpft, %d Netzabfragen.', $processed, $linked, $netCalls));
-
-        $locationsForPois = array_values(array_filter(
-            $uniqueLocations,
-            static fn (Location $location): bool => $refreshPois || $location->getPois() === null,
-        ));
-
-        if (count($locationsForPois) > 0) {
-            $io->section('📍 POI-Daten aktualisieren');
-            if ($refreshPois) {
-                $io->note('Bestehende POI-Daten werden neu abgerufen.');
-            }
-
-            $statistics = $this->processPoiUpdates($locationsForPois, $dryRun, $refreshPois, $output);
-
-            $this->renderPoiUpdateSummary($io, $statistics, $dryRun);
-        }
-
-        if ($dryRun) {
-            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
-        }
+        $this->workflow->run($options, $io, $output);
 
         return Command::SUCCESS;
-    }
-
-    private function refreshAllPois(bool $dryRun, SymfonyStyle $io, OutputInterface $output): int
-    {
-        $io->section('🌐 Alle POI-Daten aktualisieren');
-        $io->note('Bestehende POI-Daten werden neu abgerufen.');
-
-        $repo      = $this->em->getRepository(Location::class);
-        $locations = $repo->createQueryBuilder('l')
-            ->orderBy('l.id', 'ASC')
-            ->getQuery()
-            ->getResult();
-
-        if (count($locations) < 1) {
-            $io->writeln('Keine Orte vorhanden.');
-
-            return Command::SUCCESS;
-        }
-
-        $statistics = $this->processPoiUpdates($locations, $dryRun, true, $output);
-
-        $this->renderPoiUpdateSummary($io, $statistics, $dryRun);
-
-        return Command::SUCCESS;
-    }
-
-    private function reprocessLocationsMissingPois(bool $dryRun, bool $refreshPois, SymfonyStyle $io, OutputInterface $output): int
-    {
-        $io->section('📍 Orte ohne POI-Daten ergänzen');
-
-        if ($refreshPois) {
-            $io->note('Bestehende POI-Daten werden neu abgerufen.');
-        }
-
-        $repo = $this->em->getRepository(Location::class);
-        $qb   = $repo->createQueryBuilder('l');
-
-        if (!$refreshPois) {
-            $qb->where('l.pois IS NULL');
-        }
-
-        $qb->orderBy('l.id', 'ASC');
-
-        /** @var list<Location> $locations */
-        $locations = $qb->getQuery()->getResult();
-
-        $count = count($locations);
-        if ($count < 1) {
-            $io->writeln('Keine Orte ohne POI-Daten gefunden.');
-
-            return Command::SUCCESS;
-        }
-
-        $statistics = $this->processPoiUpdates($locations, $dryRun, $refreshPois, $output);
-
-        $this->renderPoiUpdateSummary($io, $statistics, $dryRun);
-
-        return Command::SUCCESS;
-    }
-
-    private function reprocessLocationsByCity(string $city, bool $dryRun, bool $refreshPois, SymfonyStyle $io, OutputInterface $output): int
-    {
-        $normalizedCity = mb_strtolower($city);
-
-        $io->section(sprintf('🏙️  Orte mit Stadtnamen "%s" aktualisieren', $city));
-
-        if ($refreshPois) {
-            $io->note('Bestehende POI-Daten werden neu abgerufen.');
-        }
-
-        $repo = $this->em->getRepository(Location::class);
-        $qb   = $repo->createQueryBuilder('l');
-
-        $qb->where('LOWER(l.city) = :city')
-            ->orWhere('LOWER(l.displayName) LIKE :cityLike')
-            ->setParameter('city', $normalizedCity)
-            ->setParameter('cityLike', '%' . $normalizedCity . '%')
-            ->orderBy('l.id', 'ASC');
-
-        /** @var list<Location> $locations */
-        $locations = $qb->getQuery()->getResult();
-
-        $count = count($locations);
-        if ($count < 1) {
-            $io->writeln('Keine passenden Orte gefunden.');
-
-            return Command::SUCCESS;
-        }
-
-        $statistics = $this->processPoiUpdates($locations, $dryRun, $refreshPois, $output);
-
-        $this->renderPoiUpdateSummary($io, $statistics, $dryRun);
-
-        return Command::SUCCESS;
-    }
-
-    /**
-     * @param list<Location> $locations
-     *
-     * @return array{int,int,int} Tuple of processed, updated, and network calls
-     */
-    private function processPoiUpdates(array $locations, bool $dryRun, bool $refreshPois, OutputInterface $output): array
-    {
-        $count = count($locations);
-
-        $bar = new ProgressBar($output, $count);
-        $bar->setFormat('%current%/%max% [%bar%] %percent:3s%% | Dauer: %elapsed:6s% | ETA: %estimated:-6s% | %message%');
-        $bar->setMessage('Starte …');
-        $bar->start();
-
-        $processed = 0;
-        $updated   = 0;
-        $netCalls  = 0;
-        $batchSize = 10;
-
-        foreach ($locations as $location) {
-            $label = $location->getDisplayName() ?? $location->getCity() ?? 'Unbenannter Ort';
-            $bar->setMessage($this->formatProgressLabel($label));
-
-            $beforePois = $location->getPois();
-
-            $this->locationResolver->ensurePois($location, $refreshPois);
-            if ($this->locationResolver->consumeLastUsedNetwork()) {
-                ++$netCalls;
-            }
-
-            if ($beforePois !== $location->getPois()) {
-                ++$updated;
-            }
-
-            ++$processed;
-            $bar->advance();
-
-            if ($processed % $batchSize === 0 && !$dryRun) {
-                $this->em->flush();
-            }
-        }
-
-        if (!$dryRun) {
-            $this->em->flush();
-        }
-
-        $bar->finish();
-
-        $output->writeln('');
-        $output->writeln('');
-
-        return [$processed, $updated, $netCalls];
-    }
-
-    /**
-     * @param array{int,int,int} $statistics
-     */
-    private function renderPoiUpdateSummary(SymfonyStyle $io, array $statistics, bool $dryRun): void
-    {
-        [$processed, $updated, $netCalls] = $statistics;
-
-        $io->writeln(sprintf('✅ %d Orte verarbeitet, %d aktualisiert, %d Netzabfragen.', $processed, $updated, $netCalls));
-
-        if ($dryRun) {
-            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
-        }
-    }
-
-    /**
-     * Shortens long progress bar labels to keep the output on a single line.
-     */
-    private function formatProgressLabel(string $label): string
-    {
-        $normalized = preg_replace('/\s+/u', ' ', trim($label)) ?? $label;
-
-        if (function_exists('mb_strimwidth')) {
-            return mb_strimwidth($normalized, 0, 70, '…', 'UTF-8');
-        }
-
-        return strlen($normalized) > 70
-            ? substr($normalized, 0, 69) . '…'
-            : $normalized;
     }
 }

--- a/src/Service/Geocoding/DefaultGeocodingWorkflow.php
+++ b/src/Service/Geocoding/DefaultGeocodingWorkflow.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function count;
+use function is_string;
+use function mb_strtolower;
+use function sprintf;
+use function trim;
+
+final class DefaultGeocodingWorkflow
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LocationCellIndex $cellIndex,
+        private readonly MediaGeocodingProcessorInterface $mediaProcessor,
+        private readonly PoiUpdateProcessorInterface $poiProcessor,
+    ) {
+    }
+
+    public function run(GeocodeCommandOptions $options, SymfonyStyle $io, OutputInterface $output): void
+    {
+        $io->title('🗺️  Orte ermitteln');
+
+        if ($options->updateMissingPois()) {
+            $this->reprocessLocationsMissingPois($options, $io, $output);
+
+            return;
+        }
+
+        $city = $options->getCity();
+        if (is_string($city) && trim($city) !== '') {
+            $this->reprocessLocationsByCity($city, $options, $io, $output);
+
+            return;
+        }
+
+        if ($options->refreshPois() && !$options->processAllMedia() && $options->getLimit() === null) {
+            $this->refreshAllPois($options, $io, $output);
+
+            return;
+        }
+
+        $this->processNewMedia($options, $io, $output);
+    }
+
+    private function processNewMedia(GeocodeCommandOptions $options, SymfonyStyle $io, OutputInterface $output): void
+    {
+        $loaded = $this->cellIndex->warmUpFromDb();
+        $io->writeln(sprintf('🔎 %d bekannte Zellen vorab geladen.', $loaded));
+
+        $medias = $this->loadMedia($options);
+
+        if (count($medias) < 1) {
+            $io->writeln('Nichts zu tun – keine Medien mit GPS gefunden.');
+
+            return;
+        }
+
+        $summary = $this->mediaProcessor->process($medias, $options->refreshPois(), $options->isDryRun(), $output);
+        $summary->render($io);
+
+        $locationsForPoi = $summary->getLocationsForPoiUpdate();
+        if (count($locationsForPoi) > 0) {
+            $io->section('📍 POI-Daten aktualisieren');
+            if ($options->refreshPois()) {
+                $io->note('Bestehende POI-Daten werden neu abgerufen.');
+            }
+
+            $poiSummary = $this->poiProcessor->process($locationsForPoi, $options->refreshPois(), $options->isDryRun(), $output);
+            $poiSummary->render($io);
+        }
+
+        if ($options->isDryRun()) {
+            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
+        }
+    }
+
+    private function refreshAllPois(GeocodeCommandOptions $options, SymfonyStyle $io, OutputInterface $output): void
+    {
+        $io->section('🌐 Alle POI-Daten aktualisieren');
+        $io->note('Bestehende POI-Daten werden neu abgerufen.');
+
+        $locations = $this->entityManager->getRepository(Location::class)
+            ->createQueryBuilder('l')
+            ->orderBy('l.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        if (count($locations) < 1) {
+            $io->writeln('Keine Orte vorhanden.');
+
+            return;
+        }
+
+        $summary = $this->poiProcessor->process($locations, true, $options->isDryRun(), $output);
+        $summary->render($io);
+
+        if ($options->isDryRun()) {
+            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
+        }
+    }
+
+    private function reprocessLocationsMissingPois(GeocodeCommandOptions $options, SymfonyStyle $io, OutputInterface $output): void
+    {
+        $io->section('📍 Orte ohne POI-Daten ergänzen');
+
+        if ($options->refreshPois()) {
+            $io->note('Bestehende POI-Daten werden neu abgerufen.');
+        }
+
+        $qb = $this->entityManager->getRepository(Location::class)->createQueryBuilder('l');
+        if (!$options->refreshPois()) {
+            $qb->where('l.pois IS NULL');
+        }
+
+        $qb->orderBy('l.id', 'ASC');
+
+        $locations = $qb->getQuery()->getResult();
+
+        if (count($locations) < 1) {
+            $io->writeln('Keine Orte ohne POI-Daten gefunden.');
+
+            return;
+        }
+
+        $summary = $this->poiProcessor->process($locations, $options->refreshPois(), $options->isDryRun(), $output);
+        $summary->render($io);
+
+        if ($options->isDryRun()) {
+            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
+        }
+    }
+
+    private function reprocessLocationsByCity(string $city, GeocodeCommandOptions $options, SymfonyStyle $io, OutputInterface $output): void
+    {
+        $normalizedCity = mb_strtolower($city);
+
+        $io->section(sprintf('🏙️  Orte mit Stadtnamen "%s" aktualisieren', $city));
+
+        if ($options->refreshPois()) {
+            $io->note('Bestehende POI-Daten werden neu abgerufen.');
+        }
+
+        $qb = $this->entityManager->getRepository(Location::class)->createQueryBuilder('l');
+        $qb->where('LOWER(l.city) = :city')
+            ->orWhere('LOWER(l.displayName) LIKE :cityLike')
+            ->setParameter('city', $normalizedCity)
+            ->setParameter('cityLike', '%' . $normalizedCity . '%')
+            ->orderBy('l.id', 'ASC');
+
+        $locations = $qb->getQuery()->getResult();
+
+        if (count($locations) < 1) {
+            $io->writeln('Keine passenden Orte gefunden.');
+
+            return;
+        }
+
+        $summary = $this->poiProcessor->process($locations, $options->refreshPois(), $options->isDryRun(), $output);
+        $summary->render($io);
+
+        if ($options->isDryRun()) {
+            $io->writeln('Hinweis: Dry-Run – es wurden keine Änderungen gespeichert.');
+        }
+    }
+
+    /**
+     * @return list<Media>
+     */
+    private function loadMedia(GeocodeCommandOptions $options): array
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('m')
+            ->from(Media::class, 'm')
+            ->where('m.gpsLat IS NOT NULL')
+            ->andWhere('m.gpsLon IS NOT NULL')
+            ->orderBy('m.takenAt', 'ASC');
+
+        if (!$options->processAllMedia() && !$options->refreshPois()) {
+            $qb->andWhere('m.location IS NULL');
+        }
+
+        $limit = $options->getLimit();
+        if ($limit !== null && $limit > 0) {
+            $qb->setMaxResults($limit);
+        }
+
+        /** @var list<Media> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+}

--- a/src/Service/Geocoding/DefaultMediaGeocodingProcessor.php
+++ b/src/Service/Geocoding/DefaultMediaGeocodingProcessor.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function count;
+use function is_array;
+use function iterator_to_array;
+use function spl_object_id;
+use function usleep;
+
+final class DefaultMediaGeocodingProcessor implements MediaGeocodingProcessorInterface
+{
+    /**
+     * @param positive-int $batchSize
+     */
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MediaLocationLinkerInterface $linker,
+        private readonly string $locale,
+        private readonly int $delayMs = 1200,
+        private readonly int $batchSize = 10,
+    ) {
+    }
+
+    public function process(iterable $media, bool $refreshPois, bool $dryRun, OutputInterface $output): GeocodingResultSummary
+    {
+        $medias = $this->normalizeIterable($media);
+        $count  = count($medias);
+
+        $progressBar = new ProgressBar($output, $count);
+        $progressBar->setFormat('%current%/%max% [%bar%] %percent:3s%% | Dauer: %elapsed:6s% | ETA: %estimated:-6s% | %message%');
+        $progressBar->setMessage('Starte …');
+        $progressBar->start();
+
+        $processed       = 0;
+        $linked          = 0;
+        $networkCalls    = 0;
+        /** @var array<int,Location> $uniqueLocations */
+        $uniqueLocations = [];
+
+        foreach ($medias as $item) {
+            $progressBar->setMessage('Rückwärtssuche');
+            $location = $this->linker->link($item, $this->locale, $refreshPois);
+
+            if ($location instanceof Location) {
+                ++$linked;
+                $uniqueLocations[spl_object_id($location)] = $location;
+            }
+
+            $networkCallsForMedia = $this->linker->consumeLastNetworkCalls();
+            if ($networkCallsForMedia > 0) {
+                $networkCalls += $networkCallsForMedia;
+
+                if ($this->delayMs > 0) {
+                    for ($i = 0; $i < $networkCallsForMedia; ++$i) {
+                        usleep($this->delayMs * 1000);
+                    }
+                }
+            }
+
+            ++$processed;
+            $progressBar->advance();
+
+            if (($processed % $this->batchSize) === 0 && !$dryRun) {
+                $this->entityManager->flush();
+            }
+        }
+
+        if (!$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        $progressBar->finish();
+
+        $output->writeln('');
+        $output->writeln('');
+
+        $locationsForPoiUpdate = $this->filterLocationsForPoiUpdate($uniqueLocations, $refreshPois);
+
+        return new GeocodingResultSummary($processed, $linked, $networkCalls, $locationsForPoiUpdate);
+    }
+
+    /**
+     * @param iterable<Media> $media
+     *
+     * @return list<Media>
+     */
+    private function normalizeIterable(iterable $media): array
+    {
+        if (is_array($media)) {
+            return $media;
+        }
+
+        return iterator_to_array($media, false);
+    }
+
+    /**
+     * @param array<int,Location> $uniqueLocations
+     *
+     * @return list<Location>
+     */
+    private function filterLocationsForPoiUpdate(array $uniqueLocations, bool $refreshPois): array
+    {
+        $locations = [];
+
+        foreach ($uniqueLocations as $location) {
+            if ($refreshPois || $location->getPois() === null) {
+                $locations[] = $location;
+            }
+        }
+
+        return $locations;
+    }
+}

--- a/src/Service/Geocoding/DefaultPoiUpdateProcessor.php
+++ b/src/Service/Geocoding/DefaultPoiUpdateProcessor.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Location;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function count;
+use function function_exists;
+use function is_array;
+use function iterator_to_array;
+use function mb_strimwidth;
+use function preg_replace;
+use function strlen;
+use function substr;
+use function trim;
+
+final class DefaultPoiUpdateProcessor implements PoiUpdateProcessorInterface
+{
+    /**
+     * @param positive-int $batchSize
+     */
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly PoiEnsurerInterface $locationResolver,
+        private readonly int $batchSize = 10,
+    ) {
+    }
+
+    public function process(iterable $locations, bool $refreshPois, bool $dryRun, OutputInterface $output): PoiUpdateSummary
+    {
+        $items = $this->normalizeIterable($locations);
+        $count = count($items);
+
+        $progressBar = new ProgressBar($output, $count);
+        $progressBar->setFormat('%current%/%max% [%bar%] %percent:3s%% | Dauer: %elapsed:6s% | ETA: %estimated:-6s% | %message%');
+        $progressBar->setMessage('Starte …');
+        $progressBar->start();
+
+        $processed    = 0;
+        $updated      = 0;
+        $networkCalls = 0;
+
+        foreach ($items as $location) {
+            $label = $location->getDisplayName() ?? $location->getCity() ?? 'Unbenannter Ort';
+            $progressBar->setMessage($this->formatProgressLabel($label));
+
+            $beforePois = $location->getPois();
+
+            $this->locationResolver->ensurePois($location, $refreshPois);
+            if ($this->locationResolver->consumeLastUsedNetwork()) {
+                ++$networkCalls;
+            }
+
+            if ($beforePois !== $location->getPois()) {
+                ++$updated;
+            }
+
+            ++$processed;
+            $progressBar->advance();
+
+            if (($processed % $this->batchSize) === 0 && !$dryRun) {
+                $this->entityManager->flush();
+            }
+        }
+
+        if (!$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        $progressBar->finish();
+
+        $output->writeln('');
+        $output->writeln('');
+
+        return new PoiUpdateSummary($processed, $updated, $networkCalls);
+    }
+
+    /**
+     * @param iterable<Location> $locations
+     *
+     * @return list<Location>
+     */
+    private function normalizeIterable(iterable $locations): array
+    {
+        if (is_array($locations)) {
+            return $locations;
+        }
+
+        return iterator_to_array($locations, false);
+    }
+
+    private function formatProgressLabel(string $label): string
+    {
+        $normalized = preg_replace('/\s+/u', ' ', trim($label)) ?? $label;
+
+        if (function_exists('mb_strimwidth')) {
+            return mb_strimwidth($normalized, 0, 70, '…', 'UTF-8');
+        }
+
+        return strlen($normalized) > 70
+            ? substr($normalized, 0, 69) . '…'
+            : $normalized;
+    }
+}

--- a/src/Service/Geocoding/GeocodeCommandOptions.php
+++ b/src/Service/Geocoding/GeocodeCommandOptions.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+final class GeocodeCommandOptions
+{
+    public function __construct(
+        private readonly bool $dryRun,
+        private readonly ?int $limit,
+        private readonly bool $processAll,
+        private readonly ?string $city,
+        private readonly bool $missingPois,
+        private readonly bool $refreshPois,
+    ) {
+    }
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function processAllMedia(): bool
+    {
+        return $this->processAll;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function updateMissingPois(): bool
+    {
+        return $this->missingPois;
+    }
+
+    public function refreshPois(): bool
+    {
+        return $this->refreshPois;
+    }
+}

--- a/src/Service/Geocoding/GeocodingResultSummary.php
+++ b/src/Service/Geocoding/GeocodingResultSummary.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Entity\Location;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class GeocodingResultSummary
+{
+    /**
+     * @param list<Location> $locationsForPoiUpdate
+     */
+    public function __construct(
+        private readonly int $processed,
+        private readonly int $linked,
+        private readonly int $networkCalls,
+        private readonly array $locationsForPoiUpdate,
+    ) {
+    }
+
+    public function getProcessed(): int
+    {
+        return $this->processed;
+    }
+
+    public function getLinked(): int
+    {
+        return $this->linked;
+    }
+
+    public function getNetworkCalls(): int
+    {
+        return $this->networkCalls;
+    }
+
+    /**
+     * @return list<Location>
+     */
+    public function getLocationsForPoiUpdate(): array
+    {
+        return $this->locationsForPoiUpdate;
+    }
+
+    public function render(SymfonyStyle $io): void
+    {
+        $io->writeln(sprintf('✅ %d Medien verarbeitet, %d Orte verknüpft, %d Netzabfragen.', $this->processed, $this->linked, $this->networkCalls));
+    }
+}

--- a/src/Service/Geocoding/LocationResolver.php
+++ b/src/Service/Geocoding/LocationResolver.php
@@ -25,7 +25,7 @@ use function strtoupper;
  * - Soft dedupe by coarse cell + address heuristics.
  * - Re-attaches cached entities after EM clear().
  */
-final class LocationResolver
+final class LocationResolver implements PoiEnsurerInterface
 {
     /** @var array<string,Location> provider|placeId -> Location (may be managed or detached) */
     private array $cacheByKey = [];

--- a/src/Service/Geocoding/MediaGeocodingProcessorInterface.php
+++ b/src/Service/Geocoding/MediaGeocodingProcessorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface MediaGeocodingProcessorInterface
+{
+    public function process(iterable $media, bool $refreshPois, bool $dryRun, OutputInterface $output): GeocodingResultSummary;
+}

--- a/src/Service/Geocoding/MediaLocationLinker.php
+++ b/src/Service/Geocoding/MediaLocationLinker.php
@@ -20,7 +20,7 @@ use function sprintf;
 /**
  * Links Media to Locations; uses a pre-warmed cell index + in-run cache.
  */
-final class MediaLocationLinker
+final class MediaLocationLinker implements MediaLocationLinkerInterface
 {
     /** @var array<string,Location> in-run cache: cell -> Location (managed) */
     private array $cellCache = [];

--- a/src/Service/Geocoding/MediaLocationLinkerInterface.php
+++ b/src/Service/Geocoding/MediaLocationLinkerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+
+interface MediaLocationLinkerInterface
+{
+    public function link(Media $media, string $acceptLanguage = 'de', bool $forceRefreshPois = false): ?Location;
+
+    public function consumeLastNetworkCalls(): int;
+}

--- a/src/Service/Geocoding/PoiEnsurerInterface.php
+++ b/src/Service/Geocoding/PoiEnsurerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Entity\Location;
+
+interface PoiEnsurerInterface
+{
+    public function ensurePois(Location $location, bool $refreshPois = false): void;
+
+    public function consumeLastUsedNetwork(): bool;
+}

--- a/src/Service/Geocoding/PoiUpdateProcessorInterface.php
+++ b/src/Service/Geocoding/PoiUpdateProcessorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface PoiUpdateProcessorInterface
+{
+    public function process(iterable $locations, bool $refreshPois, bool $dryRun, OutputInterface $output): PoiUpdateSummary;
+}

--- a/src/Service/Geocoding/PoiUpdateSummary.php
+++ b/src/Service/Geocoding/PoiUpdateSummary.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class PoiUpdateSummary
+{
+    public function __construct(
+        private readonly int $processed,
+        private readonly int $updated,
+        private readonly int $networkCalls,
+    ) {
+    }
+
+    public function getProcessed(): int
+    {
+        return $this->processed;
+    }
+
+    public function getUpdated(): int
+    {
+        return $this->updated;
+    }
+
+    public function getNetworkCalls(): int
+    {
+        return $this->networkCalls;
+    }
+
+    public function render(SymfonyStyle $io): void
+    {
+        $io->writeln(sprintf('✅ %d Orte verarbeitet, %d aktualisiert, %d Netzabfragen.', $this->processed, $this->updated, $this->networkCalls));
+    }
+}

--- a/test/Unit/Service/Geocoding/DefaultMediaGeocodingProcessorTest.php
+++ b/test/Unit/Service/Geocoding/DefaultMediaGeocodingProcessorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Geocoding\DefaultMediaGeocodingProcessor;
+use MagicSunday\Memories\Service\Geocoding\MediaLocationLinkerInterface;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+final class DefaultMediaGeocodingProcessorTest extends TestCase
+{
+    #[Test]
+    public function processesMediaAndCollectsUniqueLocations(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $mediaA = new Media('a.jpg', 'hash-a', 100);
+        $mediaB = new Media('b.jpg', 'hash-b', 200);
+
+        $location = new Location('nominatim', '1', 'Berlin', 1.0, 2.0, 'cell');
+
+        $linker = new class($location, $mediaA, $mediaB) implements MediaLocationLinkerInterface {
+            private int $invocations = 0;
+
+            /** @var list<int> */
+            private array $networkCalls = [1, 0];
+
+            public function __construct(
+                private readonly Location $location,
+                private readonly Media $first,
+                private readonly Media $second,
+            ) {
+            }
+
+            public function link(Media $media, string $acceptLanguage = 'de', bool $forceRefreshPois = false): ?Location
+            {
+                Assert::assertSame('de', $acceptLanguage);
+                Assert::assertFalse($forceRefreshPois);
+
+                if ($this->invocations === 0) {
+                    Assert::assertSame($this->first, $media);
+                    ++$this->invocations;
+
+                    return $this->location;
+                }
+
+                Assert::assertSame($this->second, $media);
+                ++$this->invocations;
+
+                return null;
+            }
+
+            public function consumeLastNetworkCalls(): int
+            {
+                return $this->networkCalls[$this->invocations - 1] ?? 0;
+            }
+        };
+
+        $processor = new DefaultMediaGeocodingProcessor($entityManager, $linker, 'de', 0, 10);
+
+        $summary = $processor->process([$mediaA, $mediaB], false, false, new NullOutput());
+
+        self::assertSame(2, $summary->getProcessed());
+        self::assertSame(1, $summary->getLinked());
+        self::assertSame(1, $summary->getNetworkCalls());
+        self::assertSame([$location], $summary->getLocationsForPoiUpdate());
+    }
+
+    #[Test]
+    public function keepsLocationsForRefreshAndSkipsFlushDuringDryRun(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $media = new Media('c.jpg', 'hash-c', 300);
+        $location = (new Location('nominatim', '2', 'Hamburg', 1.0, 2.0, 'cell'))->setPois([['name' => 'Alster']]);
+
+        $linker = new class($media, $location) implements MediaLocationLinkerInterface {
+            private bool $linked = false;
+
+            public function __construct(
+                private readonly Media $expectedMedia,
+                private readonly Location $location,
+            ) {
+            }
+
+            public function link(Media $media, string $acceptLanguage = 'de', bool $forceRefreshPois = false): ?Location
+            {
+                Assert::assertSame($this->expectedMedia, $media);
+                Assert::assertSame('de', $acceptLanguage);
+                Assert::assertTrue($forceRefreshPois);
+
+                $this->linked = true;
+
+                return $this->location;
+            }
+
+            public function consumeLastNetworkCalls(): int
+            {
+                Assert::assertTrue($this->linked);
+
+                return 0;
+            }
+        };
+
+        $processor = new DefaultMediaGeocodingProcessor($entityManager, $linker, 'de', 0, 10);
+
+        $summary = $processor->process([$media], true, true, new NullOutput());
+
+        self::assertSame([$location], $summary->getLocationsForPoiUpdate());
+    }
+}

--- a/test/Unit/Service/Geocoding/DefaultPoiUpdateProcessorTest.php
+++ b/test/Unit/Service/Geocoding/DefaultPoiUpdateProcessorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Service\Geocoding\DefaultPoiUpdateProcessor;
+use MagicSunday\Memories\Service\Geocoding\PoiEnsurerInterface;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+final class DefaultPoiUpdateProcessorTest extends TestCase
+{
+    #[Test]
+    public function processesLocationsAndCountsUpdates(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $locationA = new Location('nominatim', '1', 'Berlin', 1.0, 2.0, 'cell-a');
+        $locationB = new Location('nominatim', '2', 'Hamburg', 3.0, 4.0, 'cell-b');
+
+        $resolver = new class($locationA, $locationB) implements PoiEnsurerInterface {
+            private int $calls = 0;
+
+            /** @var list<bool> */
+            private array $network = [true, false];
+
+            public function __construct(
+                private readonly Location $first,
+                private readonly Location $second,
+            ) {
+            }
+
+            public function ensurePois(Location $location, bool $refreshPois = false): void
+            {
+                Assert::assertFalse($refreshPois);
+
+                if ($this->calls === 0) {
+                    Assert::assertSame($this->first, $location);
+                    $location->setPois([
+                        ['name' => 'Brandenburger Tor'],
+                    ]);
+                } else {
+                    Assert::assertSame($this->second, $location);
+                }
+
+                ++$this->calls;
+            }
+
+            public function consumeLastUsedNetwork(): bool
+            {
+                return $this->network[$this->calls - 1] ?? false;
+            }
+        };
+
+        $processor = new DefaultPoiUpdateProcessor($entityManager, $resolver, 10);
+
+        $summary = $processor->process([$locationA, $locationB], false, false, new NullOutput());
+
+        self::assertSame(2, $summary->getProcessed());
+        self::assertSame(1, $summary->getUpdated());
+        self::assertSame(1, $summary->getNetworkCalls());
+    }
+
+    #[Test]
+    public function skipsPersistenceDuringDryRun(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $resolver = new class implements PoiEnsurerInterface {
+            private bool $ensured = false;
+
+            public function ensurePois(Location $location, bool $refreshPois = false): void
+            {
+                Assert::assertTrue($refreshPois);
+                $this->ensured = true;
+            }
+
+            public function consumeLastUsedNetwork(): bool
+            {
+                Assert::assertTrue($this->ensured);
+
+                return false;
+            }
+        };
+
+        $location = new Location('nominatim', '3', 'München', 5.0, 6.0, 'cell-c');
+
+        $processor = new DefaultPoiUpdateProcessor($entityManager, $resolver, 10);
+
+        $summary = $processor->process([$location], true, true, new NullOutput());
+
+        self::assertSame(1, $summary->getProcessed());
+        self::assertSame(0, $summary->getUpdated());
+        self::assertSame(0, $summary->getNetworkCalls());
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated processors and value objects for media geocoding and POI updates
- introduce a workflow service and options object to keep GeocodeCommand focused on input parsing
- cover the new processors with unit tests and wire everything through the container

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dbe0c6bce883238e7b2570ec51f860