### PR TITLE
Refactor Overpass parser into dedicated collaborators

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -206,6 +206,26 @@ services:
     MagicSunday\Memories\Service\Geocoding\OverpassQueryBuilderInterface:
         alias: MagicSunday\Memories\Service\Geocoding\DefaultOverpassQueryBuilder
 
+    MagicSunday\Memories\Service\Geocoding\OverpassElementFilter: ~
+
+    MagicSunday\Memories\Service\Geocoding\Contract\OverpassElementFilterInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\OverpassElementFilter
+
+    MagicSunday\Memories\Service\Geocoding\OverpassTagSelector: ~
+
+    MagicSunday\Memories\Service\Geocoding\Contract\OverpassTagSelectorInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\OverpassTagSelector
+
+    MagicSunday\Memories\Service\Geocoding\OverpassPrimaryTagResolver: ~
+
+    MagicSunday\Memories\Service\Geocoding\Contract\OverpassPrimaryTagResolverInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\OverpassPrimaryTagResolver
+
+    MagicSunday\Memories\Service\Geocoding\PoiNameExtractor: ~
+
+    MagicSunday\Memories\Service\Geocoding\Contract\PoiNameExtractorInterface:
+        alias: MagicSunday\Memories\Service\Geocoding\PoiNameExtractor
+
     MagicSunday\Memories\Service\Geocoding\DefaultOverpassResponseParser: ~
 
     MagicSunday\Memories\Service\Geocoding\OverpassResponseParserInterface:

--- a/src/Service/Geocoding/Contract/OverpassElementFilterInterface.php
+++ b/src/Service/Geocoding/Contract/OverpassElementFilterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding\Contract;
+
+/**
+ * Filters raw Overpass API elements to the subset usable for POI processing.
+ */
+interface OverpassElementFilterInterface
+{
+    /**
+     * Validates a raw Overpass element and extracts the normalized structure used by the parser.
+     *
+     * @param array<string, mixed> $element
+     *
+     * @return array{
+     *     id: string,
+     *     lat: float,
+     *     lon: float,
+     *     tags: array<string, mixed>
+     * }|null
+     */
+    public function filter(array $element): ?array;
+}

--- a/src/Service/Geocoding/Contract/OverpassPrimaryTagResolverInterface.php
+++ b/src/Service/Geocoding/Contract/OverpassPrimaryTagResolverInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding\Contract;
+
+/**
+ * Resolves the primary category tag for a POI element.
+ */
+interface OverpassPrimaryTagResolverInterface
+{
+    /**
+     * Determines the primary tag key/value pair from the provided tag list.
+     *
+     * @param array<string, mixed> $tags
+     *
+     * @return array{key: string, value: string}|null
+     */
+    public function resolve(array $tags): ?array;
+}

--- a/src/Service/Geocoding/Contract/OverpassTagSelectorInterface.php
+++ b/src/Service/Geocoding/Contract/OverpassTagSelectorInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding\Contract;
+
+/**
+ * Selects the relevant tags and names from Overpass POI metadata.
+ */
+interface OverpassTagSelectorInterface
+{
+    /**
+     * Reduces raw tags to the allowed subset and collects all supported name variants.
+     *
+     * @param array<string, mixed> $tags
+     *
+     * @return array{
+     *     tags: array<string, string>,
+     *     names: array{
+     *         default: ?string,
+     *         localized: array<string, string>,
+     *         alternates: list<string>
+     *     }
+     * }
+     */
+    public function select(array $tags): array;
+}

--- a/src/Service/Geocoding/Contract/PoiNameExtractorInterface.php
+++ b/src/Service/Geocoding/Contract/PoiNameExtractorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding\Contract;
+
+/**
+ * Resolves the display name for a POI based on extracted name information.
+ */
+interface PoiNameExtractorInterface
+{
+    /**
+     * Determines the preferred POI name from the collected name candidates.
+     *
+     * @param array{
+     *     default: ?string,
+     *     localized: array<string, string>,
+     *     alternates: list<string>
+     * } $names
+     */
+    public function extract(array $names): ?string;
+}

--- a/src/Service/Geocoding/DefaultOverpassResponseParser.php
+++ b/src/Service/Geocoding/DefaultOverpassResponseParser.php
@@ -11,42 +11,27 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Geocoding;
 
+use MagicSunday\Memories\Service\Geocoding\Contract\OverpassElementFilterInterface;
+use MagicSunday\Memories\Service\Geocoding\Contract\OverpassPrimaryTagResolverInterface;
+use MagicSunday\Memories\Service\Geocoding\Contract\OverpassTagSelectorInterface;
+use MagicSunday\Memories\Service\Geocoding\Contract\PoiNameExtractorInterface;
 use MagicSunday\Memories\Utility\MediaMath;
 
-use function array_filter;
-use function array_map;
 use function array_slice;
-use function array_unique;
 use function array_values;
 use function count;
-use function explode;
 use function is_array;
-use function is_numeric;
-use function is_string;
-use function ksort;
 use function round;
-use function str_replace;
-use function str_starts_with;
-use function strtolower;
-use function substr;
-use function trim;
 use function usort;
-
-use const SORT_STRING;
 
 final class DefaultOverpassResponseParser implements OverpassResponseParserInterface
 {
-    /**
-     * Additional tags that are kept in the output even if they are not primary category keys.
-     *
-     * @var list<string>
-     */
-    private const array AUXILIARY_TAG_KEYS = [
-        'wikidata',
-    ];
-
-    public function __construct(private readonly OverpassTagConfiguration $configuration)
-    {
+    public function __construct(
+        private readonly OverpassElementFilterInterface $elementFilter,
+        private readonly OverpassTagSelectorInterface $tagSelector,
+        private readonly OverpassPrimaryTagResolverInterface $primaryTagResolver,
+        private readonly PoiNameExtractorInterface $poiNameExtractor,
+    ) {
     }
 
     public function parse(array $payload, float $lat, float $lon, ?int $limit): array
@@ -63,55 +48,40 @@ final class DefaultOverpassResponseParser implements OverpassResponseParserInter
                 continue;
             }
 
-            $id = $this->elementId($element);
-            if ($id === null) {
+            $normalized = $this->elementFilter->filter($element);
+            if ($normalized === null) {
                 continue;
             }
 
+            $id = $normalized['id'];
             if (isset($pois[$id])) {
                 continue;
             }
 
-            $coordinate = $this->extractCoordinate($element);
-            if ($coordinate === null) {
-                continue;
-            }
-
-            $tags = $element['tags'] ?? null;
-            if (!is_array($tags)) {
-                $tags = [];
-            }
-
-            $selection    = $this->selectRelevantTags($tags);
+            $selection    = $this->tagSelector->select($normalized['tags']);
             $selectedTags = $selection['tags'];
             if ($selectedTags === []) {
                 continue;
             }
 
+            $primary = $this->primaryTagResolver->resolve($normalized['tags']);
+            if ($primary === null) {
+                continue;
+            }
+
             $names = $selection['names'];
-            $name  = $this->fallbackPoiName($names);
-
-            $primaryKey   = $this->primaryTagKey($tags);
-            $primaryValue = $primaryKey !== null ? $this->stringOrNull($selectedTags[$primaryKey] ?? null) : null;
-
-            if ($primaryKey === null || $primaryValue === null) {
-                continue;
-            }
-
-            if ($name === null && $primaryValue === null) {
-                continue;
-            }
+            $name  = $this->poiNameExtractor->extract($names);
 
             $pois[$id] = [
                 'id'             => $id,
                 'name'           => $name,
                 'names'          => $names,
-                'categoryKey'    => $primaryKey,
-                'categoryValue'  => $primaryValue,
-                'lat'            => $coordinate['lat'],
-                'lon'            => $coordinate['lon'],
+                'categoryKey'    => $primary['key'],
+                'categoryValue'  => $primary['value'],
+                'lat'            => $normalized['lat'],
+                'lon'            => $normalized['lon'],
                 'distanceMeters' => round(
-                    MediaMath::haversineDistanceInMeters($lat, $lon, $coordinate['lat'], $coordinate['lon']),
+                    MediaMath::haversineDistanceInMeters($lat, $lon, $normalized['lat'], $normalized['lon']),
                     2
                 ),
                 'tags' => $selectedTags,
@@ -133,218 +103,5 @@ final class DefaultOverpassResponseParser implements OverpassResponseParserInter
         }
 
         return $values;
-    }
-
-    private function elementId(array $element): ?string
-    {
-        $type = $this->stringOrNull($element['type'] ?? null);
-        $id   = $element['id'] ?? null;
-
-        if ($type === null || (!is_numeric($id) && !is_string($id))) {
-            return null;
-        }
-
-        return $type . '/' . $id;
-    }
-
-    /**
-     * @return array{lat: float, lon: float}|null
-     */
-    private function extractCoordinate(array $element): ?array
-    {
-        $lat = $element['lat'] ?? null;
-        $lon = $element['lon'] ?? null;
-
-        if (is_numeric($lat) && is_numeric($lon)) {
-            return ['lat' => (float) $lat, 'lon' => (float) $lon];
-        }
-
-        $center = $element['center'] ?? null;
-        if (is_array($center) && is_numeric($center['lat'] ?? null) && is_numeric($center['lon'] ?? null)) {
-            return ['lat' => (float) $center['lat'], 'lon' => (float) $center['lon']];
-        }
-
-        return null;
-    }
-
-    private function primaryTagKey(array $tags): ?string
-    {
-        foreach ($this->configuration->getAllowedTagMap() as $key => $values) {
-            $value = $this->stringOrNull($tags[$key] ?? null);
-            if ($value === null) {
-                continue;
-            }
-
-            if ($this->isAllowedTagValue($value, $values)) {
-                return $key;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array{
-     *     tags: array<string,string>,
-     *     names: array{
-     *         default: ?string,
-     *         localized: array<string,string>,
-     *         alternates: list<string>
-     *     }
-     * }
-     */
-    private function selectRelevantTags(array $tags): array
-    {
-        $selected = $this->filterAllowedTags($tags);
-
-        foreach (self::AUXILIARY_TAG_KEYS as $key) {
-            $value = $this->stringOrNull($tags[$key] ?? null);
-            if ($value !== null) {
-                $selected[$key] = $value;
-            }
-        }
-
-        $names = $this->extractNames($tags);
-
-        return [
-            'tags'  => $selected,
-            'names' => $names,
-        ];
-    }
-
-    /**
-     * @return array{
-     *     default: ?string,
-     *     localized: array<string,string>,
-     *     alternates: list<string>
-     * }
-     */
-    private function extractNames(array $tags): array
-    {
-        $default = $this->stringOrNull($tags['name'] ?? null);
-
-        /** @var array<string,string> $localized */
-        $localized = [];
-        foreach ($tags as $key => $value) {
-            if (!is_string($key)) {
-                continue;
-            }
-
-            if (!str_starts_with($key, 'name:')) {
-                continue;
-            }
-
-            $locale = substr($key, 5);
-            if ($locale === false) {
-                continue;
-            }
-
-            $locale = strtolower($locale);
-            if ($locale === '') {
-                continue;
-            }
-
-            $normalizedLocale = str_replace(' ', '_', $locale);
-            $name             = $this->stringOrNull($value);
-            if ($name === null) {
-                continue;
-            }
-
-            $localized[$normalizedLocale] = $name;
-        }
-
-        if ($localized !== []) {
-            ksort($localized, SORT_STRING);
-        }
-
-        $alternates = [];
-        $altName    = $this->stringOrNull($tags['alt_name'] ?? null);
-        if ($altName !== null) {
-            $parts = array_map(static fn (string $part): string => trim($part), explode(';', $altName));
-            $parts = array_filter($parts, static fn (string $part): bool => $part !== '');
-            if ($parts !== []) {
-                /** @var list<string> $unique */
-                $unique     = array_values(array_unique($parts));
-                $alternates = $unique;
-            }
-        }
-
-        return [
-            'default'    => $default,
-            'localized'  => $localized,
-            'alternates' => $alternates,
-        ];
-    }
-
-    /**
-     * @param array{
-     *     default: ?string,
-     *     localized: array<string,string>,
-     *     alternates: list<string>
-     * } $names
-     */
-    private function fallbackPoiName(array $names): ?string
-    {
-        $default = $names['default'];
-        if ($default !== null) {
-            return $default;
-        }
-
-        foreach ($names['localized'] as $name) {
-            if ($name !== '') {
-                return $name;
-            }
-        }
-
-        foreach ($names['alternates'] as $alternate) {
-            if ($alternate !== '') {
-                return $alternate;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array<string,string>
-     */
-    private function filterAllowedTags(array $tags): array
-    {
-        $allowed = [];
-        foreach ($this->configuration->getAllowedTagMap() as $key => $values) {
-            $value = $this->stringOrNull($tags[$key] ?? null);
-            if ($value === null) {
-                continue;
-            }
-
-            if ($this->isAllowedTagValue($value, $values)) {
-                $allowed[$key] = $value;
-            }
-        }
-
-        return $allowed;
-    }
-
-    /**
-     * @param list<string> $allowedValues
-     */
-    private function isAllowedTagValue(string $value, array $allowedValues): bool
-    {
-        if ($allowedValues === []) {
-            return false;
-        }
-
-        foreach ($allowedValues as $allowed) {
-            if ($allowed === $value) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function stringOrNull(mixed $value): ?string
-    {
-        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/src/Service/Geocoding/OverpassElementFilter.php
+++ b/src/Service/Geocoding/OverpassElementFilter.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\Contract\OverpassElementFilterInterface;
+
+use function is_array;
+use function is_numeric;
+use function is_string;
+
+final class OverpassElementFilter implements OverpassElementFilterInterface
+{
+    public function filter(array $element): ?array
+    {
+        $id = $this->elementId($element);
+        if ($id === null) {
+            return null;
+        }
+
+        $coordinate = $this->extractCoordinate($element);
+        if ($coordinate === null) {
+            return null;
+        }
+
+        $tags = $element['tags'] ?? [];
+        if (!is_array($tags)) {
+            $tags = [];
+        }
+
+        return [
+            'id'   => $id,
+            'lat'  => $coordinate['lat'],
+            'lon'  => $coordinate['lon'],
+            'tags' => $tags,
+        ];
+    }
+
+    private function elementId(array $element): ?string
+    {
+        $type = $element['type'] ?? null;
+        $id   = $element['id'] ?? null;
+
+        if (!is_string($type) || ($type === '')) {
+            return null;
+        }
+
+        if (!is_numeric($id) && !is_string($id)) {
+            return null;
+        }
+
+        return $type . '/' . $id;
+    }
+
+    /**
+     * @return array{lat: float, lon: float}|null
+     */
+    private function extractCoordinate(array $element): ?array
+    {
+        $lat = $element['lat'] ?? null;
+        $lon = $element['lon'] ?? null;
+
+        if (is_numeric($lat) && is_numeric($lon)) {
+            return ['lat' => (float) $lat, 'lon' => (float) $lon];
+        }
+
+        $center = $element['center'] ?? null;
+        if (is_array($center) && is_numeric($center['lat'] ?? null) && is_numeric($center['lon'] ?? null)) {
+            return ['lat' => (float) $center['lat'], 'lon' => (float) $center['lon']];
+        }
+
+        return null;
+    }
+}

--- a/src/Service/Geocoding/OverpassPrimaryTagResolver.php
+++ b/src/Service/Geocoding/OverpassPrimaryTagResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\Contract\OverpassPrimaryTagResolverInterface;
+
+use function is_string;
+
+final class OverpassPrimaryTagResolver implements OverpassPrimaryTagResolverInterface
+{
+    public function __construct(private readonly OverpassTagConfiguration $configuration)
+    {
+    }
+
+    public function resolve(array $tags): ?array
+    {
+        foreach ($this->configuration->getAllowedTagMap() as $key => $values) {
+            $value = $this->stringOrNull($tags[$key] ?? null);
+            if ($value === null) {
+                continue;
+            }
+
+            if ($this->isAllowedTagValue($value, $values)) {
+                return ['key' => $key, 'value' => $value];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $allowedValues
+     */
+    private function isAllowedTagValue(string $value, array $allowedValues): bool
+    {
+        if ($allowedValues === []) {
+            return false;
+        }
+
+        foreach ($allowedValues as $allowed) {
+            if ($allowed === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Service/Geocoding/OverpassTagSelector.php
+++ b/src/Service/Geocoding/OverpassTagSelector.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\Contract\OverpassTagSelectorInterface;
+
+use function array_filter;
+use function array_map;
+use function array_unique;
+use function array_values;
+use function explode;
+use function is_string;
+use function ksort;
+use function str_replace;
+use function str_starts_with;
+use function strtolower;
+use function substr;
+use function trim;
+
+use const SORT_STRING;
+
+final class OverpassTagSelector implements OverpassTagSelectorInterface
+{
+    /**
+     * Additional tags that are preserved even if they are not a category key.
+     *
+     * @var list<string>
+     */
+    private const array AUXILIARY_TAG_KEYS = [
+        'wikidata',
+    ];
+
+    public function __construct(private readonly OverpassTagConfiguration $configuration)
+    {
+    }
+
+    public function select(array $tags): array
+    {
+        $selected = $this->filterAllowedTags($tags);
+
+        foreach (self::AUXILIARY_TAG_KEYS as $key) {
+            $value = $this->stringOrNull($tags[$key] ?? null);
+            if ($value !== null) {
+                $selected[$key] = $value;
+            }
+        }
+
+        $names = $this->extractNames($tags);
+
+        return [
+            'tags'  => $selected,
+            'names' => $names,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     default: ?string,
+     *     localized: array<string, string>,
+     *     alternates: list<string>
+     * }
+     */
+    private function extractNames(array $tags): array
+    {
+        $default = $this->stringOrNull($tags['name'] ?? null);
+
+        /** @var array<string,string> $localized */
+        $localized = [];
+        foreach ($tags as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            if (!str_starts_with($key, 'name:')) {
+                continue;
+            }
+
+            $locale = substr($key, 5);
+            if ($locale === false) {
+                continue;
+            }
+
+            $locale = strtolower($locale);
+            if ($locale === '') {
+                continue;
+            }
+
+            $normalizedLocale = str_replace(' ', '_', $locale);
+            $name             = $this->stringOrNull($value);
+            if ($name === null) {
+                continue;
+            }
+
+            $localized[$normalizedLocale] = $name;
+        }
+
+        if ($localized !== []) {
+            ksort($localized, SORT_STRING);
+        }
+
+        $alternates = [];
+        $altName    = $this->stringOrNull($tags['alt_name'] ?? null);
+        if ($altName !== null) {
+            $parts = array_map(static fn (string $part): string => trim($part), explode(';', $altName));
+            $parts = array_filter($parts, static fn (string $part): bool => $part !== '');
+            if ($parts !== []) {
+                /** @var list<string> $unique */
+                $unique     = array_values(array_unique($parts));
+                $alternates = $unique;
+            }
+        }
+
+        return [
+            'default'    => $default,
+            'localized'  => $localized,
+            'alternates' => $alternates,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function filterAllowedTags(array $tags): array
+    {
+        $allowed = [];
+        foreach ($this->configuration->getAllowedTagMap() as $key => $values) {
+            $value = $this->stringOrNull($tags[$key] ?? null);
+            if ($value === null) {
+                continue;
+            }
+
+            if ($this->isAllowedTagValue($value, $values)) {
+                $allowed[$key] = $value;
+            }
+        }
+
+        return $allowed;
+    }
+
+    /**
+     * @param list<string> $allowedValues
+     */
+    private function isAllowedTagValue(string $value, array $allowedValues): bool
+    {
+        if ($allowedValues === []) {
+            return false;
+        }
+
+        foreach ($allowedValues as $allowed) {
+            if ($allowed === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Service/Geocoding/PoiNameExtractor.php
+++ b/src/Service/Geocoding/PoiNameExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\Contract\PoiNameExtractorInterface;
+
+final class PoiNameExtractor implements PoiNameExtractorInterface
+{
+    public function extract(array $names): ?string
+    {
+        $default = $names['default'];
+        if ($default !== null) {
+            return $default;
+        }
+
+        foreach ($names['localized'] as $name) {
+            if ($name !== '') {
+                return $name;
+            }
+        }
+
+        foreach ($names['alternates'] as $alternate) {
+            if ($alternate !== '') {
+                return $alternate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/test/Integration/Service/Geocoding/OverpassClientTest.php
+++ b/test/Integration/Service/Geocoding/OverpassClientTest.php
@@ -14,7 +14,11 @@ namespace MagicSunday\Memories\Test\Integration\Service\Geocoding;
 use MagicSunday\Memories\Service\Geocoding\DefaultOverpassQueryBuilder;
 use MagicSunday\Memories\Service\Geocoding\DefaultOverpassResponseParser;
 use MagicSunday\Memories\Service\Geocoding\OverpassClient;
+use MagicSunday\Memories\Service\Geocoding\OverpassElementFilter;
+use MagicSunday\Memories\Service\Geocoding\OverpassPrimaryTagResolver;
 use MagicSunday\Memories\Service\Geocoding\OverpassTagConfiguration;
+use MagicSunday\Memories\Service\Geocoding\OverpassTagSelector;
+use MagicSunday\Memories\Service\Geocoding\PoiNameExtractor;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -37,7 +41,12 @@ final class OverpassClientTest extends TestCase
         ]);
 
         $builder = new DefaultOverpassQueryBuilder($configuration, 25);
-        $parser  = new DefaultOverpassResponseParser($configuration);
+        $parser  = new DefaultOverpassResponseParser(
+            new OverpassElementFilter(),
+            new OverpassTagSelector($configuration),
+            new OverpassPrimaryTagResolver($configuration),
+            new PoiNameExtractor(),
+        );
 
         $response = new StaticJsonResponse(200, [
             'elements' => [

--- a/test/Unit/Service/Geocoding/DefaultOverpassResponseParserTest.php
+++ b/test/Unit/Service/Geocoding/DefaultOverpassResponseParserTest.php
@@ -12,7 +12,11 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
 
 use MagicSunday\Memories\Service\Geocoding\DefaultOverpassResponseParser;
+use MagicSunday\Memories\Service\Geocoding\OverpassElementFilter;
+use MagicSunday\Memories\Service\Geocoding\OverpassPrimaryTagResolver;
 use MagicSunday\Memories\Service\Geocoding\OverpassTagConfiguration;
+use MagicSunday\Memories\Service\Geocoding\OverpassTagSelector;
+use MagicSunday\Memories\Service\Geocoding\PoiNameExtractor;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -21,7 +25,13 @@ final class DefaultOverpassResponseParserTest extends TestCase
     #[Test]
     public function parsesPayloadAndOrdersByDistance(): void
     {
-        $parser = new DefaultOverpassResponseParser(new OverpassTagConfiguration());
+        $configuration = new OverpassTagConfiguration();
+        $parser        = new DefaultOverpassResponseParser(
+            new OverpassElementFilter(),
+            new OverpassTagSelector($configuration),
+            new OverpassPrimaryTagResolver($configuration),
+            new PoiNameExtractor(),
+        );
 
         $payload = [
             'elements' => [
@@ -87,7 +97,13 @@ final class DefaultOverpassResponseParserTest extends TestCase
     #[Test]
     public function appliesLimitToResultSet(): void
     {
-        $parser = new DefaultOverpassResponseParser(new OverpassTagConfiguration());
+        $configuration = new OverpassTagConfiguration();
+        $parser        = new DefaultOverpassResponseParser(
+            new OverpassElementFilter(),
+            new OverpassTagSelector($configuration),
+            new OverpassPrimaryTagResolver($configuration),
+            new PoiNameExtractor(),
+        );
 
         $payload = [
             'elements' => [

--- a/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
+++ b/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
@@ -17,7 +17,11 @@ use MagicSunday\Memories\Service\Geocoding\DefaultOverpassResponseParser;
 use MagicSunday\Memories\Service\Geocoding\GeocodeResult;
 use MagicSunday\Memories\Service\Geocoding\LocationPoiEnricher;
 use MagicSunday\Memories\Service\Geocoding\OverpassClient;
+use MagicSunday\Memories\Service\Geocoding\OverpassElementFilter;
+use MagicSunday\Memories\Service\Geocoding\OverpassPrimaryTagResolver;
 use MagicSunday\Memories\Service\Geocoding\OverpassTagConfiguration;
+use MagicSunday\Memories\Service\Geocoding\OverpassTagSelector;
+use MagicSunday\Memories\Service\Geocoding\PoiNameExtractor;
 use MagicSunday\Memories\Test\TestCase;
 use MagicSunday\Memories\Utility\MediaMath;
 use PHPUnit\Framework\Attributes\Test;
@@ -277,7 +281,12 @@ final class LocationPoiEnricherTest extends TestCase
         $client        = new OverpassClient(
             http: new FakeHttpClient($responses),
             queryBuilder: new DefaultOverpassQueryBuilder($configuration, 25),
-            responseParser: new DefaultOverpassResponseParser($configuration),
+            responseParser: new DefaultOverpassResponseParser(
+                new OverpassElementFilter(),
+                new OverpassTagSelector($configuration),
+                new OverpassPrimaryTagResolver($configuration),
+                new PoiNameExtractor(),
+            ),
             httpTimeout: 5.0,
         );
 

--- a/test/Unit/Service/Geocoding/OverpassElementFilterTest.php
+++ b/test/Unit/Service/Geocoding/OverpassElementFilterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\OverpassElementFilter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OverpassElementFilterTest extends TestCase
+{
+    #[Test]
+    public function returnsNormalizedElementWhenLatLonPresent(): void
+    {
+        $filter  = new OverpassElementFilter();
+        $element = [
+            'type' => 'node',
+            'id'   => 123,
+            'lat'  => 52.5,
+            'lon'  => 13.4,
+            'tags' => [
+                'tourism' => 'museum',
+            ],
+        ];
+
+        $normalized = $filter->filter($element);
+
+        self::assertNotNull($normalized);
+        self::assertSame('node/123', $normalized['id']);
+        self::assertSame(52.5, $normalized['lat']);
+        self::assertSame(13.4, $normalized['lon']);
+        self::assertSame(['tourism' => 'museum'], $normalized['tags']);
+    }
+
+    #[Test]
+    public function returnsNullWhenCoordinatesMissing(): void
+    {
+        $filter  = new OverpassElementFilter();
+        $element = [
+            'type' => 'node',
+            'id'   => 123,
+            'tags' => [],
+        ];
+
+        self::assertNull($filter->filter($element));
+    }
+
+    #[Test]
+    public function acceptsCenterCoordinateFallback(): void
+    {
+        $filter  = new OverpassElementFilter();
+        $element = [
+            'type'   => 'way',
+            'id'     => 456,
+            'center' => ['lat' => 48.1, 'lon' => 11.6],
+            'tags'   => [],
+        ];
+
+        $normalized = $filter->filter($element);
+
+        self::assertNotNull($normalized);
+        self::assertSame('way/456', $normalized['id']);
+        self::assertSame(48.1, $normalized['lat']);
+        self::assertSame(11.6, $normalized['lon']);
+    }
+}

--- a/test/Unit/Service/Geocoding/OverpassPrimaryTagResolverTest.php
+++ b/test/Unit/Service/Geocoding/OverpassPrimaryTagResolverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\OverpassPrimaryTagResolver;
+use MagicSunday\Memories\Service\Geocoding\OverpassTagConfiguration;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OverpassPrimaryTagResolverTest extends TestCase
+{
+    #[Test]
+    public function resolvesFirstMatchingTagBasedOnConfigurationOrder(): void
+    {
+        $configuration = new OverpassTagConfiguration();
+
+        $resolver = new OverpassPrimaryTagResolver($configuration);
+
+        $result = $resolver->resolve([
+            'man_made' => 'tower',
+            'historic' => 'castle',
+        ]);
+
+        self::assertNotNull($result);
+        self::assertSame('historic', $result['key']);
+        self::assertSame('castle', $result['value']);
+    }
+
+    #[Test]
+    public function returnsNullWhenNoAllowedTagPresent(): void
+    {
+        $configuration = new OverpassTagConfiguration([
+            ['tourism' => ['viewpoint']],
+        ]);
+
+        $resolver = new OverpassPrimaryTagResolver($configuration);
+
+        self::assertNull($resolver->resolve(['amenity' => 'cafe']));
+    }
+}

--- a/test/Unit/Service/Geocoding/OverpassTagSelectorTest.php
+++ b/test/Unit/Service/Geocoding/OverpassTagSelectorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\OverpassTagConfiguration;
+use MagicSunday\Memories\Service\Geocoding\OverpassTagSelector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class OverpassTagSelectorTest extends TestCase
+{
+    #[Test]
+    public function keepsAllowedTagsAndAuxiliaryOnes(): void
+    {
+        $configuration = new OverpassTagConfiguration();
+        $selector      = new OverpassTagSelector($configuration);
+
+        $result = $selector->select([
+            'tourism'  => 'museum',
+            'amenity'  => 'cafe',
+            'alt_name' => 'Alt A ; Alt B',
+            'name'     => 'Museum of Art',
+            'name:de'  => 'Kunstmuseum',
+            'name:en'  => 'Museum of Art',
+            'wikidata' => 'Q12345',
+        ]);
+
+        self::assertSame([
+            'tourism'  => 'museum',
+            'wikidata' => 'Q12345',
+        ], $result['tags']);
+
+        self::assertSame('Museum of Art', $result['names']['default']);
+        self::assertSame([
+            'de' => 'Kunstmuseum',
+            'en' => 'Museum of Art',
+        ], $result['names']['localized']);
+        self::assertSame(['Alt A', 'Alt B'], $result['names']['alternates']);
+    }
+
+    #[Test]
+    public function ignoresDisallowedTagsAndEmptyNames(): void
+    {
+        $configuration = new OverpassTagConfiguration([
+            ['tourism' => ['viewpoint']],
+        ]);
+        $selector      = new OverpassTagSelector($configuration);
+
+        $result = $selector->select([
+            'tourism'   => 'viewpoint',
+            'alt_name'  => ' ; Alt C ; Alt C',
+            'name:fr'   => '',
+            'name:es'   => ' Vista ',
+            'wikidata'  => 'Q99',
+            'randomtag' => 'value',
+        ]);
+
+        self::assertSame([
+            'tourism'  => 'viewpoint',
+            'wikidata' => 'Q99',
+        ], $result['tags']);
+
+        self::assertNull($result['names']['default']);
+        self::assertSame(['es' => ' Vista '], $result['names']['localized']);
+        self::assertSame(['Alt C'], $result['names']['alternates']);
+    }
+}

--- a/test/Unit/Service/Geocoding/PoiNameExtractorTest.php
+++ b/test/Unit/Service/Geocoding/PoiNameExtractorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\PoiNameExtractor;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PoiNameExtractorTest extends TestCase
+{
+    #[Test]
+    public function returnsDefaultNameWhenAvailable(): void
+    {
+        $extractor = new PoiNameExtractor();
+
+        $name = $extractor->extract([
+            'default'    => 'Central Park',
+            'localized'  => ['de' => 'Zentralpark'],
+            'alternates' => ['Park Central'],
+        ]);
+
+        self::assertSame('Central Park', $name);
+    }
+
+    #[Test]
+    public function fallsBackToLocalizedAndAlternateNames(): void
+    {
+        $extractor = new PoiNameExtractor();
+
+        $name = $extractor->extract([
+            'default'    => null,
+            'localized'  => ['de' => '', 'en' => 'Green Meadow'],
+            'alternates' => [''],
+        ]);
+
+        self::assertSame('Green Meadow', $name);
+
+        $alternateName = $extractor->extract([
+            'default'    => null,
+            'localized'  => [],
+            'alternates' => ['First Alternate', ''],
+        ]);
+
+        self::assertSame('First Alternate', $alternateName);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce dedicated contracts and implementations for Overpass element filtering, tag selection, primary tag resolution, and POI name extraction
- refactor the default Overpass response parser to coordinate the new collaborators and register them in the service container
- add targeted unit coverage for each new component and adjust existing tests to the orchestrated design

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68dbf7effd2c8323901f35171a2d50b6