### PR TITLE
Refactor media ingestion into staged pipeline

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -130,10 +130,27 @@ services:
     MagicSunday\Memories\Service\Indexing\MediaFileLocatorInterface:
         alias: MagicSunday\Memories\Service\Indexing\DefaultMediaFileLocator
 
-    MagicSunday\Memories\Service\Indexing\DefaultMediaIngestionPipeline:
+    MagicSunday\Memories\Service\Indexing\Stage\MimeDetectionStage:
         arguments:
             $imageExtensions: '%memories.index.image_ext%'
             $videoExtensions: '%memories.index.video_ext%'
+
+    MagicSunday\Memories\Service\Indexing\Stage\DuplicateHandlingStage: ~
+
+    MagicSunday\Memories\Service\Indexing\Stage\MetadataExtractionStage: ~
+
+    MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage: ~
+
+    MagicSunday\Memories\Service\Indexing\Stage\PersistenceBatchStage: ~
+
+    MagicSunday\Memories\Service\Indexing\DefaultMediaIngestionPipeline:
+        arguments:
+            $stages:
+                - '@MagicSunday\Memories\Service\Indexing\Stage\MimeDetectionStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\DuplicateHandlingStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\MetadataExtractionStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\PersistenceBatchStage'
 
     MagicSunday\Memories\Service\Indexing\MediaIngestionPipelineInterface:
         alias: MagicSunday\Memories\Service\Indexing\DefaultMediaIngestionPipeline

--- a/src/Service/Indexing/Contract/FinalizableMediaIngestionStageInterface.php
+++ b/src/Service/Indexing/Contract/FinalizableMediaIngestionStageInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Contract;
+
+interface FinalizableMediaIngestionStageInterface extends MediaIngestionStageInterface
+{
+    public function finalize(MediaIngestionContext $context): void;
+}

--- a/src/Service/Indexing/Contract/MediaIngestionContext.php
+++ b/src/Service/Indexing/Contract/MediaIngestionContext.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Contract;
+
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class MediaIngestionContext
+{
+    private function __construct(
+        private readonly string $filePath,
+        private readonly bool $force,
+        private readonly bool $dryRun,
+        private readonly bool $withThumbnails,
+        private readonly bool $strictMime,
+        private readonly OutputInterface $output,
+        private readonly ?Media $media,
+        private readonly ?string $detectedMime,
+        private readonly ?string $checksum,
+        private readonly bool $skipped,
+        private readonly ?string $skipMessage,
+    ) {
+    }
+
+    public static function create(
+        string $filePath,
+        bool $force,
+        bool $dryRun,
+        bool $withThumbnails,
+        bool $strictMime,
+        OutputInterface $output
+    ): self {
+        return new self(
+            $filePath,
+            $force,
+            $dryRun,
+            $withThumbnails,
+            $strictMime,
+            $output,
+            null,
+            null,
+            null,
+            false,
+            null,
+        );
+    }
+
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+
+    public function isForce(): bool
+    {
+        return $this->force;
+    }
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    public function shouldGenerateThumbnails(): bool
+    {
+        return $this->withThumbnails;
+    }
+
+    public function isStrictMime(): bool
+    {
+        return $this->strictMime;
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
+    }
+
+    public function getMedia(): ?Media
+    {
+        return $this->media;
+    }
+
+    public function getDetectedMime(): ?string
+    {
+        return $this->detectedMime;
+    }
+
+    public function getChecksum(): ?string
+    {
+        return $this->checksum;
+    }
+
+    public function isSkipped(): bool
+    {
+        return $this->skipped;
+    }
+
+    public function getSkipMessage(): ?string
+    {
+        return $this->skipMessage;
+    }
+
+    public function withDetectedMime(string $detectedMime): self
+    {
+        return new self(
+            $this->filePath,
+            $this->force,
+            $this->dryRun,
+            $this->withThumbnails,
+            $this->strictMime,
+            $this->output,
+            $this->media,
+            $detectedMime,
+            $this->checksum,
+            $this->skipped,
+            $this->skipMessage,
+        );
+    }
+
+    public function withChecksum(string $checksum): self
+    {
+        return new self(
+            $this->filePath,
+            $this->force,
+            $this->dryRun,
+            $this->withThumbnails,
+            $this->strictMime,
+            $this->output,
+            $this->media,
+            $this->detectedMime,
+            $checksum,
+            $this->skipped,
+            $this->skipMessage,
+        );
+    }
+
+    public function withMedia(Media $media): self
+    {
+        return new self(
+            $this->filePath,
+            $this->force,
+            $this->dryRun,
+            $this->withThumbnails,
+            $this->strictMime,
+            $this->output,
+            $media,
+            $this->detectedMime,
+            $this->checksum,
+            $this->skipped,
+            $this->skipMessage,
+        );
+    }
+
+    public function markSkipped(?string $message = null): self
+    {
+        return new self(
+            $this->filePath,
+            $this->force,
+            $this->dryRun,
+            $this->withThumbnails,
+            $this->strictMime,
+            $this->output,
+            $this->media,
+            $this->detectedMime,
+            $this->checksum,
+            true,
+            $message,
+        );
+    }
+}

--- a/src/Service/Indexing/Contract/MediaIngestionStageInterface.php
+++ b/src/Service/Indexing/Contract/MediaIngestionStageInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Contract;
+
+interface MediaIngestionStageInterface
+{
+    public function process(MediaIngestionContext $context): MediaIngestionContext;
+}

--- a/src/Service/Indexing/DefaultMediaIngestionPipeline.php
+++ b/src/Service/Indexing/DefaultMediaIngestionPipeline.php
@@ -11,68 +11,29 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Indexing;
 
-use Doctrine\ORM\EntityManagerInterface;
-use finfo;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface;
-use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
+use MagicSunday\Memories\Service\Indexing\Contract\FinalizableMediaIngestionStageInterface;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 
-use function filesize;
-use function hash_file;
-use function in_array;
-use function is_string;
-use function mime_content_type;
-use function pathinfo;
-use function preg_match;
-use function sprintf;
-use function strtolower;
-
-use const FILEINFO_MIME_TYPE;
-use const PATHINFO_EXTENSION;
+use function is_array;
+use function iterator_to_array;
 
 final class DefaultMediaIngestionPipeline implements MediaIngestionPipelineInterface
 {
-    private const BATCH_SIZE = 50;
-
-    private readonly finfo $finfo;
-
-    private int $batchCount = 0;
+    /**
+     * @var list<MediaIngestionStageInterface>
+     */
+    private readonly array $stages;
 
     /**
-     * @var list<string>
+     * @param iterable<MediaIngestionStageInterface> $stages
      */
-    private readonly array $imageExtensions;
-
-    /**
-     * @var list<string>
-     */
-    private readonly array $videoExtensions;
-
-    private const DEFAULT_IMAGE_EXT = [
-        'jpg', 'jpeg', 'jpe', 'jxl', 'avif', 'heic', 'heif', 'png', 'webp', 'gif', 'bmp', 'tiff', 'tif',
-        'cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng',
-    ];
-
-    private const DEFAULT_VIDEO_EXT = [
-        'mp4', 'm4v', 'mov', '3gp', '3g2', 'avi', 'mkv', 'webm',
-    ];
-
-    /**
-     * @param list<string>|null $imageExtensions
-     * @param list<string>|null $videoExtensions
-     */
-    public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly MetadataExtractorInterface $metadataExtractor,
-        private readonly ThumbnailServiceInterface $thumbnailService,
-        ?array $imageExtensions = null,
-        ?array $videoExtensions = null,
-    ) {
-        $this->imageExtensions = $imageExtensions ?? self::DEFAULT_IMAGE_EXT;
-        $this->videoExtensions = $videoExtensions ?? self::DEFAULT_VIDEO_EXT;
-        $this->finfo          = new finfo(FILEINFO_MIME_TYPE);
+    public function __construct(iterable $stages)
+    {
+        $this->stages = is_array($stages) ? $stages : iterator_to_array($stages);
     }
 
     public function process(
@@ -83,127 +44,31 @@ final class DefaultMediaIngestionPipeline implements MediaIngestionPipelineInter
         bool $strictMime,
         OutputInterface $output
     ): ?Media {
-        $detectedMime = $this->detectMime($filepath);
+        $context = MediaIngestionContext::create($filepath, $force, $dryRun, $withThumbnails, $strictMime, $output);
 
-        if ($strictMime && $this->isMimeConsistent($filepath, $detectedMime) === false) {
-            return null;
-        }
-
-        $checksum = @hash_file('sha256', $filepath);
-        if ($checksum === false) {
-            $output->writeln(sprintf('<error>Could not compute checksum for file: %s</error>', $filepath));
-
-            return null;
-        }
-
-        $repository = $this->entityManager->getRepository(Media::class);
-        $existing   = $repository->findOneBy(['checksum' => $checksum]);
-
-        if ($existing instanceof Media && $force === false) {
-            $output->writeln(' -> Übersprungen (bereits indexiert)', OutputInterface::VERBOSITY_VERBOSE);
-
-            return null;
-        }
-
-        $size  = filesize($filepath) ?: 0;
-        $media = $existing ?? new Media($filepath, $checksum, $size);
-        $media->setMime($detectedMime);
-
-        try {
-            $media = $this->metadataExtractor->extract($filepath, $media);
-        } catch (Throwable $exception) {
-            $output->writeln(
-                sprintf('<error>Metadata extraction failed for %s: %s</error>', $filepath, $exception->getMessage())
-            );
-        }
-
-        if ($withThumbnails) {
-            try {
-                $media->setThumbnails($this->thumbnailService->generateAll($filepath, $media));
-            } catch (Throwable $exception) {
-                $output->writeln(
-                    sprintf('<error>Thumbnail generation failed for %s: %s</error>', $filepath, $exception->getMessage())
-                );
+        foreach ($this->stages as $stage) {
+            if ($context->isSkipped()) {
+                break;
             }
+
+            $context = $stage->process($context);
         }
 
-        if ($dryRun) {
-            $output->writeln(' (dry-run) ', OutputInterface::VERBOSITY_VERBOSE);
-
-            return $media;
+        if ($context->isSkipped()) {
+            return null;
         }
 
-        $this->entityManager->persist($media);
-        ++$this->batchCount;
-
-        if ($this->batchCount >= self::BATCH_SIZE) {
-            $this->entityManager->flush();
-            $this->entityManager->clear();
-            $this->batchCount = 0;
-        }
-
-        return $media;
+        return $context->getMedia();
     }
 
     public function finalize(bool $dryRun): void
     {
-        if ($dryRun) {
-            $this->batchCount = 0;
+        $context = MediaIngestionContext::create('', false, $dryRun, false, false, new NullOutput());
 
-            return;
-        }
-
-        $this->entityManager->flush();
-        $this->batchCount = 0;
-    }
-
-    private function detectMime(string $path): string
-    {
-        $mime = '';
-
-        try {
-            $m = @$this->finfo->file($path);
-            if (is_string($m) && $m !== '') {
-                $mime = $m;
-            }
-        } catch (Throwable) {
-            // ignore and try fallback
-        }
-
-        if ($mime === '') {
-            $m = @mime_content_type($path);
-            if (is_string($m) && $m !== '') {
-                $mime = $m;
+        foreach ($this->stages as $stage) {
+            if ($stage instanceof FinalizableMediaIngestionStageInterface) {
+                $stage->finalize($context);
             }
         }
-
-        return $mime !== '' ? $mime : 'application/octet-stream';
-    }
-
-    private function isMimeConsistent(string $filepath, string $detectedMime): bool
-    {
-        if ($this->isImageExt($filepath)) {
-            return preg_match('#^image/#', $detectedMime) === 1;
-        }
-
-        if ($this->isVideoExt($filepath)) {
-            return preg_match('#^video/#', $detectedMime) === 1;
-        }
-
-        return true;
-    }
-
-    private function isImageExt(string $filepath): bool
-    {
-        $ext = strtolower((string) pathinfo($filepath, PATHINFO_EXTENSION));
-
-        return $ext !== '' && in_array($ext, $this->imageExtensions, true);
-    }
-
-    private function isVideoExt(string $filepath): bool
-    {
-        $ext = strtolower((string) pathinfo($filepath, PATHINFO_EXTENSION));
-
-        return $ext !== '' && in_array($ext, $this->videoExtensions, true);
     }
 }

--- a/src/Service/Indexing/Stage/DuplicateHandlingStage.php
+++ b/src/Service/Indexing/Stage/DuplicateHandlingStage.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function filesize;
+use function hash_file;
+use function sprintf;
+
+final class DuplicateHandlingStage implements MediaIngestionStageInterface
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        $checksum = @hash_file('sha256', $context->getFilePath());
+        if ($checksum === false) {
+            $context->getOutput()->writeln(
+                sprintf('<error>Could not compute checksum for file: %s</error>', $context->getFilePath())
+            );
+
+            return $context->markSkipped();
+        }
+
+        $repository = $this->entityManager->getRepository(Media::class);
+        $existing   = $repository->findOneBy(['checksum' => $checksum]);
+
+        if ($existing instanceof Media && $context->isForce() === false) {
+            $context->getOutput()->writeln(
+                ' -> Übersprungen (bereits indexiert)',
+                OutputInterface::VERBOSITY_VERBOSE
+            );
+
+            return $context->markSkipped();
+        }
+
+        $media = $existing ?? new Media(
+            $context->getFilePath(),
+            $checksum,
+            filesize($context->getFilePath()) ?: 0,
+        );
+
+        $detectedMime = $context->getDetectedMime();
+        if ($detectedMime !== null) {
+            $media->setMime($detectedMime);
+        }
+
+        return $context
+            ->withChecksum($checksum)
+            ->withMedia($media);
+    }
+}

--- a/src/Service/Indexing/Stage/MetadataExtractionStage.php
+++ b/src/Service/Indexing/Stage/MetadataExtractionStage.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+use MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface;
+use Throwable;
+
+use function sprintf;
+
+final class MetadataExtractionStage implements MediaIngestionStageInterface
+{
+    public function __construct(
+        private readonly MetadataExtractorInterface $metadataExtractor,
+    ) {
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped() || $context->getMedia() === null) {
+            return $context;
+        }
+
+        try {
+            $media = $this->metadataExtractor->extract($context->getFilePath(), $context->getMedia());
+        } catch (Throwable $exception) {
+            $context->getOutput()->writeln(
+                sprintf('<error>Metadata extraction failed for %s: %s</error>', $context->getFilePath(), $exception->getMessage())
+            );
+
+            return $context;
+        }
+
+        return $context->withMedia($media);
+    }
+}

--- a/src/Service/Indexing/Stage/MimeDetectionStage.php
+++ b/src/Service/Indexing/Stage/MimeDetectionStage.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+use finfo;
+use Throwable;
+
+use function in_array;
+use function is_string;
+use function mime_content_type;
+use function pathinfo;
+use function preg_match;
+use function strtolower;
+
+use const FILEINFO_MIME_TYPE;
+use const PATHINFO_EXTENSION;
+
+final class MimeDetectionStage implements MediaIngestionStageInterface
+{
+    /**
+     * @var list<string>
+     */
+    private readonly array $imageExtensions;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $videoExtensions;
+
+    private readonly finfo $finfo;
+
+    /**
+     * @param list<string>|null $imageExtensions
+     * @param list<string>|null $videoExtensions
+     */
+    public function __construct(
+        ?array $imageExtensions = null,
+        ?array $videoExtensions = null,
+    ) {
+        $this->imageExtensions = $imageExtensions ?? self::defaultImageExtensions();
+        $this->videoExtensions = $videoExtensions ?? self::defaultVideoExtensions();
+        $this->finfo           = new finfo(FILEINFO_MIME_TYPE);
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        $mime = $this->detectMime($context->getFilePath());
+        $context = $context->withDetectedMime($mime);
+
+        if ($context->isStrictMime() && $this->isMimeConsistent($context->getFilePath(), $mime) === false) {
+            return $context->markSkipped();
+        }
+
+        return $context;
+    }
+
+    private function detectMime(string $path): string
+    {
+        $mime = '';
+
+        try {
+            $value = @$this->finfo->file($path);
+            if (is_string($value) && $value !== '') {
+                $mime = $value;
+            }
+        } catch (Throwable) {
+            // Ignore and fallback to mime_content_type
+        }
+
+        if ($mime === '') {
+            $value = @mime_content_type($path);
+            if (is_string($value) && $value !== '') {
+                $mime = $value;
+            }
+        }
+
+        return $mime !== '' ? $mime : 'application/octet-stream';
+    }
+
+    private function isMimeConsistent(string $filepath, string $detectedMime): bool
+    {
+        if ($this->isImageExt($filepath)) {
+            return preg_match('#^image/#', $detectedMime) === 1;
+        }
+
+        if ($this->isVideoExt($filepath)) {
+            return preg_match('#^video/#', $detectedMime) === 1;
+        }
+
+        return true;
+    }
+
+    private function isImageExt(string $filepath): bool
+    {
+        $ext = strtolower((string) pathinfo($filepath, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->imageExtensions, true);
+    }
+
+    private function isVideoExt(string $filepath): bool
+    {
+        $ext = strtolower((string) pathinfo($filepath, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->videoExtensions, true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function defaultImageExtensions(): array
+    {
+        return [
+            'jpg', 'jpeg', 'jpe', 'jxl', 'avif', 'heic', 'heif', 'png', 'webp', 'gif', 'bmp', 'tiff', 'tif',
+            'cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function defaultVideoExtensions(): array
+    {
+        return [
+            'mp4', 'm4v', 'mov', '3gp', '3g2', 'avi', 'mkv', 'webm',
+        ];
+    }
+}

--- a/src/Service/Indexing/Stage/PersistenceBatchStage.php
+++ b/src/Service/Indexing/Stage/PersistenceBatchStage.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Service\Indexing\Contract\FinalizableMediaIngestionStageInterface;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PersistenceBatchStage implements FinalizableMediaIngestionStageInterface
+{
+    private const BATCH_SIZE = 50;
+
+    private int $batchCount = 0;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped() || $context->getMedia() === null) {
+            return $context;
+        }
+
+        if ($context->isDryRun()) {
+            $context->getOutput()->writeln(' (dry-run) ', OutputInterface::VERBOSITY_VERBOSE);
+
+            return $context;
+        }
+
+        $this->entityManager->persist($context->getMedia());
+        ++$this->batchCount;
+
+        if ($this->batchCount >= self::BATCH_SIZE) {
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+            $this->batchCount = 0;
+        }
+
+        return $context;
+    }
+
+    public function finalize(MediaIngestionContext $context): void
+    {
+        if ($context->isDryRun()) {
+            $this->batchCount = 0;
+
+            return;
+        }
+
+        $this->entityManager->flush();
+        $this->batchCount = 0;
+    }
+}

--- a/src/Service/Indexing/Stage/ThumbnailGenerationStage.php
+++ b/src/Service/Indexing/Stage/ThumbnailGenerationStage.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
+use Throwable;
+
+use function sprintf;
+
+final class ThumbnailGenerationStage implements MediaIngestionStageInterface
+{
+    public function __construct(
+        private readonly ThumbnailServiceInterface $thumbnailService,
+    ) {
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped() || $context->getMedia() === null || $context->shouldGenerateThumbnails() === false) {
+            return $context;
+        }
+
+        try {
+            $thumbnails = $this->thumbnailService->generateAll($context->getFilePath(), $context->getMedia());
+            $context->getMedia()->setThumbnails($thumbnails);
+        } catch (Throwable $exception) {
+            $context->getOutput()->writeln(
+                sprintf('<error>Thumbnail generation failed for %s: %s</error>', $context->getFilePath(), $exception->getMessage())
+            );
+        }
+
+        return $context;
+    }
+}

--- a/test/Unit/Service/Indexing/Stage/DuplicateHandlingStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/DuplicateHandlingStageTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing\Stage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Stage\DuplicateHandlingStage;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function file_put_contents;
+use function hash_file;
+use function is_file;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class DuplicateHandlingStageTest extends TestCase
+{
+    private ?string $tempFile = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile !== null && is_file($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+
+        $this->tempFile = null;
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function processSkipsWhenExistingMediaFoundAndForceDisabled(): void
+    {
+        $filepath = $this->createTempFile('jpg', 'existing');
+        $checksum = (string) hash_file('sha256', $filepath);
+        $media    = new Media($filepath, $checksum, 1);
+
+        $repository = $this->getMockBuilder(EntityRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findOneBy'])
+            ->getMock();
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn($media);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(Media::class)
+            ->willReturn($repository);
+
+        $stage = new DuplicateHandlingStage($entityManager);
+        $context = MediaIngestionContext::create(
+            $filepath,
+            false,
+            false,
+            false,
+            false,
+            new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE)
+        )->withDetectedMime('image/jpeg');
+
+        $result = $stage->process($context);
+
+        self::assertTrue($result->isSkipped());
+        self::assertNull($result->getMedia());
+    }
+
+    #[Test]
+    public function processCreatesMediaWhenNoExistingEntryFound(): void
+    {
+        $filepath = $this->createTempFile('jpg', 'fresh');
+
+        $repository = $this->getMockBuilder(EntityRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findOneBy'])
+            ->getMock();
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(Media::class)
+            ->willReturn($repository);
+
+        $stage = new DuplicateHandlingStage($entityManager);
+        $context = MediaIngestionContext::create(
+            $filepath,
+            false,
+            false,
+            false,
+            false,
+            new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE)
+        )->withDetectedMime('image/jpeg');
+
+        $result = $stage->process($context);
+
+        self::assertFalse($result->isSkipped());
+        self::assertNotNull($result->getChecksum());
+        self::assertInstanceOf(Media::class, $result->getMedia());
+        self::assertSame('image/jpeg', $result->getMedia()?->getMime());
+    }
+
+    private function createTempFile(string $extension, string $content): string
+    {
+        $path = sys_get_temp_dir() . '/memories-stage-' . uniqid('', true) . '.' . $extension;
+        file_put_contents($path, $content);
+        $this->tempFile = $path;
+
+        return $path;
+    }
+}

--- a/test/Unit/Service/Indexing/Stage/MimeDetectionStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/MimeDetectionStageTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Stage\MimeDetectionStage;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function file_put_contents;
+use function is_file;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class MimeDetectionStageTest extends TestCase
+{
+    private ?string $tempFile = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile !== null && is_file($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+
+        $this->tempFile = null;
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function processMarksContextSkippedWhenStrictValidationFails(): void
+    {
+        $filepath = $this->createTempFile('jpg', 'plain-text-content');
+        $stage    = new MimeDetectionStage(['jpg'], []);
+        $context  = MediaIngestionContext::create(
+            $filepath,
+            false,
+            false,
+            false,
+            true,
+            new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE)
+        );
+
+        $result = $stage->process($context);
+
+        self::assertNotNull($result->getDetectedMime());
+        self::assertTrue($result->isSkipped());
+    }
+
+    private function createTempFile(string $extension, string $content): string
+    {
+        $path = sys_get_temp_dir() . '/memories-stage-' . uniqid('', true) . '.' . $extension;
+        file_put_contents($path, $content);
+        $this->tempFile = $path;
+
+        return $path;
+    }
+}

--- a/test/Unit/Service/Indexing/Stage/PersistenceBatchStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/PersistenceBatchStageTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing\Stage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Stage\PersistenceBatchStage;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class PersistenceBatchStageTest extends TestCase
+{
+    #[Test]
+    public function processPersistsAndFlushesOnFinalize(): void
+    {
+        $media = new Media('file', 'checksum', 1);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('persist')->with($media);
+        $entityManager->expects(self::once())->method('flush');
+        $entityManager->expects(self::never())->method('clear');
+
+        $stage = new PersistenceBatchStage($entityManager);
+        $context = MediaIngestionContext::create(
+            'file',
+            false,
+            false,
+            false,
+            false,
+            new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE)
+        )->withMedia($media);
+
+        $stage->process($context);
+        $stage->finalize(MediaIngestionContext::create('', false, false, false, false, new NullOutput()));
+    }
+
+    #[Test]
+    public function processSkipsPersistenceDuringDryRun(): void
+    {
+        $media = new Media('file', 'checksum', 1);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+
+        $output  = new BufferedOutput(OutputInterface::VERBOSITY_VERBOSE);
+        $stage   = new PersistenceBatchStage($entityManager);
+        $context = MediaIngestionContext::create(
+            'file',
+            false,
+            true,
+            false,
+            false,
+            $output
+        )->withMedia($media);
+
+        $result = $stage->process($context);
+
+        self::assertStringContainsString(' (dry-run) ', $output->fetch());
+        self::assertSame($context, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a MediaIngestionContext value object and stage interfaces for the ingestion workflow
- split MIME validation, duplicate detection, metadata enrichment, thumbnailing, and persistence into dedicated stages
- refactor the default ingestion pipeline and service wiring to execute the ordered stage stack with new unit coverage

## Testing
- `php vendor/bin/phpunit --configuration .build/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68dbe5642b4c8323a6775fe4d18d158a