### PR TITLE
Refactor EXIF metadata extraction into modular processors

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -66,6 +66,9 @@ services:
         arguments:
             $readExifForVideos: false
 
+    MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface:
+        alias: MagicSunday\Memories\Service\Metadata\Exif\DefaultExifValueAccessor
+
     MagicSunday\Memories\Service\Metadata\XmpIptcExtractor: ~
 
     MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor: ~

--- a/src/Service/Metadata/Exif/Contract/ExifMetadataProcessorInterface.php
+++ b/src/Service/Metadata/Exif/Contract/ExifMetadataProcessorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Contract;
+
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Defines the contract for processing EXIF metadata fragments.
+ */
+interface ExifMetadataProcessorInterface
+{
+    /**
+     * Applies EXIF data extracted from a media file onto the Media entity.
+     *
+     * @param array<string,mixed> $exif The complete EXIF array as returned by the extractor.
+     */
+    public function process(array $exif, Media $media): void;
+}

--- a/src/Service/Metadata/Exif/Contract/ExifValueAccessorInterface.php
+++ b/src/Service/Metadata/Exif/Contract/ExifValueAccessorInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Contract;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Service\Metadata\Exif\Value\GpsMetadata;
+
+/**
+ * Provides strongly typed accessors for common EXIF value conversions.
+ */
+interface ExifValueAccessorInterface
+{
+    /**
+     * Finds the most suitable capture date within the EXIF data.
+     *
+     * @param array<string,mixed> $exif
+     */
+    public function findDate(array $exif): ?DateTimeImmutable;
+
+    /**
+     * Parses the timezone offset in minutes from the EXIF data.
+     *
+     * @param array<string,mixed> $exif
+     */
+    public function parseOffsetMinutes(array $exif): ?int;
+
+    public function intOrNull(mixed $value): ?int;
+
+    public function intFromScalarOrArray(mixed $value): ?int;
+
+    public function floatOrRational(mixed $value): ?float;
+
+    public function exposureToSeconds(mixed $value): ?float;
+
+    public function strOrNull(mixed $value): ?string;
+
+    /**
+     * Converts GPS EXIF data into decimal degrees/metric values.
+     *
+     * @param array<string,mixed> $gps
+     */
+    public function gpsFromExif(array $gps): ?GpsMetadata;
+}

--- a/src/Service/Metadata/Exif/DefaultExifValueAccessor.php
+++ b/src/Service/Metadata/Exif/DefaultExifValueAccessor.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Value\GpsMetadata;
+use Throwable;
+
+use function array_pad;
+use function explode;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_string;
+use function preg_match;
+use function str_contains;
+use function strlen;
+use function strtoupper;
+use function strtr;
+use function substr;
+
+/**
+ * Converts raw EXIF values into typed representations.
+ */
+final class DefaultExifValueAccessor implements ExifValueAccessorInterface
+{
+    public function findDate(array $exif): ?DateTimeImmutable
+    {
+        $candidates = [
+            $exif['EXIF']['DateTimeOriginal'] ?? null,
+            $exif['IFD0']['DateTime'] ?? null,
+            $exif['EXIF']['DateTimeDigitized'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) && $candidate !== '') {
+                $normalized = substr($candidate, 0, 19);
+                if ($this->looksLikeExifDate($normalized)) {
+                    $value = $this->normalizeExifDate($normalized);
+                    try {
+                        return new DateTimeImmutable($value);
+                    } catch (Throwable) {
+                        // continue, the fallback below may still succeed
+                    }
+                }
+
+                try {
+                    return new DateTimeImmutable($candidate);
+                } catch (Throwable) {
+                    // try next candidate
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function parseOffsetMinutes(array $exif): ?int
+    {
+        $offset = $exif['EXIF']['OffsetTimeOriginal'] ?? ($exif['EXIF']['OffsetTime'] ?? null);
+        if (!is_string($offset)) {
+            return null;
+        }
+
+        if (preg_match('~^([+-])(\d{2}):?(\d{2})$~', $offset, $matches) !== 1) {
+            return null;
+        }
+
+        $sign = $matches[1] === '-' ? -1 : 1;
+        $hours = (int) $matches[2];
+        $minutes = (int) $matches[3];
+
+        return $sign * ($hours * 60 + $minutes);
+    }
+
+    public function intOrNull(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    public function intFromScalarOrArray(mixed $value): ?int
+    {
+        $int = $this->intOrNull($value);
+        if ($int !== null) {
+            return $int;
+        }
+
+        if (is_array($value) && isset($value[0])) {
+            return $this->intOrNull($value[0]);
+        }
+
+        return null;
+    }
+
+    public function floatOrRational(mixed $value): ?float
+    {
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            if (str_contains($value, '/')) {
+                [$numerator, $denominator] = array_pad(explode('/', $value, 2), 2, '1');
+                $denominatorValue          = (float) $denominator;
+
+                return $denominatorValue !== 0.0 ? (float) $numerator / $denominatorValue : null;
+            }
+
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    public function exposureToSeconds(mixed $value): ?float
+    {
+        if (is_string($value) && str_contains($value, '/')) {
+            [$numerator, $denominator] = array_pad(explode('/', $value, 2), 2, '1');
+            $denominatorValue          = (float) $denominator;
+
+            return $denominatorValue !== 0.0 ? (float) $numerator / $denominatorValue : null;
+        }
+
+        if (is_float($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    public function strOrNull(mixed $value): ?string
+    {
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        return null;
+    }
+
+    public function gpsFromExif(array $gps): ?GpsMetadata
+    {
+        $latitude  = $this->coordinateToFloat($gps['GPSLatitude'] ?? null, $gps['GPSLatitudeRef'] ?? null);
+        $longitude = $this->coordinateToFloat($gps['GPSLongitude'] ?? null, $gps['GPSLongitudeRef'] ?? null);
+        if ($latitude === null || $longitude === null) {
+            return null;
+        }
+
+        $altitude    = $this->floatOrRational($gps['GPSAltitude'] ?? null);
+        $altitudeRef = $this->intOrNull($gps['GPSAltitudeRef'] ?? null);
+        if ($altitude !== null && $altitudeRef === 1) {
+            $altitude = -$altitude;
+        }
+
+        $speedValue = $this->floatOrRational($gps['GPSSpeed'] ?? null);
+        $speed      = null;
+        if ($speedValue !== null) {
+            $reference = is_string($gps['GPSSpeedRef'] ?? null) ? $gps['GPSSpeedRef'] : 'K';
+            $speed     = match (strtoupper($reference)) {
+                'M'     => $speedValue * 0.44704,
+                'N'     => $speedValue * 0.514444,
+                default => $speedValue / 3.6,
+            };
+        }
+
+        $course = $this->floatOrRational($gps['GPSTrack'] ?? null);
+
+        return new GpsMetadata($latitude, $longitude, $altitude, $speed, $course);
+    }
+
+    private function looksLikeExifDate(string $value): bool
+    {
+        return strlen($value) === 19
+            && $value[4] === ':'
+            && $value[7] === ':'
+            && $value[13] === ':'
+            && $value[16] === ':';
+    }
+
+    private function normalizeExifDate(string $value): string
+    {
+        $normalized = strtr($value, [':' => '-']);
+        $normalized[13] = ':';
+        $normalized[16] = ':';
+
+        return $normalized;
+    }
+
+    private function coordinateToFloat(mixed $value, ?string $reference): ?float
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        $degrees = $this->floatOrRational($value[0] ?? null);
+        $minutes = $this->floatOrRational($value[1] ?? null);
+        $seconds = $this->floatOrRational($value[2] ?? null);
+        if ($degrees === null || $minutes === null || $seconds === null) {
+            return null;
+        }
+
+        $sign = ($reference === 'S' || $reference === 'W') ? -1.0 : 1.0;
+
+        return $sign * ($degrees + $minutes / 60.0 + $seconds / 3600.0);
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/AspectFlagExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/AspectFlagExifMetadataProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Derives portrait and panorama flags from the media's aspect ratio.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class AspectFlagExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function process(array $exif, Media $media): void
+    {
+        $width = $media->getWidth();
+        $height = $media->getHeight();
+        if ($width === null || $height === null || $width <= 0 || $height <= 0) {
+            return;
+        }
+
+        if ($height > $width && ((float) $height / (float) $width) >= 1.2) {
+            $media->setIsPortrait(true);
+        }
+
+        if ($width > $height && ((float) $width / (float) $height) >= 2.4) {
+            $media->setIsPanorama(true);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/CameraExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/CameraExifMetadataProcessor.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Extracts camera and lens information from EXIF data.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class CameraExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function __construct(
+        private readonly ExifValueAccessorInterface $accessor,
+    ) {
+    }
+
+    public function process(array $exif, Media $media): void
+    {
+        $make = $this->accessor->strOrNull($exif['IFD0']['Make'] ?? null);
+        if ($make !== null) {
+            $media->setCameraMake($make);
+        }
+
+        $model = $this->accessor->strOrNull($exif['IFD0']['Model'] ?? null);
+        if ($model !== null) {
+            $media->setCameraModel($model);
+        }
+
+        $lens = $this->accessor->strOrNull(
+            $exif['EXIF']['UndefinedTag:0xA434'] ?? ($exif['EXIF']['LensModel'] ?? null)
+        );
+        if ($lens !== null) {
+            $media->setLensModel($lens);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/DateTimeExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/DateTimeExifMetadataProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Applies capture date, timezone offset and sub-second precision from EXIF data.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class DateTimeExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function __construct(
+        private readonly ExifValueAccessorInterface $accessor,
+    ) {
+    }
+
+    public function process(array $exif, Media $media): void
+    {
+        $takenAt = $this->accessor->findDate($exif);
+        if ($takenAt !== null) {
+            $media->setTakenAt($takenAt);
+        }
+
+        $offset = $this->accessor->parseOffsetMinutes($exif);
+        if ($offset !== null) {
+            $media->setTimezoneOffsetMin($offset);
+        }
+
+        $subSeconds = $this->accessor->intOrNull($exif['EXIF']['SubSecTimeOriginal'] ?? null);
+        if ($subSeconds !== null) {
+            $media->setSubSecOriginal($subSeconds);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/DimensionsExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/DimensionsExifMetadataProcessor.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Sets missing width/height information from the EXIF COMPUTED section.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class DimensionsExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function process(array $exif, Media $media): void
+    {
+        $width = $media->getWidth();
+        $height = $media->getHeight();
+        if ($width !== null && $height !== null && $width > 0 && $height > 0) {
+            return;
+        }
+
+        $computedWidth = isset($exif['COMPUTED']['Width']) ? (int) $exif['COMPUTED']['Width'] : null;
+        $computedHeight = isset($exif['COMPUTED']['Height']) ? (int) $exif['COMPUTED']['Height'] : null;
+
+        if ($width === null && $computedWidth !== null && $computedWidth > 0) {
+            $media->setWidth($computedWidth);
+        }
+
+        if ($height === null && $computedHeight !== null && $computedHeight > 0) {
+            $media->setHeight($computedHeight);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/ExposureExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/ExposureExifMetadataProcessor.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps exposure related metadata such as focal length and ISO.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class ExposureExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function __construct(
+        private readonly ExifValueAccessorInterface $accessor,
+    ) {
+    }
+
+    public function process(array $exif, Media $media): void
+    {
+        $focalLength = $this->accessor->floatOrRational($exif['EXIF']['FocalLength'] ?? null);
+        if ($focalLength !== null) {
+            $media->setFocalLengthMm($focalLength);
+        }
+
+        $focalLength35 = $this->accessor->intOrNull($exif['EXIF']['FocalLengthIn35mmFilm'] ?? null);
+        if ($focalLength35 !== null) {
+            $media->setFocalLength35mm($focalLength35);
+        }
+
+        $aperture = $this->accessor->floatOrRational($exif['EXIF']['FNumber'] ?? null);
+        if ($aperture !== null) {
+            $media->setApertureF($aperture);
+        }
+
+        $exposureTime = $this->accessor->exposureToSeconds($exif['EXIF']['ExposureTime'] ?? null);
+        if ($exposureTime !== null) {
+            $media->setExposureTimeS($exposureTime);
+        }
+
+        $iso = $this->accessor->intFromScalarOrArray(
+            $exif['EXIF']['ISOSpeedRatings'] ?? ($exif['EXIF']['PhotographicSensitivity'] ?? null)
+        );
+        if ($iso !== null) {
+            $media->setIso($iso);
+        }
+
+        $flash = $this->accessor->intOrNull($exif['EXIF']['Flash'] ?? null);
+        if ($flash !== null) {
+            $media->setFlashFired(($flash & 1) === 1);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/GpsExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/GpsExifMetadataProcessor.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Value\GpsMetadata;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function is_array;
+
+/**
+ * Enriches the media entity with GPS coordinates, altitude, speed and course.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class GpsExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function __construct(
+        private readonly ExifValueAccessorInterface $accessor,
+    ) {
+    }
+
+    public function process(array $exif, Media $media): void
+    {
+        if (!isset($exif['GPS']) || !is_array($exif['GPS'])) {
+            return;
+        }
+
+        $metadata = $this->accessor->gpsFromExif($exif['GPS']);
+        if (!$metadata instanceof GpsMetadata) {
+            return;
+        }
+
+        $media->setGpsLat($metadata->latitude);
+        $media->setGpsLon($metadata->longitude);
+
+        if ($metadata->altitude !== null) {
+            $media->setGpsAlt($metadata->altitude);
+        }
+
+        if ($metadata->speedMetersPerSecond !== null) {
+            $media->setGpsSpeedMps($metadata->speedMetersPerSecond);
+        }
+
+        if ($metadata->courseDegrees !== null) {
+            $media->setGpsHeadingDeg($metadata->courseDegrees);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Processor/OrientationExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/OrientationExifMetadataProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps orientation data onto the media entity.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class OrientationExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function __construct(
+        private readonly ExifValueAccessorInterface $accessor,
+    ) {
+    }
+
+    public function process(array $exif, Media $media): void
+    {
+        $orientation = $this->accessor->intOrNull($exif['IFD0']['Orientation'] ?? null);
+        if ($orientation !== null) {
+            $media->setOrientation($orientation);
+        }
+    }
+}

--- a/src/Service/Metadata/Exif/Value/GpsMetadata.php
+++ b/src/Service/Metadata/Exif/Value/GpsMetadata.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Value;
+
+/**
+ * Represents normalized GPS information extracted from EXIF data.
+ */
+final readonly class GpsMetadata
+{
+    public function __construct(
+        public float $latitude,
+        public float $longitude,
+        public ?float $altitude,
+        public ?float $speedMetersPerSecond,
+        public ?float $courseDegrees,
+    ) {
+    }
+}

--- a/src/Service/Metadata/ExifMetadataExtractor.php
+++ b/src/Service/Metadata/ExifMetadataExtractor.php
@@ -11,25 +11,14 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Metadata;
 
-use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Throwable;
 
-use function array_pad;
 use function exif_read_data;
-use function explode;
-use function is_array;
 use function is_file;
-use function is_float;
-use function is_int;
-use function is_string;
-use function preg_match;
-use function str_contains;
 use function str_starts_with;
-use function strlen;
-use function strtoupper;
-use function strtr;
-use function substr;
 
 /**
  * Extracts EXIF metadata from images (and optionally videos) and enriches Media.
@@ -42,7 +31,12 @@ use function substr;
  */
 final readonly class ExifMetadataExtractor implements SingleMetadataExtractorInterface
 {
+    /**
+     * @param iterable<ExifMetadataProcessorInterface> $processors
+     */
     public function __construct(
+        #[TaggedIterator('memories.metadata.exif.processor')]
+        private iterable $processors,
         private bool $readExifForVideos = false,
     ) {
     }
@@ -79,338 +73,10 @@ final readonly class ExifMetadataExtractor implements SingleMetadataExtractorInt
             return $media;
         }
 
-        // --- Date & Time ---
-        $taken = $this->findDate($exif);
-        if ($taken instanceof DateTimeImmutable) {
-            $media->setTakenAt($taken);
-        }
-
-        $offset = $this->parseOffsetMinutes($exif);
-        if ($offset !== null) {
-            $media->setTimezoneOffsetMin($offset);
-        }
-
-        // --- Dimensions (fallback if missing) ---
-        if ($media->getWidth() === null || $media->getHeight() === null) {
-            $w = isset($exif['COMPUTED']['Width']) ? (int) $exif['COMPUTED']['Width'] : null;
-            $h = isset($exif['COMPUTED']['Height']) ? (int) $exif['COMPUTED']['Height'] : null;
-            if ($w !== null && $w > 0) {
-                $media->setWidth($w);
-            }
-
-            if ($h !== null && $h > 0) {
-                $media->setHeight($h);
-            }
-        }
-
-        // --- Orientation ---
-        $orient = $this->intOrNull($exif['IFD0']['Orientation'] ?? null);
-        if ($orient !== null) {
-            $media->setOrientation($orient);
-        }
-
-        // --- Camera / Lens ---
-        $make  = $this->strOrNull($exif['IFD0']['Make'] ?? null);
-        $model = $this->strOrNull($exif['IFD0']['Model'] ?? null);
-        $lens  = $this->strOrNull(
-            $exif['EXIF']['UndefinedTag:0xA434'] ?? ($exif['EXIF']['LensModel'] ?? null)
-        );
-
-        if ($make !== null) {
-            $media->setCameraMake($make);
-        }
-
-        if ($model !== null) {
-            $media->setCameraModel($model);
-        }
-
-        if ($lens !== null) {
-            $media->setLensModel($lens);
-        }
-
-        $focalMm   = $this->floatOrRational($exif['EXIF']['FocalLength'] ?? null);
-        $focal35   = $this->intOrNull($exif['EXIF']['FocalLengthIn35mmFilm'] ?? null);
-        $fNumber   = $this->floatOrRational($exif['EXIF']['FNumber'] ?? null);
-        $exposureS = $this->exposureToSeconds($exif['EXIF']['ExposureTime'] ?? null);
-        $iso       = $this->intFromScalarOrArray($exif['EXIF']['ISOSpeedRatings'] ?? ($exif['EXIF']['PhotographicSensitivity'] ?? null));
-        $flash     = $this->intOrNull($exif['EXIF']['Flash'] ?? null);
-
-        if ($focalMm !== null) {
-            $media->setFocalLengthMm($focalMm);
-        }
-
-        if ($focal35 !== null) {
-            $media->setFocalLength35mm($focal35);
-        }
-
-        if ($fNumber !== null) {
-            $media->setApertureF($fNumber);
-        }
-
-        if ($exposureS !== null) {
-            $media->setExposureTimeS($exposureS);
-        }
-
-        if ($iso !== null) {
-            $media->setIso($iso);
-        }
-
-        if ($flash !== null) {
-            $media->setFlashFired(($flash & 1) === 1);
-        }
-
-        // --- SubSec (fine ordering) ---
-        $subsec = $this->intOrNull($exif['EXIF']['SubSecTimeOriginal'] ?? null);
-        if ($subsec !== null) {
-            $media->setSubSecOriginal($subsec);
-        }
-
-        // --- GPS ---
-        if (isset($exif['GPS']) && is_array($exif['GPS'])) {
-            $gps = $this->gpsFromExif($exif['GPS']);
-            if ($gps !== null) {
-                $media->setGpsLat($gps['lat']);
-                $media->setGpsLon($gps['lon']);
-                if ($gps['alt'] !== null) {
-                    $media->setGpsAlt($gps['alt']);
-                }
-
-                if ($gps['speed'] !== null) {
-                    $media->setGpsSpeedMps($gps['speed']);
-                }
-
-                if ($gps['course'] !== null) {
-                    $media->setGpsHeadingDeg($gps['course']);
-                }
-            }
-        }
-
-        // --- Aspect flags (Portrait/Panorama) ---
-        $wM = $media->getWidth();
-        $hM = $media->getHeight();
-        if ($wM !== null && $hM !== null && $wM > 0 && $hM > 0) {
-            if ($hM > $wM && ((float) $hM / (float) $wM) >= 1.2) {
-                $media->setIsPortrait(true);
-            }
-
-            if ($wM > $hM && ((float) $wM / (float) $hM) >= 2.4) {
-                $media->setIsPanorama(true);
-            }
+        foreach ($this->processors as $processor) {
+            $processor->process($exif, $media);
         }
 
         return $media;
-    }
-
-    // ---------------------------------------------------------------------
-    // Helpers
-    // ---------------------------------------------------------------------
-
-    private function findDate(array $exif): ?DateTimeImmutable
-    {
-        $candidates = [
-            $exif['EXIF']['DateTimeOriginal'] ?? null,
-            $exif['IFD0']['DateTime'] ?? null,
-            $exif['EXIF']['DateTimeDigitized'] ?? null,
-        ];
-
-        foreach ($candidates as $c) {
-            if (is_string($c) && $c !== '') {
-                // Typical EXIF format: "YYYY:MM:DD HH:MM:SS"
-                $s = substr($c, 0, 19);
-                if (strlen($s) === 19 && $s[4] === ':' && $s[7] === ':' && $s[13] === ':' && $s[16] === ':') {
-                    $norm = strtr($s, [':' => '-']); // becomes "YYYY-MM-DD HH-MM-SS"
-                    // restore time separators
-                    $norm[13] = ':';
-                    $norm[16] = ':';
-                    try {
-                        return new DateTimeImmutable($norm);
-                    } catch (Throwable) {
-                        // continue with fallback below
-                    }
-                }
-
-                try {
-                    // Fallback: feed original as-is
-                    return new DateTimeImmutable($c);
-                } catch (Throwable) {
-                    // try next candidate
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private function parseOffsetMinutes(array $exif): ?int
-    {
-        $off = $exif['EXIF']['OffsetTimeOriginal'] ?? ($exif['EXIF']['OffsetTime'] ?? null);
-        if (!is_string($off)) {
-            return null;
-        }
-
-        // Match "+02:00" or "+0200"
-        if (preg_match('~^([+-])(\d{2}):?(\d{2})$~', $off, $m) === 1) {
-            $sign = $m[1] === '-' ? -1 : 1;
-            $h    = (int) $m[2];
-            $mn   = (int) $m[3];
-
-            return $sign * ($h * 60 + $mn);
-        }
-
-        return null;
-    }
-
-    /** @param mixed $v */
-    private function intOrNull($v): ?int
-    {
-        if (is_int($v)) {
-            return $v;
-        }
-
-        if (is_string($v) && $v !== '') {
-            return (int) $v;
-        }
-
-        return null;
-    }
-
-    /** @param mixed $v */
-    private function intFromScalarOrArray($v): ?int
-    {
-        if (is_int($v)) {
-            return $v;
-        }
-
-        if (is_string($v) && $v !== '') {
-            return (int) $v;
-        }
-
-        if (is_array($v) && isset($v[0])) {
-            $first = $v[0];
-            if (is_int($first)) {
-                return $first;
-            }
-
-            if (is_string($first) && $first !== '') {
-                return (int) $first;
-            }
-        }
-
-        return null;
-    }
-
-    /** @param mixed $v */
-    private function floatOrRational($v): ?float
-    {
-        if (is_float($v)) {
-            return $v;
-        }
-
-        if (is_int($v)) {
-            return (float) $v;
-        }
-
-        if (is_string($v) && $v !== '') {
-            if (str_contains($v, '/')) {
-                [$a, $b] = array_pad(explode('/', $v, 2), 2, '1');
-                $bn      = (float) $b;
-
-                return $bn !== 0.0 ? (float) $a / $bn : null;
-            }
-
-            return (float) $v;
-        }
-
-        return null;
-    }
-
-    /** @param mixed $v */
-    private function exposureToSeconds($v): ?float
-    {
-        if (is_string($v) && str_contains($v, '/')) {
-            [$a, $b] = array_pad(explode('/', $v, 2), 2, '1');
-            $bn      = (float) $b;
-
-            return $bn !== 0.0 ? (float) $a / $bn : null;
-        }
-
-        if (is_float($v)) {
-            return $v;
-        }
-
-        if (is_int($v)) {
-            return (float) $v;
-        }
-
-        return null;
-    }
-
-    private function strOrNull(mixed $v): ?string
-    {
-        if (is_string($v) && $v !== '') {
-            return $v;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string,mixed> $gps
-     *
-     * @return array{lat: float, lon: float, alt: ?float, speed: ?float, course: ?float}|null
-     */
-    private function gpsFromExif(array $gps): ?array
-    {
-        $lat = $this->coordToFloat($gps['GPSLatitude'] ?? null, $gps['GPSLatitudeRef'] ?? null);
-        $lon = $this->coordToFloat($gps['GPSLongitude'] ?? null, $gps['GPSLongitudeRef'] ?? null);
-        if ($lat === null || $lon === null) {
-            return null;
-        }
-
-        // Altitude with reference: 0=above sea level, 1=below
-        $alt    = $this->floatOrRational($gps['GPSAltitude'] ?? null);
-        $altRef = $this->intOrNull($gps['GPSAltitudeRef'] ?? null);
-        if ($alt !== null && $altRef === 1) {
-            $alt = -$alt;
-        }
-
-        // Speed with unit conversion to m/s
-        $speed   = $this->floatOrRational($gps['GPSSpeed'] ?? null);
-        $speedMs = null;
-        if ($speed !== null) {
-            $ref     = is_string($gps['GPSSpeedRef'] ?? null) ? $gps['GPSSpeedRef'] : 'K';
-            $speedMs = match (strtoupper($ref)) {
-                'M'     => $speed * 0.44704,   // mph -> m/s
-                'N'     => $speed * 0.514444, // knots -> m/s
-                default => $speed / 3.6,  // 'K' km/h -> m/s
-            };
-        }
-
-        // Track (heading / course) in degrees; reference ignored (T/M)
-        $course = $this->floatOrRational($gps['GPSTrack'] ?? null);
-
-        return ['lat' => $lat, 'lon' => $lon, 'alt' => $alt, 'speed' => $speedMs, 'course' => $course];
-    }
-
-    /**
-     * @param mixed       $val EXIF GPS coordinate array with rationals
-     * @param string|null $ref 'N'/'S' or 'E'/'W'
-     */
-    private function coordToFloat(mixed $val, ?string $ref): ?float
-    {
-        if (!is_array($val)) {
-            return null;
-        }
-
-        $deg = $this->floatOrRational($val[0] ?? null);
-        $min = $this->floatOrRational($val[1] ?? null);
-        $sec = $this->floatOrRational($val[2] ?? null);
-        if ($deg === null || $min === null || $sec === null) {
-            return null;
-        }
-
-        $sign = ($ref === 'S' || $ref === 'W') ? -1.0 : 1.0;
-
-        return $sign * ($deg + $min / 60.0 + $sec / 3600.0);
     }
 }


### PR DESCRIPTION
## Summary
- introduce dedicated EXIF metadata processor and value accessor contracts to modularise extraction responsibilities
- split EXIF enrichment logic into tagged processor services and simplify the main extractor
- register the accessor implementation in the container to keep autowiring working

## Testing
- composer ci:test *(fails: `bin/php` not found in container)*
- php vendor/bin/phpunit --configuration .build/phpunit.xml


------
https://chatgpt.com/codex/tasks/task_e_68dbf2a139cc83239dacf53ae9adc57f