### PR TITLE
BUGFIX: fix cluster consolidation alias

### DIFF
--- a/src/Service/Clusterer/ClusterConsolidationService.php
+++ b/src/Service/Clusterer/ClusterConsolidationService.php
@@ -11,11 +11,27 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Clusterer;
 
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidatorInterface;
 use MagicSunday\Memories\Service\Clusterer\Pipeline\PipelineClusterConsolidator;
 
 /**
  * @deprecated Use PipelineClusterConsolidator with ClusterConsolidatorInterface instead.
  */
-final class ClusterConsolidationService extends PipelineClusterConsolidator
+final class ClusterConsolidationService implements ClusterConsolidatorInterface
 {
+    public function __construct(private readonly PipelineClusterConsolidator $consolidator)
+    {
+    }
+
+    /**
+     * @param list<ClusterDraft>                                     $drafts
+     * @param callable(int $done, int $max, string $stage):void|null $progress
+     *
+     * @return list<ClusterDraft>
+     */
+    public function consolidate(array $drafts, ?callable $progress = null): array
+    {
+        return $this->consolidator->consolidate($drafts, $progress);
+    }
 }


### PR DESCRIPTION
## Summary
- rework the deprecated ClusterConsolidationService to compose the pipeline consolidator instead of extending it
- keep backward compatibility with the ClusterConsolidatorInterface while avoiding inheritance from a final class

## Testing
- composer ci:test *(fails: bin/php not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe2f2c76c8323ba515d91f980de31