### PR TITLE
feat: extract cluster job runner service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,6 +41,15 @@ services:
     MagicSunday\Memories\Utility\Contract\PoiScoringStrategyInterface:
         alias: MagicSunday\Memories\Utility\DefaultPoiScorer
 
+    MagicSunday\Memories\Service\Clusterer\Contract\ClusterJobRunnerInterface:
+        alias: MagicSunday\Memories\Service\Clusterer\DefaultClusterJobRunner
+
+    MagicSunday\Memories\Service\Clusterer\Contract\HybridClustererInterface:
+        alias: MagicSunday\Memories\Service\Clusterer\HybridClusterer
+
+    MagicSunday\Memories\Service\Clusterer\Contract\ClusterPersistenceInterface:
+        alias: MagicSunday\Memories\Service\Clusterer\ClusterPersistenceService
+
     MagicSunday\Memories\Utility\Contract\LocationLabelResolverInterface:
         alias: MagicSunday\Memories\Utility\DefaultLocationLabelResolver
 

--- a/src/Command/ClusterCommand.php
+++ b/src/Command/ClusterCommand.php
@@ -12,29 +12,18 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Command;
 
 use DateTimeImmutable;
-use Doctrine\ORM\EntityManagerInterface;
-use MagicSunday\Memories\Clusterer\ClusterDraft;
-use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidatorInterface;
-use MagicSunday\Memories\Service\Clusterer\ClusterPersistenceService;
-use MagicSunday\Memories\Service\Clusterer\HybridClusterer;
+use MagicSunday\Memories\Service\Clusterer\ClusterJobOptions;
+use MagicSunday\Memories\Service\Clusterer\ConsoleProgressReporter;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterJobRunnerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function array_keys;
-use function count;
 use function ctype_digit;
-use function floor;
 use function is_string;
-use function max;
-use function method_exists;
-use function microtime;
 use function sprintf;
 
 #[AsCommand(
@@ -43,12 +32,8 @@ use function sprintf;
 )]
 final class ClusterCommand extends Command
 {
-    public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly HybridClusterer $clusterer,
-        private readonly ClusterPersistenceService $persistence,
-        private readonly ClusterConsolidatorInterface $consolidation,
-    ) {
+    public function __construct(private readonly ClusterJobRunnerInterface $runner)
+    {
         parent::__construct();
     }
 
@@ -71,31 +56,17 @@ final class ClusterCommand extends Command
 
         $io->title('🧠 Memories: Cluster erstellen');
 
-        // 1) Medien laden
-        $io->section('Medien laden');
-
-        $countQb = $this->em->createQueryBuilder()
-            ->select('COUNT(m.id)')
-            ->from(Media::class, 'm');
-
-        $listQb = $this->em->createQueryBuilder()
-            ->select('m')
-            ->from(Media::class, 'm')
-            ->orderBy('m.takenAt', 'ASC')
-            ->addOrderBy('m.id', 'ASC');
-
+        $sinceValue = null;
         if (is_string($since) && $since !== '') {
-            $sinceDt = DateTimeImmutable::createFromFormat('Y-m-d|', $since);
-            if (!$sinceDt instanceof DateTimeImmutable) {
+            $sinceValue = DateTimeImmutable::createFromFormat('Y-m-d|', $since);
+            if (!$sinceValue instanceof DateTimeImmutable) {
                 $io->error('Invalid "since" date. Use YYYY-MM-DD.');
 
                 return Command::INVALID;
             }
-
-            $countQb->andWhere('m.takenAt >= :since')->setParameter('since', $sinceDt);
-            $listQb->andWhere('m.takenAt >= :since')->setParameter('since', $sinceDt);
         }
 
+        $limitValue = null;
         if (is_string($limit) && $limit !== '') {
             if (!ctype_digit($limit)) {
                 $io->error('Invalid "limit" value. Use a positive integer.');
@@ -103,218 +74,45 @@ final class ClusterCommand extends Command
                 return Command::INVALID;
             }
 
-            $lim = (int) $limit;
-            if ($lim > 0) {
-                $listQb->setMaxResults($lim);
+            $limitAsInt = (int) $limit;
+            if ($limitAsInt > 0) {
+                $limitValue = $limitAsInt;
             }
         }
 
-        $total = (int) $countQb->getQuery()->getSingleScalarResult();
-        if ($total === 0) {
+        $options = new ClusterJobOptions($dryRun, $limitValue, $sinceValue, $replace);
+
+        $progressReporter = new ConsoleProgressReporter($io, $output);
+        $result            = $this->runner->run($options, $progressReporter);
+
+        if ($result->getTotalMediaCount() === 0) {
             $io->warning('Keine Medien gefunden.');
 
             return Command::SUCCESS;
         }
 
-        $loadSection = $output->section();
-        $loadBar     = $this->makeBar($loadSection, $total, '📥 Einlesen');
-        $loadStart   = microtime(true);
-
-        /** @var list<Media> $items */
-        $items = [];
-        foreach ($listQb->getQuery()->toIterable() as $row) {
-            /** @var Media $m */
-            $m       = $row;
-            $items[] = $m;
-            $this->tick($loadBar, $loadStart, count($items), 'Medien');
-        }
-
-        $loadBar->finish();
-        $loadSection->writeln('');
-        $io->success(sprintf('%d Medien geladen.', count($items)));
-
-        if (count($items) === 0) {
+        $io->success(sprintf('%d Medien geladen.', $result->getLoadedMediaCount()));
+        if ($result->getLoadedMediaCount() === 0) {
             $io->note('Keine Medien zum Clustern vorhanden.');
 
             return Command::SUCCESS;
         }
 
-        // 2) Clustern – Hauptbalken + pro Strategie Unterbalken
-        $io->section('Clustere');
-
-        $strategyCount = $this->clusterer->countStrategies();
-
-        $mainSection = $output->section();
-        $mainBar     = $this->makeBar($mainSection, $strategyCount, '🧩 Strategien');
-        $mainStart   = microtime(true);
-
-        // Hauptleiste: bei Start nur Text setzen, bei Done einen Schritt vorwärts
-        $onStart = function (string $strategyName, int $index, int $total) use ($mainBar): void {
-            $mainBar->setMessage(sprintf('Strategie: %s (%d/%d)', $strategyName, $index, $total), 'phase');
-            $mainBar->setMessage('–', 'rate');
-            // kein advance hier – erst bei Done
-        };
-
-        $onDone = function (string $strategyName, int $index, int $total) use ($mainBar, $mainStart, $items): void {
-            $elapsed = max(0.000001, microtime(true) - $mainStart);
-            $rate    = count($items) / $elapsed;
-            $mainBar->setMessage(sprintf('Strategie: %s (%d/%d)', $strategyName, $index, $total), 'phase');
-            $mainBar->setMessage(sprintf('Durchsatz: %.1f Medien/s', $rate), 'rate');
-            $mainBar->advance(); // jetzt 1 Schritt weiter
-        };
-
-        /** @var list<ClusterDraft> $drafts */
-        $drafts = $this->clusterer->build(
-            $items,
-            $onStart,
-            $onDone,
-        );
-
-        $mainBar->finish();
-        $mainSection->writeln('');
-        $io->success(sprintf('%d Cluster vorgeschlagen.', count($drafts)));
-
-        if (count($drafts) === 0) {
+        $io->success(sprintf('%d Cluster vorgeschlagen.', $result->getDraftCount()));
+        if ($result->getDraftCount() === 0) {
             $io->note('Keine Cluster zu speichern.');
 
             return Command::SUCCESS;
         }
 
-        $io->section('Konsolidieren');
+        $io->success(sprintf('%d → %d Cluster nach Konsolidierung.', $result->getDraftCount(), $result->getConsolidatedCount()));
 
-        $before        = count($drafts);
-        $consolSection = $output->section();
-        $consolBar     = $this->makeBar($consolSection, $before, '🧹 Konsolidieren');
-        $conStart      = microtime(true);
-
-        $drafts = $this->consolidation->consolidate(
-            $drafts,
-            function (int $done, int $max, string $stage) use ($consolBar, $conStart): void {
-                $elapsed = max(
-                    0.000001,
-                    microtime(true) - $conStart
-                );
-                $rate = $done / $elapsed;
-                $consolBar->setMessage(
-                    sprintf(
-                        '%s | Durchsatz: %.1f Schritte/s',
-                        $stage,
-                        $rate
-                    ),
-                    'rate'
-                );
-                if (method_exists(
-                    $consolBar,
-                    'setProgress'
-                )) {
-                    $consolBar->setProgress($done);
-                } else {
-                    $consolBar->advance();
-                }
-            }
-        );
-
-        $consolBar->finish();
-        $consolSection->writeln('');
-        $io->success(sprintf('%d → %d Cluster nach Konsolidierung.', $before, count($drafts)));
-
-        // 3) Persistieren
-        $io->section($dryRun ? 'Persistieren (Trockenlauf)' : 'Persistieren');
-
-        if ($replace && !$dryRun) {
-            $algorithms = $this->collectAlgorithms($drafts);
-
-            if ($algorithms !== []) {
-                $deleted = $this->persistence->deleteByAlgorithms($algorithms);
-                $io->info(sprintf('%d bestehende Cluster gelöscht.', $deleted));
-            }
+        if (!$options->isDryRun() && $options->shouldReplace() && $result->getDeletedCount() > 0) {
+            $io->info(sprintf('%d bestehende Cluster gelöscht.', $result->getDeletedCount()));
         }
 
-        $persistSection = $output->section();
-        $persistBar     = $this->makeBar($persistSection, count($drafts), '💾 Speichern');
-        $persistStart   = microtime(true);
-
-        $persisted = 0;
-        if ($dryRun) {
-            foreach ($drafts as $_) {
-                ++$persisted;
-                $this->tick($persistBar, $persistStart, $persisted, 'Cluster');
-            }
-        } else {
-            $persisted = $this->persistence->persistBatched(
-                $drafts,
-                250,
-                function (int $ok) use ($persistBar, $persistStart, &$persisted): void {
-                    $persisted += $ok;
-                    $this->tick($persistBar, $persistStart, $persisted, 'Cluster');
-                }
-            );
-        }
-
-        $persistBar->finish();
-        $persistSection->writeln('');
-        $io->success(sprintf('%d Cluster gespeichert.', $persisted));
+        $io->success(sprintf('%d Cluster gespeichert.', $result->getPersistedCount()));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @param list<ClusterDraft> $drafts
-     *
-     * @return list<string>
-     */
-    private function collectAlgorithms(array $drafts): array
-    {
-        $algorithms = [];
-
-        foreach ($drafts as $draft) {
-            $algorithms[$draft->getAlgorithm()] = true;
-        }
-
-        return array_keys($algorithms);
-    }
-
-    /**
-     * Create a progress bar with stage text and live throughput.
-     * Uses named messages %phase% and %rate% (Console 7.3+).
-     */
-    private function makeBar(ConsoleSectionOutput $section, int $max, string $headline): ProgressBar
-    {
-        $bar = new ProgressBar($section, $max);
-
-        // Own duration placeholder to avoid version-specific APIs
-        $startedAt = microtime(true);
-        ProgressBar::setPlaceholderFormatterDefinition('duration_hms', static function () use ($startedAt): string {
-            $elapsed = (int) max(0, microtime(true) - $startedAt);
-            $h       = (int) floor($elapsed / 3600);
-            $m       = (int) floor(($elapsed % 3600) / 60);
-            $s       = $elapsed % 60;
-
-            return sprintf('%02d:%02d:%02d', $h, $m, $s);
-        });
-
-        // Named messages: %phase% and %rate%
-        $bar->setFormat(sprintf(
-            "%s\n%%current%%/%%max%% [%%bar%%] %%percent%%%% | Dauer: %%duration_hms%% | ETA: %%remaining%% | %%phase%% | %%rate%%",
-            $headline
-        ));
-        $bar->setBarCharacter('=');
-        $bar->setEmptyBarCharacter(' ');
-        $bar->setProgressCharacter('>');
-        $bar->setRedrawFrequency(1);
-
-        // init named messages
-        $bar->setMessage('', 'phase');
-        $bar->setMessage('–', 'rate');
-
-        return $bar;
-    }
-
-    private function tick(ProgressBar $bar, float $startTs, int $processed, string $unit): void
-    {
-        $elapsed = max(0.000001, microtime(true) - $startTs);
-        $rate    = $processed / $elapsed;
-        $bar->setMessage(sprintf('Durchsatz: %.1f %s/s', $rate, $unit));
-        $bar->advance();
     }
 }

--- a/src/Service/Clusterer/ClusterJobOptions.php
+++ b/src/Service/Clusterer/ClusterJobOptions.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer;
+
+use DateTimeImmutable;
+
+final class ClusterJobOptions
+{
+    public function __construct(
+        private readonly bool $dryRun,
+        private readonly ?int $limit,
+        private readonly ?DateTimeImmutable $since,
+        private readonly bool $replace,
+    ) {
+    }
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function getSince(): ?DateTimeImmutable
+    {
+        return $this->since;
+    }
+
+    public function shouldReplace(): bool
+    {
+        return $this->replace;
+    }
+}

--- a/src/Service/Clusterer/ClusterJobResult.php
+++ b/src/Service/Clusterer/ClusterJobResult.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer;
+
+final class ClusterJobResult
+{
+    public function __construct(
+        private readonly int $totalMediaCount,
+        private readonly int $loadedMediaCount,
+        private readonly int $draftCount,
+        private readonly int $consolidatedCount,
+        private readonly int $persistedCount,
+        private readonly int $deletedCount,
+        private readonly bool $dryRun,
+    ) {
+    }
+
+    public function getTotalMediaCount(): int
+    {
+        return $this->totalMediaCount;
+    }
+
+    public function getLoadedMediaCount(): int
+    {
+        return $this->loadedMediaCount;
+    }
+
+    public function getDraftCount(): int
+    {
+        return $this->draftCount;
+    }
+
+    public function getConsolidatedCount(): int
+    {
+        return $this->consolidatedCount;
+    }
+
+    public function getPersistedCount(): int
+    {
+        return $this->persistedCount;
+    }
+
+    public function getDeletedCount(): int
+    {
+        return $this->deletedCount;
+    }
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+}

--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -14,12 +14,13 @@ namespace MagicSunday\Memories\Service\Clusterer;
 use Doctrine\ORM\EntityManagerInterface;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Entity\Cluster;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterPersistenceInterface;
 
 use function array_keys;
 use function array_unique;
 use function array_values;
 
-final readonly class ClusterPersistenceService
+final readonly class ClusterPersistenceService implements ClusterPersistenceInterface
 {
     public function __construct(
         private EntityManagerInterface $em,

--- a/src/Service/Clusterer/ConsoleProgressReporter.php
+++ b/src/Service/Clusterer/ConsoleProgressReporter.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer;
+
+use MagicSunday\Memories\Service\Clusterer\Contract\ProgressHandleInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\ProgressReporterInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function floor;
+use function max;
+use function microtime;
+use function sprintf;
+
+final class ConsoleProgressReporter implements ProgressReporterInterface
+{
+    public function __construct(
+        private readonly SymfonyStyle $io,
+        private readonly OutputInterface $output,
+    ) {
+    }
+
+    public function create(string $sectionTitle, string $headline, int $max): ProgressHandleInterface
+    {
+        $this->io->section($sectionTitle);
+
+        $section = $this->output->section();
+        $bar     = $this->makeBar($section, $max, $headline);
+
+        return new class($section, $bar) implements ProgressHandleInterface {
+            public function __construct(
+                private readonly ConsoleSectionOutput $section,
+                private readonly ProgressBar $bar,
+            ) {
+            }
+
+            public function advance(int $step = 1): void
+            {
+                if ($step <= 0) {
+                    return;
+                }
+
+                $this->bar->advance($step);
+            }
+
+            public function setPhase(?string $message): void
+            {
+                $this->bar->setMessage($message ?? '', 'phase');
+            }
+
+            public function setRate(?string $message): void
+            {
+                $this->bar->setMessage($message ?? '–', 'rate');
+            }
+
+            public function setProgress(int $current): void
+            {
+                $this->bar->setProgress($current);
+            }
+
+            public function finish(): void
+            {
+                $this->bar->finish();
+                $this->section->writeln('');
+            }
+        };
+    }
+
+    private function makeBar(ConsoleSectionOutput $section, int $max, string $headline): ProgressBar
+    {
+        $bar = new ProgressBar($section, $max);
+
+        $startedAt = microtime(true);
+        ProgressBar::setPlaceholderFormatterDefinition('duration_hms', static function () use ($startedAt): string {
+            $elapsed = (int) max(0, microtime(true) - $startedAt);
+            $hours   = (int) floor($elapsed / 3600);
+            $minutes = (int) floor(($elapsed % 3600) / 60);
+            $seconds = $elapsed % 60;
+
+            return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
+        });
+
+        $bar->setFormat(sprintf(
+            "%s\n%%current%%/%%max%% [%%bar%%] %%percent%%%% | Dauer: %%duration_hms%% | ETA: %%remaining%% | %%phase%% | %%rate%%",
+            $headline,
+        ));
+        $bar->setBarCharacter('=');
+        $bar->setEmptyBarCharacter(' ');
+        $bar->setProgressCharacter('>');
+        $bar->setRedrawFrequency(1);
+        $bar->setMessage('', 'phase');
+        $bar->setMessage('–', 'rate');
+
+        return $bar;
+    }
+}

--- a/src/Service/Clusterer/Contract/ClusterJobRunnerInterface.php
+++ b/src/Service/Clusterer/Contract/ClusterJobRunnerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer\Contract;
+
+use MagicSunday\Memories\Service\Clusterer\ClusterJobOptions;
+use MagicSunday\Memories\Service\Clusterer\ClusterJobResult;
+
+interface ClusterJobRunnerInterface
+{
+    public function run(ClusterJobOptions $options, ProgressReporterInterface $progressReporter): ClusterJobResult;
+}

--- a/src/Service/Clusterer/Contract/ClusterPersistenceInterface.php
+++ b/src/Service/Clusterer/Contract/ClusterPersistenceInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer\Contract;
+
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+
+interface ClusterPersistenceInterface
+{
+    /**
+     * @param list<ClusterDraft>                   $drafts
+     * @param callable(int):void|null              $onBatchPersisted
+     */
+    public function persistBatched(array $drafts, int $batchSize, ?callable $onBatchPersisted): int;
+
+    /**
+     * @param list<string> $algorithms
+     */
+    public function deleteByAlgorithms(array $algorithms): int;
+}

--- a/src/Service/Clusterer/Contract/HybridClustererInterface.php
+++ b/src/Service/Clusterer/Contract/HybridClustererInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer\Contract;
+
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Entity\Media;
+
+interface HybridClustererInterface
+{
+    public function countStrategies(): int;
+
+    /**
+     * @param list<Media>                      $items
+     * @param callable(string,int,int):void    $onStart
+     * @param callable(string,int,int):void    $onDone
+     *
+     * @return list<ClusterDraft>
+     */
+    public function build(array $items, callable $onStart, callable $onDone): array;
+}

--- a/src/Service/Clusterer/Contract/ProgressHandleInterface.php
+++ b/src/Service/Clusterer/Contract/ProgressHandleInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer\Contract;
+
+interface ProgressHandleInterface
+{
+    public function advance(int $step = 1): void;
+
+    public function setPhase(?string $message): void;
+
+    public function setRate(?string $message): void;
+
+    public function setProgress(int $current): void;
+
+    public function finish(): void;
+}

--- a/src/Service/Clusterer/Contract/ProgressReporterInterface.php
+++ b/src/Service/Clusterer/Contract/ProgressReporterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer\Contract;
+
+interface ProgressReporterInterface
+{
+    public function create(string $sectionTitle, string $headline, int $max): ProgressHandleInterface;
+}

--- a/src/Service/Clusterer/DefaultClusterJobRunner.php
+++ b/src/Service/Clusterer/DefaultClusterJobRunner.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidatorInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterJobRunnerInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterPersistenceInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\HybridClustererInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\ProgressReporterInterface;
+
+use function array_keys;
+use function count;
+use function max;
+use function microtime;
+use function sprintf;
+
+final class DefaultClusterJobRunner implements ClusterJobRunnerInterface
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly HybridClustererInterface $clusterer,
+        private readonly ClusterConsolidatorInterface $consolidator,
+        private readonly ClusterPersistenceInterface $persistence,
+    ) {
+    }
+
+    public function run(ClusterJobOptions $options, ProgressReporterInterface $progressReporter): ClusterJobResult
+    {
+        $countQb = $this->entityManager->createQueryBuilder()
+            ->select('COUNT(m.id)')
+            ->from(Media::class, 'm');
+
+        $listQb = $this->entityManager->createQueryBuilder()
+            ->select('m')
+            ->from(Media::class, 'm')
+            ->orderBy('m.takenAt', 'ASC')
+            ->addOrderBy('m.id', 'ASC');
+
+        $since = $options->getSince();
+        if ($since instanceof DateTimeImmutable) {
+            $countQb->andWhere('m.takenAt >= :since')->setParameter('since', $since);
+            $listQb->andWhere('m.takenAt >= :since')->setParameter('since', $since);
+        }
+
+        $limit = $options->getLimit();
+        if ($limit !== null && $limit > 0) {
+            $listQb->setMaxResults($limit);
+        }
+
+        $total = (int) $countQb->getQuery()->getSingleScalarResult();
+        if ($total === 0) {
+            return new ClusterJobResult(0, 0, 0, 0, 0, 0, $options->isDryRun());
+        }
+
+        /** @var list<Media> $items */
+        $items = [];
+        $loadHandle = $progressReporter->create('Medien laden', '📥 Einlesen', $total);
+        $loadStart  = microtime(true);
+        foreach ($listQb->getQuery()->toIterable() as $row) {
+            $items[] = $row;
+            $processed = count($items);
+            $loadHandle->setRate($this->formatRate($processed, $loadStart, 'Medien'));
+            $loadHandle->advance();
+        }
+        $loadHandle->finish();
+
+        $loadedCount = count($items);
+        if ($loadedCount === 0) {
+            return new ClusterJobResult($total, 0, 0, 0, 0, 0, $options->isDryRun());
+        }
+
+        $strategyCount = $this->clusterer->countStrategies();
+        $clusterHandle = $progressReporter->create('Clustere', '🧩 Strategien', $strategyCount);
+        $clusterStart  = microtime(true);
+
+        /** @var list<ClusterDraft> $drafts */
+        $drafts = $this->clusterer->build(
+            $items,
+            function (string $strategyName, int $index, int $strategyTotal) use ($clusterHandle): void {
+                $clusterHandle->setPhase(sprintf('Strategie: %s (%d/%d)', $strategyName, $index, $strategyTotal));
+                $clusterHandle->setRate('–');
+            },
+            function (string $strategyName, int $index, int $strategyTotal) use ($clusterHandle, $clusterStart, $loadedCount): void {
+                $clusterHandle->setPhase(sprintf('Strategie: %s (%d/%d)', $strategyName, $index, $strategyTotal));
+                $clusterHandle->setRate($this->formatRate($loadedCount, $clusterStart, 'Medien'));
+                $clusterHandle->advance();
+            },
+        );
+        $clusterHandle->finish();
+
+        $draftCount = count($drafts);
+        if ($draftCount === 0) {
+            return new ClusterJobResult($total, $loadedCount, 0, 0, 0, 0, $options->isDryRun());
+        }
+
+        $consolidateHandle = $progressReporter->create('Konsolidieren', '🧹 Konsolidieren', $draftCount);
+        $consolidateStart  = microtime(true);
+
+        $drafts = $this->consolidator->consolidate(
+            $drafts,
+            function (int $done, int $maxSteps, string $stage) use ($consolidateHandle, $consolidateStart): void {
+                $consolidateHandle->setPhase($stage);
+                $consolidateHandle->setRate($this->formatRate($done, $consolidateStart, 'Schritte'));
+                $consolidateHandle->setProgress($done);
+            },
+        );
+        $consolidateHandle->finish();
+
+        $consolidatedCount = count($drafts);
+        if ($consolidatedCount === 0) {
+            return new ClusterJobResult($total, $loadedCount, $draftCount, 0, 0, 0, $options->isDryRun());
+        }
+
+        $deleted = 0;
+        if ($options->shouldReplace() && !$options->isDryRun()) {
+            $deleted = $this->persistence->deleteByAlgorithms($this->collectAlgorithms($drafts));
+        }
+
+        $persistHandle = $progressReporter->create(
+            $options->isDryRun() ? 'Persistieren (Trockenlauf)' : 'Persistieren',
+            '💾 Speichern',
+            $consolidatedCount,
+        );
+        $persistStart = microtime(true);
+
+        $persisted = 0;
+        if ($options->isDryRun()) {
+            foreach ($drafts as $_) {
+                ++$persisted;
+                $persistHandle->setRate($this->formatRate($persisted, $persistStart, 'Cluster'));
+                $persistHandle->advance();
+            }
+        } else {
+            $persisted = $this->persistence->persistBatched(
+                $drafts,
+                250,
+                function (int $persistedInBatch) use (&$persisted, $persistHandle, $persistStart): void {
+                    $persisted += $persistedInBatch;
+                    $persistHandle->setRate($this->formatRate($persisted, $persistStart, 'Cluster'));
+                    $persistHandle->advance($persistedInBatch);
+                },
+            );
+        }
+        $persistHandle->finish();
+
+        return new ClusterJobResult(
+            $total,
+            $loadedCount,
+            $draftCount,
+            $consolidatedCount,
+            $persisted,
+            $deleted,
+            $options->isDryRun(),
+        );
+    }
+
+    /**
+     * @param list<ClusterDraft> $drafts
+     *
+     * @return list<string>
+     */
+    private function collectAlgorithms(array $drafts): array
+    {
+        $algorithms = [];
+
+        foreach ($drafts as $draft) {
+            $algorithms[$draft->getAlgorithm()] = true;
+        }
+
+        return array_keys($algorithms);
+    }
+
+    private function formatRate(int $processed, float $startedAt, string $unit): string
+    {
+        $elapsed = max(0.000001, microtime(true) - $startedAt);
+        $rate    = $processed / $elapsed;
+
+        return sprintf('Durchsatz: %.1f %s/s', $rate, $unit);
+    }
+}

--- a/src/Service/Clusterer/HybridClusterer.php
+++ b/src/Service/Clusterer/HybridClusterer.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Clusterer;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Clusterer\Contract\HybridClustererInterface;
 use MagicSunday\Memories\Service\Clusterer\Scoring\CompositeClusterScorer;
 
 use function array_merge;
@@ -21,7 +22,7 @@ use function count;
 use function is_array;
 use function iterator_to_array;
 
-final class HybridClusterer
+final class HybridClusterer implements HybridClustererInterface
 {
     /** @var list<ClusterStrategyInterface>|null */
     private ?array $strategiesCache = null;

--- a/src/Service/Clusterer/NullProgressReporter.php
+++ b/src/Service/Clusterer/NullProgressReporter.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Clusterer;
+
+use MagicSunday\Memories\Service\Clusterer\Contract\ProgressHandleInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\ProgressReporterInterface;
+
+final class NullProgressReporter implements ProgressReporterInterface
+{
+    public function create(string $sectionTitle, string $headline, int $max): ProgressHandleInterface
+    {
+        return new class() implements ProgressHandleInterface {
+            public function advance(int $step = 1): void
+            {
+            }
+
+            public function setPhase(?string $message): void
+            {
+            }
+
+            public function setRate(?string $message): void
+            {
+            }
+
+            public function setProgress(int $current): void
+            {
+            }
+
+            public function finish(): void
+            {
+            }
+        };
+    }
+}

--- a/test/Unit/Command/ClusterCommandTest.php
+++ b/test/Unit/Command/ClusterCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Command;
+
+use MagicSunday\Memories\Command\ClusterCommand;
+use MagicSunday\Memories\Service\Clusterer\ClusterJobOptions;
+use MagicSunday\Memories\Service\Clusterer\ClusterJobResult;
+use MagicSunday\Memories\Service\Clusterer\ConsoleProgressReporter;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterJobRunnerInterface;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ClusterCommandTest extends TestCase
+{
+    #[Test]
+    public function executeRejectsInvalidSinceDate(): void
+    {
+        $runner = $this->createMock(ClusterJobRunnerInterface::class);
+        $runner->expects(self::never())->method('run');
+
+        $command = new ClusterCommand($runner);
+        $tester  = new CommandTester($command);
+
+        $status = $tester->execute([
+            '--since' => 'not-a-date',
+        ], [
+            'decorated' => false,
+        ]);
+
+        self::assertSame(Command::INVALID, $status);
+        self::assertStringContainsString('Invalid "since" date. Use YYYY-MM-DD.', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function executeDelegatesToRunnerAndPrintsSummary(): void
+    {
+        $runner = $this->createMock(ClusterJobRunnerInterface::class);
+        $runner->expects(self::once())
+            ->method('run')
+            ->with(
+                self::callback(function (ClusterJobOptions $options): bool {
+                    self::assertTrue($options->isDryRun());
+                    self::assertSame(25, $options->getLimit());
+                    self::assertNotNull($options->getSince());
+                    self::assertTrue($options->shouldReplace());
+
+                    return true;
+                }),
+                self::callback(function ($reporter): bool {
+                    self::assertInstanceOf(ConsoleProgressReporter::class, $reporter);
+
+                    return true;
+                }),
+            )
+            ->willReturn(new ClusterJobResult(5, 4, 3, 2, 2, 0, true));
+
+        $command = new ClusterCommand($runner);
+        $tester  = new CommandTester($command);
+
+        $status = $tester->execute([
+            '--dry-run' => true,
+            '--limit'   => '25',
+            '--since'   => '2023-05-17',
+            '--replace' => true,
+        ], [
+            'decorated' => false,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('4 Medien geladen.', $display);
+        self::assertStringContainsString('3 Cluster vorgeschlagen.', $display);
+        self::assertStringContainsString('3 → 2 Cluster nach Konsolidierung.', $display);
+        self::assertStringContainsString('2 Cluster gespeichert.', $display);
+    }
+}

--- a/test/Unit/Service/Clusterer/DefaultClusterJobRunnerTest.php
+++ b/test/Unit/Service/Clusterer/DefaultClusterJobRunnerTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Clusterer;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Clusterer\ClusterJobOptions;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidatorInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterPersistenceInterface;
+use MagicSunday\Memories\Service\Clusterer\Contract\HybridClustererInterface;
+use MagicSunday\Memories\Service\Clusterer\DefaultClusterJobRunner;
+use MagicSunday\Memories\Service\Clusterer\NullProgressReporter;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DefaultClusterJobRunnerTest extends TestCase
+{
+    #[Test]
+    public function runReturnsEarlyWhenNoMedia(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $countQb = $this->createQueryBuilderMock(['select', 'from', 'andWhere', 'setParameter', 'getQuery']);
+        $countQuery = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSingleScalarResult'])
+            ->getMock();
+        $countQuery->expects(self::once())->method('getSingleScalarResult')->willReturn('0');
+        $countQb->method('getQuery')->willReturn($countQuery);
+
+        $listQb = $this->createQueryBuilderMock(['select', 'from', 'orderBy', 'addOrderBy', 'andWhere', 'setParameter', 'setMaxResults', 'getQuery']);
+        $listQb->expects(self::never())->method('getQuery');
+
+        $entityManager->expects(self::exactly(2))
+            ->method('createQueryBuilder')
+            ->willReturnOnConsecutiveCalls($countQb, $listQb);
+
+        $clusterer = $this->createMock(HybridClustererInterface::class);
+        $clusterer->expects(self::never())->method('countStrategies');
+        $clusterer->expects(self::never())->method('build');
+
+        $consolidator = $this->createMock(ClusterConsolidatorInterface::class);
+        $consolidator->expects(self::never())->method('consolidate');
+
+        $persistence = $this->createMock(ClusterPersistenceInterface::class);
+        $persistence->expects(self::never())->method('deleteByAlgorithms');
+        $persistence->expects(self::never())->method('persistBatched');
+
+        $runner  = new DefaultClusterJobRunner($entityManager, $clusterer, $consolidator, $persistence);
+        $options = new ClusterJobOptions(false, null, null, false);
+
+        $result = $runner->run($options, new NullProgressReporter());
+
+        self::assertSame(0, $result->getTotalMediaCount());
+        self::assertSame(0, $result->getLoadedMediaCount());
+        self::assertSame(0, $result->getDraftCount());
+        self::assertSame(0, $result->getConsolidatedCount());
+        self::assertSame(0, $result->getPersistedCount());
+        self::assertSame(0, $result->getDeletedCount());
+        self::assertFalse($result->isDryRun());
+    }
+
+    #[Test]
+    public function runPersistsConsolidatedDrafts(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $countQb = $this->createQueryBuilderMock(['select', 'from', 'andWhere', 'setParameter', 'getQuery']);
+        $countQuery = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSingleScalarResult'])
+            ->getMock();
+        $countQuery->expects(self::once())->method('getSingleScalarResult')->willReturn('2');
+        $countQb->method('getQuery')->willReturn($countQuery);
+
+        $listQb = $this->createQueryBuilderMock(['select', 'from', 'orderBy', 'addOrderBy', 'andWhere', 'setParameter', 'setMaxResults', 'getQuery']);
+        $mediaOne = new Media('one.jpg', 'checksum-one', 1);
+        $mediaTwo = new Media('two.jpg', 'checksum-two', 1);
+        $listQuery = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['toIterable'])
+            ->getMock();
+        $listQuery->expects(self::once())->method('toIterable')->willReturn([$mediaOne, $mediaTwo]);
+        $listQb->method('getQuery')->willReturn($listQuery);
+
+        $entityManager->expects(self::exactly(2))
+            ->method('createQueryBuilder')
+            ->willReturnOnConsecutiveCalls($countQb, $listQb);
+
+        $drafts = [
+            new ClusterDraft('algo-a', [], ['lat' => 0.0, 'lon' => 0.0], [1, 2]),
+            new ClusterDraft('algo-b', [], ['lat' => 0.0, 'lon' => 0.0], [3, 4]),
+        ];
+        $consolidatedDrafts = [
+            new ClusterDraft('algo-a', [], ['lat' => 0.0, 'lon' => 0.0], [1, 2]),
+        ];
+
+        $clusterer = $this->createMock(HybridClustererInterface::class);
+        $clusterer->expects(self::once())->method('countStrategies')->willReturn(1);
+        $clusterer->expects(self::once())
+            ->method('build')
+            ->willReturnCallback(function (array $items, callable $onStart, callable $onDone) use ($drafts): array {
+                self::assertCount(2, $items);
+                $onStart('Strategy', 1, 1);
+                $onDone('Strategy', 1, 1);
+
+                return $drafts;
+            });
+
+        $consolidator = $this->createMock(ClusterConsolidatorInterface::class);
+        $consolidator->expects(self::once())
+            ->method('consolidate')
+            ->willReturnCallback(function (array $inputDrafts, callable $callback) use ($consolidatedDrafts): array {
+                self::assertCount(2, $inputDrafts);
+                $callback(1, 2, 'stage');
+
+                return $consolidatedDrafts;
+            });
+
+        $persistence = $this->createMock(ClusterPersistenceInterface::class);
+        $persistence->expects(self::once())
+            ->method('deleteByAlgorithms')
+            ->with(['algo-a'])
+            ->willReturn(5);
+        $persistence->expects(self::once())
+            ->method('persistBatched')
+            ->willReturnCallback(function (array $persistedDrafts, int $batchSize, ?callable $callback): int {
+                self::assertSame(250, $batchSize);
+                self::assertCount(1, $persistedDrafts);
+                self::assertNotNull($callback);
+                $callback(1);
+
+                return 1;
+            });
+
+        $runner  = new DefaultClusterJobRunner($entityManager, $clusterer, $consolidator, $persistence);
+        $options = new ClusterJobOptions(false, null, null, true);
+
+        $result = $runner->run($options, new NullProgressReporter());
+
+        self::assertSame(2, $result->getTotalMediaCount());
+        self::assertSame(2, $result->getLoadedMediaCount());
+        self::assertSame(2, $result->getDraftCount());
+        self::assertSame(1, $result->getConsolidatedCount());
+        self::assertSame(1, $result->getPersistedCount());
+        self::assertSame(5, $result->getDeletedCount());
+        self::assertFalse($result->isDryRun());
+    }
+
+    #[Test]
+    public function runPerformsDryRunWithoutPersistence(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $countQb = $this->createQueryBuilderMock(['select', 'from', 'andWhere', 'setParameter', 'getQuery']);
+        $countQuery = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSingleScalarResult'])
+            ->getMock();
+        $countQuery->expects(self::once())->method('getSingleScalarResult')->willReturn('2');
+        $countQb->method('getQuery')->willReturn($countQuery);
+
+        $listQb = $this->createQueryBuilderMock(['select', 'from', 'orderBy', 'addOrderBy', 'andWhere', 'setParameter', 'setMaxResults', 'getQuery']);
+        $mediaOne = new Media('dry-one.jpg', 'checksum-dry-one', 1);
+        $mediaTwo = new Media('dry-two.jpg', 'checksum-dry-two', 1);
+        $listQuery = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['toIterable'])
+            ->getMock();
+        $listQuery->expects(self::once())->method('toIterable')->willReturn([$mediaOne, $mediaTwo]);
+        $listQb->method('getQuery')->willReturn($listQuery);
+
+        $entityManager->expects(self::exactly(2))
+            ->method('createQueryBuilder')
+            ->willReturnOnConsecutiveCalls($countQb, $listQb);
+
+        $drafts = [
+            new ClusterDraft('algo-a', [], ['lat' => 0.0, 'lon' => 0.0], [1]),
+            new ClusterDraft('algo-b', [], ['lat' => 0.0, 'lon' => 0.0], [2]),
+        ];
+
+        $clusterer = $this->createMock(HybridClustererInterface::class);
+        $clusterer->expects(self::once())->method('countStrategies')->willReturn(2);
+        $clusterer->expects(self::once())
+            ->method('build')
+            ->willReturnCallback(function (array $items, callable $onStart, callable $onDone) use ($drafts): array {
+                $onStart('Strategy A', 1, 2);
+                $onDone('Strategy A', 1, 2);
+
+                return $drafts;
+            });
+
+        $consolidator = $this->createMock(ClusterConsolidatorInterface::class);
+        $consolidator->expects(self::once())
+            ->method('consolidate')
+            ->willReturnCallback(function (array $inputDrafts, callable $callback): array {
+                $callback(2, 2, 'stage');
+
+                return $inputDrafts;
+            });
+
+        $persistence = $this->createMock(ClusterPersistenceInterface::class);
+        $persistence->expects(self::never())->method('deleteByAlgorithms');
+        $persistence->expects(self::never())->method('persistBatched');
+
+        $runner  = new DefaultClusterJobRunner($entityManager, $clusterer, $consolidator, $persistence);
+        $options = new ClusterJobOptions(true, null, null, true);
+
+        $result = $runner->run($options, new NullProgressReporter());
+
+        self::assertSame(2, $result->getTotalMediaCount());
+        self::assertSame(2, $result->getLoadedMediaCount());
+        self::assertSame(2, $result->getDraftCount());
+        self::assertSame(2, $result->getConsolidatedCount());
+        self::assertSame(2, $result->getPersistedCount());
+        self::assertSame(0, $result->getDeletedCount());
+        self::assertTrue($result->isDryRun());
+    }
+
+    /**
+     * @param list<string> $methods
+     */
+    private function createQueryBuilderMock(array $methods): QueryBuilder
+    {
+        $qb = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods($methods)
+            ->getMock();
+
+        foreach ($methods as $method) {
+            if ($method === 'getQuery') {
+                continue;
+            }
+
+            $qb->method($method)->willReturnSelf();
+        }
+
+        return $qb;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a ClusterJobRunnerInterface with a DefaultClusterJobRunner that coordinates loading, clustering, consolidating, and persisting work
- add value objects for runner options/results plus a console-aware progress reporter implementation and service aliases
- refactor the cluster command to delegate to the runner and cover behaviour with new unit tests

## Testing
- ./vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: `bin/php` not found in container)*
- composer ci:test:php:unit *(fails: `bin/php` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfd1fca7c8323a6f417916a89b0a1