### PR TITLE
Refactor POI context analysis into dedicated services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,12 +25,21 @@ services:
         arguments:
             $commands: !tagged command
 
-    MagicSunday\Memories\Utility\DefaultPoiContextAnalyzer:
+    MagicSunday\Memories\Utility\DefaultPoiLabelResolver:
         arguments:
             $preferredLocale: '%memories.localization.preferred_locale%'
 
     MagicSunday\Memories\Utility\Contract\PoiContextAnalyzerInterface:
         alias: MagicSunday\Memories\Utility\DefaultPoiContextAnalyzer
+
+    MagicSunday\Memories\Utility\Contract\PoiLabelResolverInterface:
+        alias: MagicSunday\Memories\Utility\DefaultPoiLabelResolver
+
+    MagicSunday\Memories\Utility\Contract\PoiNormalizerInterface:
+        alias: MagicSunday\Memories\Utility\DefaultPoiNormalizer
+
+    MagicSunday\Memories\Utility\Contract\PoiScoringStrategyInterface:
+        alias: MagicSunday\Memories\Utility\DefaultPoiScorer
 
     MagicSunday\Memories\Utility\Contract\LocationLabelResolverInterface:
         alias: MagicSunday\Memories\Utility\DefaultLocationLabelResolver

--- a/src/Utility/Contract/PoiLabelResolverInterface.php
+++ b/src/Utility/Contract/PoiLabelResolverInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility\Contract;
+
+/**
+ * Resolves human readable labels for normalised POIs.
+ */
+interface PoiLabelResolverInterface
+{
+    /**
+     * @param array{
+     *     name:?string,
+     *     names:array{default:?string,localized:array<string,string>,alternates:list<string>},
+     *     categoryKey:?string,
+     *     categoryValue:?string,
+     *     tags:array<string,string>
+     * } $poi
+     */
+    public function preferredLabel(array $poi): ?string;
+}

--- a/src/Utility/Contract/PoiNormalizerInterface.php
+++ b/src/Utility/Contract/PoiNormalizerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility\Contract;
+
+/**
+ * Normalises raw POI payloads from geocoding providers.
+ */
+interface PoiNormalizerInterface
+{
+    /**
+     * @param array<string, mixed> $poi
+     *
+     * @return array{
+     *     name:?string,
+     *     names:array{default:?string,localized:array<string,string>,alternates:list<string>},
+     *     categoryKey:?string,
+     *     categoryValue:?string,
+     *     tags:array<string,string>
+     * }|null
+     */
+    public function normalise(array $poi): ?array;
+}

--- a/src/Utility/Contract/PoiScoringStrategyInterface.php
+++ b/src/Utility/Contract/PoiScoringStrategyInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility\Contract;
+
+/**
+ * Scores normalised POIs to determine their relative importance.
+ */
+interface PoiScoringStrategyInterface
+{
+    /**
+     * @param array{
+     *     name:?string,
+     *     names:array{default:?string,localized:array<string,string>,alternates:list<string>},
+     *     categoryKey:?string,
+     *     categoryValue:?string,
+     *     tags:array<string,string>
+     * } $poi
+     */
+    public function score(array $poi, ?float $distance): int;
+}

--- a/src/Utility/DefaultPoiContextAnalyzer.php
+++ b/src/Utility/DefaultPoiContextAnalyzer.php
@@ -14,92 +14,31 @@ namespace MagicSunday\Memories\Utility;
 use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\Contract\PoiContextAnalyzerInterface;
+use MagicSunday\Memories\Utility\Contract\PoiLabelResolverInterface;
+use MagicSunday\Memories\Utility\Contract\PoiNormalizerInterface;
+use MagicSunday\Memories\Utility\Contract\PoiScoringStrategyInterface;
 
-use function array_keys;
-use function explode;
-use function floor;
 use function is_array;
 use function is_numeric;
 use function is_string;
-use function ksort;
 use function reset;
 use function strcmp;
 use function strtolower;
-use function str_replace;
-use function str_contains;
-use function trim;
 use function uasort;
 use function usort;
 
 use const INF;
-use const SORT_STRING;
 
 /**
  * Default implementation analysing the POI context for media locations.
  */
 final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInterface
 {
-    private const int POI_NAME_BONUS = 100;
-
-    private const int POI_CATEGORY_VALUE_BONUS = 30;
-
-    private const int POI_WIKIDATA_BONUS = 120;
-
-    private const int POI_DISTANCE_PENALTY_DIVISOR = 25;
-
-    /**
-     * Tag specific weightings favouring more significant POIs.
-     *
-     * @var array<string,int>
-     */
-    private const array POI_TAG_WEIGHTS = [
-        'tourism'  => 600,
-        'historic' => 450,
-        'man_made' => 220,
-        'leisure'  => 140,
-        'natural'  => 140,
-        'place'    => 130,
-        'sport'    => 60,
-        'landuse'  => 25,
-    ];
-
-    /**
-     * Category key bonuses stacked on top of the tag weights.
-     *
-     * @var array<string,int>
-     */
-    private const array POI_CATEGORY_KEY_BONUS = [
-        'tourism'  => 220,
-        'historic' => 180,
-        'man_made' => 150,
-        'leisure'  => 90,
-        'natural'  => 90,
-        'place'    => 80,
-        'sport'    => 50,
-    ];
-
-    /**
-     * Additional bonuses for specific tag/value combinations.
-     *
-     * @var array<string,int>
-     */
-    private const array POI_TAG_VALUE_BONUS = [
-        'man_made:tower' => 260,
-    ];
-
-    /**
-     * @var list<string>
-     */
-    private array $preferredLocaleKeys;
-
-    public function __construct(?string $preferredLocale = null)
-    {
-        $preferredLocale = $preferredLocale !== null ? trim($preferredLocale) : null;
-        if ($preferredLocale === '') {
-            $preferredLocale = null;
-        }
-
-        $this->preferredLocaleKeys = $this->buildPreferredLocaleKeys($preferredLocale);
+    public function __construct(
+        private PoiNormalizerInterface $poiNormalizer,
+        private PoiScoringStrategyInterface $poiScorer,
+        private PoiLabelResolverInterface $poiLabelResolver,
+    ) {
     }
 
     public function resolvePrimaryPoi(Location $location): ?array
@@ -115,7 +54,7 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
                 continue;
             }
 
-            $normalised = $this->normalisePoi($poi);
+            $normalised = $this->poiNormalizer->normalise($poi);
             if ($normalised === null) {
                 continue;
             }
@@ -123,7 +62,7 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
             $distance     = $this->distanceOrNull($poi['distanceMeters'] ?? null);
             $candidates[] = [
                 'data'     => $normalised,
-                'score'    => $this->computePoiWeight($normalised, $distance),
+                'score'    => $this->poiScorer->score($normalised, $distance),
                 'distance' => $distance,
                 'index'    => $index,
             ];
@@ -184,7 +123,7 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
             return null;
         }
 
-        $label = $this->preferredPoiLabel($poi);
+        $label = $this->poiLabelResolver->preferredLabel($poi);
         if ($label !== null) {
             return $label;
         }
@@ -213,7 +152,7 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
                 continue;
             }
 
-            $label = $this->preferredPoiLabel($poi) ?? $poi['categoryValue'];
+            $label = $this->poiLabelResolver->preferredLabel($poi) ?? $poi['categoryValue'];
             if (!is_string($label) || $label === '') {
                 continue;
             }
@@ -269,42 +208,6 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
         ];
     }
 
-    /**
-     * @param array{name:?string,categoryKey:?string,categoryValue:?string,tags:array<string,string>} $poi
-     */
-    private function computePoiWeight(array $poi, ?float $distance): int
-    {
-        $score = 0;
-
-        if ($poi['name'] !== null) {
-            $score += self::POI_NAME_BONUS;
-        }
-
-        if ($poi['categoryValue'] !== null) {
-            $score += self::POI_CATEGORY_VALUE_BONUS;
-        }
-
-        $categoryKey = $poi['categoryKey'];
-        if ($categoryKey !== null) {
-            $score += self::POI_CATEGORY_KEY_BONUS[$categoryKey] ?? 0;
-        }
-
-        foreach ($poi['tags'] as $tagKey => $tagValue) {
-            $score += self::POI_TAG_WEIGHTS[$tagKey] ?? 0;
-            $score += self::POI_TAG_VALUE_BONUS[$tagKey . ':' . $tagValue] ?? 0;
-        }
-
-        if (isset($poi['tags']['wikidata'])) {
-            $score += self::POI_WIKIDATA_BONUS;
-        }
-
-        if ($distance !== null && $distance > 0.0) {
-            $score -= (int) floor($distance / self::POI_DISTANCE_PENALTY_DIVISOR);
-        }
-
-        return $score;
-    }
-
     private function distanceOrNull(mixed $value): ?float
     {
         if (is_numeric($value)) {
@@ -312,253 +215,5 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
         }
 
         return null;
-    }
-
-    /**
-     * @param array{name:?string,names:array{default:?string,localized:array<string,string>,alternates:list<string>},categoryKey:?string,categoryValue:?string,tags:array<string,string>} $poi
-     */
-    private function preferredPoiLabel(array $poi): ?string
-    {
-        $names = $poi['names'] ?? null;
-        if (is_array($names)) {
-            $label = $this->labelFromNames($names);
-            if ($label !== null) {
-                return $label;
-            }
-        }
-
-        $name = $poi['name'] ?? null;
-        if (is_string($name) && $name !== '') {
-            return $name;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array{default:?string,localized:array<string,string>,alternates:list<string>} $names
-     */
-    private function labelFromNames(array $names): ?string
-    {
-        $localized = $names['localized'] ?? [];
-        if (is_array($localized) && $localized !== []) {
-            foreach ($this->preferredLocaleKeys as $key) {
-                $value = $localized[$key] ?? null;
-                if (is_string($value) && $value !== '') {
-                    return $value;
-                }
-            }
-        }
-
-        $default = $names['default'] ?? null;
-        if (is_string($default) && $default !== '') {
-            return $default;
-        }
-
-        if (is_array($localized)) {
-            foreach ($localized as $value) {
-                if (is_string($value) && $value !== '') {
-                    return $value;
-                }
-            }
-        }
-
-        $alternates = $names['alternates'] ?? [];
-        if (is_array($alternates)) {
-            foreach ($alternates as $alternate) {
-                if (is_string($alternate) && $alternate !== '') {
-                    return $alternate;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string,mixed> $poi
-     *
-     * @return array{
-     *     name:?string,
-     *     names:array{default:?string,localized:array<string,string>,alternates:list<string>},
-     *     categoryKey:?string,
-     *     categoryValue:?string,
-     *     tags:array<string,string>
-     * }|null
-     */
-    private function normalisePoi(array $poi): ?array
-    {
-        $name  = is_string($poi['name'] ?? null) && $poi['name'] !== '' ? $poi['name'] : null;
-        $names = $this->normaliseNames($poi['names'] ?? null, $name);
-        if ($name === null) {
-            $name = $this->coalesceName($names);
-        }
-
-        $categoryKey   = is_string($poi['categoryKey'] ?? null) && $poi['categoryKey'] !== '' ? $poi['categoryKey'] : null;
-        $categoryValue = is_string($poi['categoryValue'] ?? null) && $poi['categoryValue'] !== '' ? $poi['categoryValue'] : null;
-
-        if ($name === null && $categoryValue === null) {
-            return null;
-        }
-
-        $tags    = [];
-        $rawTags = $poi['tags'] ?? null;
-        if (is_array($rawTags)) {
-            foreach ($rawTags as $tagKey => $tagValue) {
-                if (!is_string($tagKey) || $tagKey === '' || !is_string($tagValue) || $tagValue === '') {
-                    continue;
-                }
-
-                $tags[$tagKey] = $tagValue;
-            }
-        }
-
-        return [
-            'name'          => $name,
-            'names'         => $names,
-            'categoryKey'   => $categoryKey,
-            'categoryValue' => $categoryValue,
-            'tags'          => $tags,
-        ];
-    }
-
-    /**
-     * @param array{default:?string,localized:array<string,string>,alternates:list<string>}|null $raw
-     *
-     * @return array{default:?string,localized:array<string,string>,alternates:list<string>}
-     */
-    private function normaliseNames(?array $raw, ?string $fallbackDefault): array
-    {
-        $default    = $fallbackDefault;
-        $localized  = [];
-        $alternates = [];
-
-        if (is_array($raw)) {
-            $rawDefault = $raw['default'] ?? null;
-            if (is_string($rawDefault) && $rawDefault !== '') {
-                $default = $rawDefault;
-            }
-
-            $rawLocalized = $raw['localized'] ?? [];
-            if (is_array($rawLocalized)) {
-                foreach ($rawLocalized as $locale => $value) {
-                    if (!is_string($locale)) {
-                        continue;
-                    }
-
-                    $locale = strtolower(str_replace(' ', '_', $locale));
-                    if ($locale === '') {
-                        continue;
-                    }
-
-                    if (!is_string($value) || $value === '') {
-                        continue;
-                    }
-
-                    $localized[$locale] = $value;
-                }
-            }
-
-            $rawAlternates = $raw['alternates'] ?? [];
-            if (is_array($rawAlternates)) {
-                foreach ($rawAlternates as $alternate) {
-                    if (!is_string($alternate)) {
-                        continue;
-                    }
-
-                    $trimmed = trim($alternate);
-                    if ($trimmed === '') {
-                        continue;
-                    }
-
-                    $alternates[$trimmed] = true;
-                }
-            }
-        }
-
-        if ($localized !== []) {
-            ksort($localized, SORT_STRING);
-        }
-
-        /** @var list<string> $alternateList */
-        $alternateList = array_keys($alternates);
-
-        return [
-            'default'    => $default,
-            'localized'  => $localized,
-            'alternates' => $alternateList,
-        ];
-    }
-
-    /**
-     * @param array{default:?string,localized:array<string,string>,alternates:list<string>} $names
-     */
-    private function coalesceName(array $names): ?string
-    {
-        $default = $names['default'];
-        if (is_string($default) && $default !== '') {
-            return $default;
-        }
-
-        foreach ($names['localized'] as $value) {
-            if (is_string($value) && $value !== '') {
-                return $value;
-            }
-        }
-
-        foreach ($names['alternates'] as $alternate) {
-            if (is_string($alternate) && $alternate !== '') {
-                return $alternate;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function buildPreferredLocaleKeys(?string $locale): array
-    {
-        if ($locale === null) {
-            return [];
-        }
-
-        $lower      = strtolower($locale);
-        $normalized = str_replace('_', '-', $lower);
-
-        $candidates = [];
-        if ($normalized !== '') {
-            $candidates[] = $normalized;
-            $candidates[] = str_replace('-', '_', $normalized);
-        }
-
-        if (str_contains($normalized, '-')) {
-            $language = explode('-', $normalized)[0];
-            if ($language !== '') {
-                $candidates[] = $language;
-            }
-        } elseif ($normalized !== '') {
-            $candidates[] = $normalized;
-        }
-
-        $filtered = [];
-        foreach ($candidates as $candidate) {
-            if (!is_string($candidate)) {
-                continue;
-            }
-
-            $trimmed = trim($candidate);
-            if ($trimmed === '') {
-                continue;
-            }
-
-            $filtered[$trimmed] = true;
-        }
-
-        /** @var list<string> $keys */
-        $keys = array_keys($filtered);
-
-        return $keys;
     }
 }

--- a/src/Utility/DefaultPoiLabelResolver.php
+++ b/src/Utility/DefaultPoiLabelResolver.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility;
+
+use MagicSunday\Memories\Utility\Contract\PoiLabelResolverInterface;
+
+use function array_keys;
+use function explode;
+use function is_array;
+use function is_string;
+use function str_contains;
+use function str_replace;
+use function strtolower;
+use function trim;
+
+/**
+ * Resolves the preferred label for a POI based on locale preferences.
+ */
+final class DefaultPoiLabelResolver implements PoiLabelResolverInterface
+{
+    /**
+     * @var list<string>
+     */
+    private array $preferredLocaleKeys;
+
+    public function __construct(?string $preferredLocale = null)
+    {
+        $preferredLocale = $preferredLocale !== null ? trim($preferredLocale) : null;
+        if ($preferredLocale === '') {
+            $preferredLocale = null;
+        }
+
+        $this->preferredLocaleKeys = $this->buildPreferredLocaleKeys($preferredLocale);
+    }
+
+    public function preferredLabel(array $poi): ?string
+    {
+        $names = $poi['names'] ?? null;
+        if (is_array($names)) {
+            $label = $this->labelFromNames($names);
+            if ($label !== null) {
+                return $label;
+            }
+        }
+
+        $name = $poi['name'] ?? null;
+        if (is_string($name) && $name !== '') {
+            return $name;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{default:?string,localized:array<string,string>,alternates:list<string>} $names
+     */
+    private function labelFromNames(array $names): ?string
+    {
+        $localized = $names['localized'] ?? [];
+        if (is_array($localized) && $localized !== []) {
+            foreach ($this->preferredLocaleKeys as $key) {
+                $value = $localized[$key] ?? null;
+                if (is_string($value) && $value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        $default = $names['default'] ?? null;
+        if (is_string($default) && $default !== '') {
+            return $default;
+        }
+
+        if (is_array($localized)) {
+            foreach ($localized as $value) {
+                if (is_string($value) && $value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        $alternates = $names['alternates'] ?? [];
+        if (is_array($alternates)) {
+            foreach ($alternates as $alternate) {
+                if (is_string($alternate) && $alternate !== '') {
+                    return $alternate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildPreferredLocaleKeys(?string $locale): array
+    {
+        if ($locale === null) {
+            return [];
+        }
+
+        $lower      = strtolower($locale);
+        $normalized = str_replace('_', '-', $lower);
+
+        $candidates = [];
+        if ($normalized !== '') {
+            $candidates[] = $normalized;
+            $candidates[] = str_replace('-', '_', $normalized);
+        }
+
+        if (str_contains($normalized, '-')) {
+            $language = explode('-', $normalized)[0];
+            if ($language !== '') {
+                $candidates[] = $language;
+            }
+        } elseif ($normalized !== '') {
+            $candidates[] = $normalized;
+        }
+
+        $filtered = [];
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate)) {
+                continue;
+            }
+
+            $trimmed = trim($candidate);
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $filtered[$trimmed] = true;
+        }
+
+        /** @var list<string> $keys */
+        $keys = array_keys($filtered);
+
+        return $keys;
+    }
+}

--- a/src/Utility/DefaultPoiNormalizer.php
+++ b/src/Utility/DefaultPoiNormalizer.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility;
+
+use MagicSunday\Memories\Utility\Contract\PoiNormalizerInterface;
+
+use function array_keys;
+use function is_array;
+use function is_string;
+use function ksort;
+use function str_replace;
+use function strtolower;
+use function trim;
+
+use const SORT_STRING;
+
+/**
+ * Normalises raw POI payloads.
+ */
+final class DefaultPoiNormalizer implements PoiNormalizerInterface
+{
+    public function normalise(array $poi): ?array
+    {
+        $name  = is_string($poi['name'] ?? null) && $poi['name'] !== '' ? $poi['name'] : null;
+        $names = $this->normaliseNames($poi['names'] ?? null, $name);
+        if ($name === null) {
+            $name = $this->coalesceName($names);
+        }
+
+        $categoryKey   = is_string($poi['categoryKey'] ?? null) && $poi['categoryKey'] !== '' ? $poi['categoryKey'] : null;
+        $categoryValue = is_string($poi['categoryValue'] ?? null) && $poi['categoryValue'] !== '' ? $poi['categoryValue'] : null;
+
+        if ($name === null && $categoryValue === null) {
+            return null;
+        }
+
+        $tags    = [];
+        $rawTags = $poi['tags'] ?? null;
+        if (is_array($rawTags)) {
+            foreach ($rawTags as $tagKey => $tagValue) {
+                if (!is_string($tagKey) || $tagKey === '' || !is_string($tagValue) || $tagValue === '') {
+                    continue;
+                }
+
+                $tags[$tagKey] = $tagValue;
+            }
+        }
+
+        return [
+            'name'          => $name,
+            'names'         => $names,
+            'categoryKey'   => $categoryKey,
+            'categoryValue' => $categoryValue,
+            'tags'          => $tags,
+        ];
+    }
+
+    /**
+     * @param array{default:?string,localized:array<string,string>,alternates:list<string>}|null $raw
+     *
+     * @return array{default:?string,localized:array<string,string>,alternates:list<string>}
+     */
+    private function normaliseNames(?array $raw, ?string $fallbackDefault): array
+    {
+        $default    = $fallbackDefault;
+        $localized  = [];
+        $alternates = [];
+
+        if (is_array($raw)) {
+            $rawDefault = $raw['default'] ?? null;
+            if (is_string($rawDefault) && $rawDefault !== '') {
+                $default = $rawDefault;
+            }
+
+            $rawLocalized = $raw['localized'] ?? [];
+            if (is_array($rawLocalized)) {
+                foreach ($rawLocalized as $locale => $value) {
+                    if (!is_string($locale)) {
+                        continue;
+                    }
+
+                    $locale = strtolower(str_replace(' ', '_', $locale));
+                    if ($locale === '') {
+                        continue;
+                    }
+
+                    if (!is_string($value) || $value === '') {
+                        continue;
+                    }
+
+                    $localized[$locale] = $value;
+                }
+            }
+
+            $rawAlternates = $raw['alternates'] ?? [];
+            if (is_array($rawAlternates)) {
+                foreach ($rawAlternates as $alternate) {
+                    if (!is_string($alternate)) {
+                        continue;
+                    }
+
+                    $trimmed = trim($alternate);
+                    if ($trimmed === '') {
+                        continue;
+                    }
+
+                    $alternates[$trimmed] = true;
+                }
+            }
+        }
+
+        if ($localized !== []) {
+            ksort($localized, SORT_STRING);
+        }
+
+        /** @var list<string> $alternateList */
+        $alternateList = array_keys($alternates);
+
+        return [
+            'default'    => $default,
+            'localized'  => $localized,
+            'alternates' => $alternateList,
+        ];
+    }
+
+    /**
+     * @param array{default:?string,localized:array<string,string>,alternates:list<string>} $names
+     */
+    private function coalesceName(array $names): ?string
+    {
+        $default = $names['default'];
+        if (is_string($default) && $default !== '') {
+            return $default;
+        }
+
+        foreach ($names['localized'] as $value) {
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        foreach ($names['alternates'] as $alternate) {
+            if (is_string($alternate) && $alternate !== '') {
+                return $alternate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Utility/DefaultPoiScorer.php
+++ b/src/Utility/DefaultPoiScorer.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility;
+
+use MagicSunday\Memories\Utility\Contract\PoiScoringStrategyInterface;
+
+use function floor;
+use function is_string;
+
+/**
+ * Applies the default POI weighting heuristics.
+ */
+final class DefaultPoiScorer implements PoiScoringStrategyInterface
+{
+    private const int POI_NAME_BONUS = 100;
+
+    private const int POI_CATEGORY_VALUE_BONUS = 30;
+
+    private const int POI_WIKIDATA_BONUS = 120;
+
+    private const int POI_DISTANCE_PENALTY_DIVISOR = 25;
+
+    /**
+     * Tag specific weightings favouring more significant POIs.
+     *
+     * @var array<string,int>
+     */
+    private const array POI_TAG_WEIGHTS = [
+        'tourism'  => 600,
+        'historic' => 450,
+        'man_made' => 220,
+        'leisure'  => 140,
+        'natural'  => 140,
+        'place'    => 130,
+        'sport'    => 60,
+        'landuse'  => 25,
+    ];
+
+    /**
+     * Category key bonuses stacked on top of the tag weights.
+     *
+     * @var array<string,int>
+     */
+    private const array POI_CATEGORY_KEY_BONUS = [
+        'tourism'  => 220,
+        'historic' => 180,
+        'man_made' => 150,
+        'leisure'  => 90,
+        'natural'  => 90,
+        'place'    => 80,
+        'sport'    => 50,
+    ];
+
+    /**
+     * Additional bonuses for specific tag/value combinations.
+     *
+     * @var array<string,int>
+     */
+    private const array POI_TAG_VALUE_BONUS = [
+        'man_made:tower' => 260,
+    ];
+
+    public function score(array $poi, ?float $distance): int
+    {
+        $score = 0;
+
+        if ($poi['name'] !== null) {
+            $score += self::POI_NAME_BONUS;
+        }
+
+        if ($poi['categoryValue'] !== null) {
+            $score += self::POI_CATEGORY_VALUE_BONUS;
+        }
+
+        $categoryKey = $poi['categoryKey'];
+        if ($categoryKey !== null) {
+            $score += self::POI_CATEGORY_KEY_BONUS[$categoryKey] ?? 0;
+        }
+
+        foreach ($poi['tags'] as $tagKey => $tagValue) {
+            if (!is_string($tagValue)) {
+                continue;
+            }
+
+            $score += self::POI_TAG_WEIGHTS[$tagKey] ?? 0;
+            $score += self::POI_TAG_VALUE_BONUS[$tagKey . ':' . $tagValue] ?? 0;
+        }
+
+        if (isset($poi['tags']['wikidata'])) {
+            $score += self::POI_WIKIDATA_BONUS;
+        }
+
+        if ($distance !== null && $distance > 0.0) {
+            $score -= (int) floor($distance / self::POI_DISTANCE_PENALTY_DIVISOR);
+        }
+
+        return $score;
+    }
+}

--- a/src/Utility/LocationHelper.php
+++ b/src/Utility/LocationHelper.php
@@ -29,8 +29,11 @@ final readonly class LocationHelper implements LocationLabelResolverInterface, P
 
     public static function createDefault(?string $preferredLocale = null): self
     {
-        $poiAnalyzer   = new DefaultPoiContextAnalyzer($preferredLocale);
-        $labelResolver = new DefaultLocationLabelResolver($poiAnalyzer);
+        $poiNormalizer   = new DefaultPoiNormalizer();
+        $poiLabelResolver = new DefaultPoiLabelResolver($preferredLocale);
+        $poiScorer       = new DefaultPoiScorer();
+        $poiAnalyzer     = new DefaultPoiContextAnalyzer($poiNormalizer, $poiScorer, $poiLabelResolver);
+        $labelResolver   = new DefaultLocationLabelResolver($poiAnalyzer, $poiLabelResolver);
 
         return new self($labelResolver, $poiAnalyzer);
     }

--- a/test/Unit/Utility/DefaultPoiLabelResolverTest.php
+++ b/test/Unit/Utility/DefaultPoiLabelResolverTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Utility;
+
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\DefaultPoiLabelResolver;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DefaultPoiLabelResolverTest extends TestCase
+{
+    #[Test]
+    public function prefersConfiguredLocale(): void
+    {
+        $resolver = new DefaultPoiLabelResolver('de-DE');
+
+        $label = $resolver->preferredLabel([
+            'name'          => 'Central Park',
+            'names'         => [
+                'default'    => 'Central Park',
+                'localized'  => [
+                    'en'    => 'Central Park',
+                    'de-de' => 'Zentralpark',
+                ],
+                'alternates' => ['Parque Central'],
+            ],
+            'categoryKey'   => 'leisure',
+            'categoryValue' => 'park',
+            'tags'          => [],
+        ]);
+
+        self::assertSame('Zentralpark', $label);
+    }
+
+    #[Test]
+    public function fallsBackToPrimaryNameWhenNoNames(): void
+    {
+        $resolver = new DefaultPoiLabelResolver('fr');
+
+        $label = $resolver->preferredLabel([
+            'name'          => 'City Museum',
+            'names'         => [
+                'default'    => null,
+                'localized'  => [],
+                'alternates' => [],
+            ],
+            'categoryKey'   => 'tourism',
+            'categoryValue' => 'museum',
+            'tags'          => [],
+        ]);
+
+        self::assertSame('City Museum', $label);
+    }
+}

--- a/test/Unit/Utility/DefaultPoiNormalizerTest.php
+++ b/test/Unit/Utility/DefaultPoiNormalizerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Utility;
+
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\DefaultPoiNormalizer;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DefaultPoiNormalizerTest extends TestCase
+{
+    #[Test]
+    public function returnsNullWhenNoLabelInformationPresent(): void
+    {
+        $normalizer = new DefaultPoiNormalizer();
+
+        $result = $normalizer->normalise([
+            'tags' => [
+                'tourism' => 'museum',
+            ],
+        ]);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function normalisesNamesAndTags(): void
+    {
+        $normalizer = new DefaultPoiNormalizer();
+
+        $result = $normalizer->normalise([
+            'name'        => '',
+            'names'       => [
+                'default'    => ' Central Park ',
+                'localized'  => [
+                    'EN'        => 'Central Park',
+                    'de-DE'     => 'Zentralpark',
+                    'invalid '  => '',
+                ],
+                'alternates' => ['  Central ', 'Park', 42],
+            ],
+            'categoryKey'   => 'leisure',
+            'categoryValue' => 'park',
+            'tags'          => [
+                'leisure'  => 'park',
+                'wikidata' => 'Q160538',
+                'invalid'  => '',
+                12         => 'ignored',
+            ],
+        ]);
+
+        self::assertNotNull($result);
+        self::assertSame(' Central Park ', $result['name']);
+        self::assertSame('leisure', $result['categoryKey']);
+        self::assertSame('park', $result['categoryValue']);
+        self::assertSame(
+            [
+                'default'    => ' Central Park ',
+                'localized'  => [
+                    'de-de' => 'Zentralpark',
+                    'en'    => 'Central Park',
+                ],
+                'alternates' => ['Central', 'Park'],
+            ],
+            $result['names'],
+        );
+        self::assertSame(
+            [
+                'leisure'  => 'park',
+                'wikidata' => 'Q160538',
+            ],
+            $result['tags'],
+        );
+    }
+}

--- a/test/Unit/Utility/DefaultPoiScorerTest.php
+++ b/test/Unit/Utility/DefaultPoiScorerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Utility;
+
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\DefaultPoiScorer;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DefaultPoiScorerTest extends TestCase
+{
+    #[Test]
+    public function tourismPoiOutranksGenericAmenity(): void
+    {
+        $scorer = new DefaultPoiScorer();
+
+        $tourism = [
+            'name'          => 'City Museum',
+            'names'         => [
+                'default'    => 'City Museum',
+                'localized'  => [],
+                'alternates' => [],
+            ],
+            'categoryKey'   => 'tourism',
+            'categoryValue' => 'museum',
+            'tags'          => [
+                'tourism'  => 'museum',
+                'wikidata' => 'Q1',
+            ],
+        ];
+
+        $parking = [
+            'name'          => 'Parking Lot',
+            'names'         => [
+                'default'    => 'Parking Lot',
+                'localized'  => [],
+                'alternates' => [],
+            ],
+            'categoryKey'   => 'amenity',
+            'categoryValue' => 'parking',
+            'tags'          => [
+                'amenity' => 'parking',
+            ],
+        ];
+
+        $tourismScore = $scorer->score($tourism, 50.0);
+        $parkingScore = $scorer->score($parking, 10.0);
+
+        self::assertGreaterThan($parkingScore, $tourismScore);
+    }
+
+    #[Test]
+    public function distancePenaltyReducesScore(): void
+    {
+        $scorer = new DefaultPoiScorer();
+
+        $poi = [
+            'name'          => 'City Museum',
+            'names'         => [
+                'default'    => 'City Museum',
+                'localized'  => [],
+                'alternates' => [],
+            ],
+            'categoryKey'   => 'tourism',
+            'categoryValue' => 'museum',
+            'tags'          => [
+                'tourism' => 'museum',
+            ],
+        ];
+
+        $scoreClose  = $scorer->score($poi, 10.0);
+        $scoreFar    = $scorer->score($poi, 500.0);
+        $scoreRemote = $scorer->score($poi, null);
+
+        self::assertGreaterThan($scoreFar, $scoreClose);
+        self::assertSame($scoreClose, $scoreRemote);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce dedicated POI normaliser, scorer, and label resolver contracts with default implementations
- refactor the default POI context analyser and location label resolver to delegate to the new collaborators and wire them in the container
- cover the new services with focused unit tests alongside the existing helper façade

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dbf7ed82b88323ab8c81f3e20c0f58