### PR TITLE
Refactor HTML feed export into a dedicated service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -832,6 +832,10 @@ services:
     # Feeds
     MagicSunday\Memories\Service\Feed\ThumbnailPathResolver: ~
     MagicSunday\Memories\Service\Feed\HtmlFeedRenderer: ~
+    MagicSunday\Memories\Service\Feed\HtmlFeedExportService: ~
+
+    MagicSunday\Memories\Service\Feed\Contract\FeedExportServiceInterface:
+        alias: MagicSunday\Memories\Service\Feed\HtmlFeedExportService
 
     # Title
     MagicSunday\Memories\Service\Clusterer\Title\TitleTemplateProvider:

--- a/src/Repository/ClusterRepository.php
+++ b/src/Repository/ClusterRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Cluster;
+
+use function max;
+
+/**
+ * Repository helper to load recently created clusters.
+ */
+readonly class ClusterRepository
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return list<Cluster>
+     */
+    public function findLatest(int $limit): array
+    {
+        $limit = max(1, $limit);
+
+        $qb = $this->em->createQueryBuilder()
+            ->select('c')
+            ->from(Cluster::class, 'c')
+            ->orderBy('c.createdAt', 'DESC')
+            ->setMaxResults($limit);
+
+        $query = $qb->getQuery();
+
+        /** @var list<Cluster> $clusters */
+        $clusters = $query->getResult();
+
+        return $clusters;
+    }
+}

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -17,7 +17,7 @@ use MagicSunday\Memories\Entity\Media;
 /**
  * Minimal repository wrapper to load Media by IDs efficiently.
  */
-final readonly class MediaRepository
+readonly class MediaRepository
 {
     public function __construct(private EntityManagerInterface $em)
     {

--- a/src/Service/Feed/Contract/FeedExportServiceInterface.php
+++ b/src/Service/Feed/Contract/FeedExportServiceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Feed\Contract;
+
+use MagicSunday\Memories\Service\Feed\FeedExportRequest;
+use MagicSunday\Memories\Service\Feed\FeedExportResult;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+interface FeedExportServiceInterface
+{
+    public function export(FeedExportRequest $request, SymfonyStyle $io): FeedExportResult;
+}

--- a/src/Service/Feed/FeedExportRequest.php
+++ b/src/Service/Feed/FeedExportRequest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Feed;
+
+use DateTimeImmutable;
+
+use function max;
+
+use const DIRECTORY_SEPARATOR;
+
+final class FeedExportRequest
+{
+    private readonly int $limitClusters;
+
+    private readonly int $maxItems;
+
+    private readonly int $imagesPerItem;
+
+    private readonly int $thumbnailWidth;
+
+    private readonly string $baseOutputDirectory;
+
+    public function __construct(
+        int $limitClusters,
+        int $maxItems,
+        int $imagesPerItem,
+        int $thumbnailWidth,
+        private readonly bool $useSymlinks,
+        string $baseOutputDirectory,
+        private readonly DateTimeImmutable $timestamp,
+    ) {
+        $this->limitClusters       = max(1, $limitClusters);
+        $this->maxItems            = max(1, $maxItems);
+        $this->imagesPerItem       = max(1, $imagesPerItem);
+        $this->thumbnailWidth      = max(1, $thumbnailWidth);
+        $this->baseOutputDirectory = $baseOutputDirectory !== '' ? $baseOutputDirectory : 'var/export';
+    }
+
+    public function getLimitClusters(): int
+    {
+        return $this->limitClusters;
+    }
+
+    public function getMaxItems(): int
+    {
+        return $this->maxItems;
+    }
+
+    public function getImagesPerItem(): int
+    {
+        return $this->imagesPerItem;
+    }
+
+    public function getThumbnailWidth(): int
+    {
+        return $this->thumbnailWidth;
+    }
+
+    public function useSymlinks(): bool
+    {
+        return $this->useSymlinks;
+    }
+
+    public function getBaseOutputDirectory(): string
+    {
+        return $this->baseOutputDirectory;
+    }
+
+    public function getTimestamp(): DateTimeImmutable
+    {
+        return $this->timestamp;
+    }
+
+    public function resolveOutputDirectory(): string
+    {
+        $base = rtrim($this->baseOutputDirectory, '/\\');
+
+        if ($base === '') {
+            $base = '.';
+        }
+
+        return $base . DIRECTORY_SEPARATOR . 'feed-' . $this->timestamp->format('Ymd-His');
+    }
+
+    public function resolveImageDirectory(): string
+    {
+        return $this->resolveOutputDirectory() . DIRECTORY_SEPARATOR . 'images';
+    }
+}

--- a/src/Service/Feed/FeedExportResult.php
+++ b/src/Service/Feed/FeedExportResult.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Feed;
+
+final class FeedExportResult
+{
+    public function __construct(
+        private readonly string $outputDirectory,
+        private readonly string $imageDirectory,
+        private readonly ?string $indexFilePath,
+        private readonly int $copiedFileCount,
+        private readonly int $skippedNoThumbnailCount,
+        private readonly int $cardCount,
+    ) {
+    }
+
+    public function getOutputDirectory(): string
+    {
+        return $this->outputDirectory;
+    }
+
+    public function getImageDirectory(): string
+    {
+        return $this->imageDirectory;
+    }
+
+    public function getIndexFilePath(): ?string
+    {
+        return $this->indexFilePath;
+    }
+
+    public function hasIndexFile(): bool
+    {
+        return $this->indexFilePath !== null;
+    }
+
+    public function getCopiedFileCount(): int
+    {
+        return $this->copiedFileCount;
+    }
+
+    public function getSkippedNoThumbnailCount(): int
+    {
+        return $this->skippedNoThumbnailCount;
+    }
+
+    public function getCardCount(): int
+    {
+        return $this->cardCount;
+    }
+}

--- a/src/Service/Feed/HtmlFeedExportService.php
+++ b/src/Service/Feed/HtmlFeedExportService.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Feed;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Feed\MemoryFeedItem;
+use MagicSunday\Memories\Repository\ClusterRepository;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidatorInterface;
+use MagicSunday\Memories\Service\Feed\Contract\FeedExportServiceInterface;
+use MagicSunday\Memories\Support\ClusterEntityToDraftMapper;
+use RuntimeException;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function array_slice;
+use function basename;
+use function copy;
+use function count;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function is_string;
+use function symlink;
+use function usort;
+
+final class HtmlFeedExportService implements FeedExportServiceInterface
+{
+    private const string FEED_TITLE = 'Rückblick – Für dich';
+
+    public function __construct(
+        private readonly ClusterRepository $clusters,
+        private readonly FeedBuilderInterface $feedBuilder,
+        private readonly ClusterConsolidatorInterface $consolidator,
+        private readonly ClusterEntityToDraftMapper $mapper,
+        private readonly MediaRepository $mediaRepository,
+        private readonly HtmlFeedRenderer $renderer,
+        private readonly ThumbnailPathResolver $thumbnailResolver,
+    ) {
+    }
+
+    public function export(FeedExportRequest $request, SymfonyStyle $io): FeedExportResult
+    {
+        $io->title('📰 HTML-Vorschau des Rückblick-Feeds');
+
+        $outputDirectory = $request->resolveOutputDirectory();
+        $imageDirectory  = $request->resolveImageDirectory();
+
+        $this->ensureDirectoryExists($outputDirectory);
+        $this->ensureDirectoryExists($imageDirectory);
+
+        $entities = $this->clusters->findLatest($request->getLimitClusters());
+        if ($entities === []) {
+            $io->warning('Keine Cluster in der Datenbank gefunden.');
+
+            return new FeedExportResult($outputDirectory, $imageDirectory, null, 0, 0, 0);
+        }
+
+        $drafts       = $this->mapper->mapMany($entities);
+        $consolidated = $this->consolidator->consolidate($drafts);
+        if ($consolidated === []) {
+            $io->warning('Keine Cluster nach der Konsolidierung.');
+
+            return new FeedExportResult($outputDirectory, $imageDirectory, null, 0, 0, 0);
+        }
+
+        $items = $this->feedBuilder->build($consolidated);
+        if ($items === []) {
+            $io->warning('Der Feed ist leer (Filter/Score/Limit zu streng?).');
+
+            return new FeedExportResult($outputDirectory, $imageDirectory, null, 0, 0, 0);
+        }
+
+        if (count($items) > $request->getMaxItems()) {
+            $items = array_slice($items, 0, $request->getMaxItems());
+        }
+
+        $cards             = [];
+        $copiedFileCount   = 0;
+        $skippedThumbCount = 0;
+
+        foreach ($items as $item) {
+            $cardData = $this->createCard($item, $request, $imageDirectory, $copiedFileCount, $skippedThumbCount);
+            if ($cardData === null) {
+                continue;
+            }
+
+            $cards[] = $cardData;
+        }
+
+        if ($cards === []) {
+            $io->warning('Keine Bilder für die HTML-Ausgabe gefunden.');
+
+            return new FeedExportResult($outputDirectory, $imageDirectory, null, $copiedFileCount, $skippedThumbCount, 0);
+        }
+
+        $html = $this->renderer->render($cards, self::FEED_TITLE);
+
+        $indexFile = $outputDirectory . '/index.html';
+        if (@file_put_contents($indexFile, $html) === false) {
+            throw new RuntimeException('Konnte HTML-Datei nicht schreiben: ' . $indexFile);
+        }
+
+        return new FeedExportResult($outputDirectory, $imageDirectory, $indexFile, $copiedFileCount, $skippedThumbCount, count($cards));
+    }
+
+    private function ensureDirectoryExists(string $directory): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+
+        if (!@mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException('Could not create output directory: ' . $directory);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function createCard(
+        MemoryFeedItem $item,
+        FeedExportRequest $request,
+        string $imageDirectory,
+        int &$copiedFileCount,
+        int &$skippedThumbCount,
+    ): ?array {
+        $memberIds = $item->getMemberIds();
+        if ($memberIds === []) {
+            return null;
+        }
+
+        $members = $this->mediaRepository->findByIds($memberIds);
+
+        $coverId = $item->getCoverMediaId();
+        if ($coverId !== null) {
+            usort($members, static function (Media $a, Media $b) use ($coverId): int {
+                if ($a->getId() === $coverId && $b->getId() !== $coverId) {
+                    return -1;
+                }
+
+                if ($b->getId() === $coverId && $a->getId() !== $coverId) {
+                    return 1;
+                }
+
+                $timestampA = $a->getTakenAt()?->getTimestamp() ?? 0;
+                $timestampB = $b->getTakenAt()?->getTimestamp() ?? 0;
+
+                return $timestampA <=> $timestampB;
+            });
+        }
+
+        $images = [];
+        foreach ($members as $media) {
+            if (count($images) >= $request->getImagesPerItem()) {
+                break;
+            }
+
+            $source = $this->thumbnailResolver->resolveBest($media, $request->getThumbnailWidth());
+            if ($source === null) {
+                ++$skippedThumbCount;
+
+                continue;
+            }
+
+            $targetName = $this->thumbnailResolver->exportName($media, $source);
+            $targetPath = $imageDirectory . '/' . $targetName;
+            $href       = 'images/' . $targetName;
+
+            if (!is_file($targetPath)) {
+                $copiedFileCount += $this->copyOrLinkThumbnail($source, $targetPath, $request->useSymlinks());
+            }
+
+            $images[] = [
+                'href' => $href,
+                'alt'  => basename($media->getPath()),
+            ];
+        }
+
+        if ($images === []) {
+            return null;
+        }
+
+        $params = $item->getParams();
+        $group  = $params['group'] ?? null;
+
+        $card = [
+            'title'     => $item->getTitle(),
+            'subtitle'  => $item->getSubtitle(),
+            'algorithm' => $item->getAlgorithm(),
+            'score'     => $item->getScore(),
+            'images'    => $images,
+        ];
+
+        if (is_string($group) && $group !== '') {
+            $card['group'] = $group;
+        }
+
+        return $card;
+    }
+
+    private function copyOrLinkThumbnail(string $source, string $targetPath, bool $useSymlink): int
+    {
+        $linked = false;
+        if ($useSymlink) {
+            $linked = @symlink($source, $targetPath);
+        }
+
+        if ($linked) {
+            return 1;
+        }
+
+        if (@copy($source, $targetPath)) {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/test/Unit/Command/FeedExportHtmlCommandTest.php
+++ b/test/Unit/Command/FeedExportHtmlCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Command;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Command\FeedExportHtmlCommand;
+use MagicSunday\Memories\Service\Feed\Contract\FeedExportServiceInterface;
+use MagicSunday\Memories\Service\Feed\FeedExportRequest;
+use MagicSunday\Memories\Service\Feed\FeedExportResult;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function sys_get_temp_dir;
+use function uniqid;
+
+final class FeedExportHtmlCommandTest extends TestCase
+{
+    #[Test]
+    public function executeDelegatesToExportService(): void
+    {
+        $service = $this->createMock(FeedExportServiceInterface::class);
+
+        $result = new FeedExportResult(
+            outputDirectory: '/tmp/feed-out',
+            imageDirectory: '/tmp/feed-out/images',
+            indexFilePath: '/tmp/feed-out/index.html',
+            copiedFileCount: 4,
+            skippedNoThumbnailCount: 2,
+            cardCount: 3,
+        );
+
+        $capturedRequest = null;
+
+        $service->expects(self::once())
+            ->method('export')
+            ->willReturnCallback(function (FeedExportRequest $request, SymfonyStyle $io) use (&$capturedRequest, $result) {
+                $capturedRequest = $request;
+
+                return $result;
+            });
+
+        $command = new FeedExportHtmlCommand($service);
+        $tester  = new CommandTester($command);
+
+        $outputDir = sys_get_temp_dir() . '/memories-export-' . uniqid('', true);
+
+        $tester->execute([
+            '--limit-clusters' => '25',
+            '--max-items'      => '5',
+            '--images-per-item'=> '2',
+            '--thumb-width'    => '320',
+            '--symlink'        => true,
+            'out-dir'          => $outputDir,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        self::assertNotNull($capturedRequest);
+        self::assertSame(25, $capturedRequest->getLimitClusters());
+        self::assertSame(5, $capturedRequest->getMaxItems());
+        self::assertSame(2, $capturedRequest->getImagesPerItem());
+        self::assertSame(320, $capturedRequest->getThumbnailWidth());
+        self::assertTrue($capturedRequest->useSymlinks());
+        self::assertSame($outputDir, $capturedRequest->getBaseOutputDirectory());
+        self::assertInstanceOf(DateTimeImmutable::class, $capturedRequest->getTimestamp());
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('HTML erzeugt: /tmp/feed-out/index.html', $display);
+        self::assertStringContainsString('Bilder: 4 kopiert/verlinkt, 2 übersprungen', $display);
+    }
+
+    #[Test]
+    public function executeReturnsFailureWhenServiceThrows(): void
+    {
+        $service = $this->createMock(FeedExportServiceInterface::class);
+        $service->expects(self::once())
+            ->method('export')
+            ->willThrowException(new RuntimeException('Fehler beim Export.'));
+
+        $command = new FeedExportHtmlCommand($service);
+        $tester  = new CommandTester($command);
+
+        $status = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $status);
+        self::assertStringContainsString('Fehler beim Export.', $tester->getDisplay());
+    }
+}

--- a/test/Unit/Service/Feed/HtmlFeedExportServiceTest.php
+++ b/test/Unit/Service/Feed/HtmlFeedExportServiceTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Feed;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Entity\Cluster;
+use MagicSunday\Memories\Feed\MemoryFeedItem;
+use MagicSunday\Memories\Repository\ClusterRepository;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidatorInterface;
+use MagicSunday\Memories\Service\Feed\FeedBuilderInterface;
+use MagicSunday\Memories\Service\Feed\FeedExportRequest;
+use MagicSunday\Memories\Service\Feed\FeedExportResult;
+use MagicSunday\Memories\Service\Feed\HtmlFeedExportService;
+use MagicSunday\Memories\Service\Feed\HtmlFeedRenderer;
+use MagicSunday\Memories\Service\Feed\ThumbnailPathResolver;
+use MagicSunday\Memories\Support\ClusterEntityToDraftMapper;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_exists;
+use function basename;
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sprintf;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class HtmlFeedExportServiceTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDirectory($dir);
+        }
+
+        $this->tempDirs = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function exportReturnsEarlyWhenNoClustersWereFound(): void
+    {
+        $baseDir = $this->createTempDir();
+
+        $request = new FeedExportRequest(
+            limitClusters: 10,
+            maxItems: 5,
+            imagesPerItem: 3,
+            thumbnailWidth: 256,
+            useSymlinks: false,
+            baseOutputDirectory: $baseDir,
+            timestamp: new DateTimeImmutable('2024-02-03 10:00:00'),
+        );
+
+        $clusterRepository = $this->createMock(ClusterRepository::class);
+        $clusterRepository->expects(self::once())
+            ->method('findLatest')
+            ->with(10)
+            ->willReturn([]);
+
+        $mapper = new ClusterEntityToDraftMapper();
+
+        $consolidator = $this->createMock(ClusterConsolidatorInterface::class);
+        $consolidator->expects(self::never())->method('consolidate');
+
+        $feedBuilder = $this->createMock(FeedBuilderInterface::class);
+        $feedBuilder->expects(self::never())->method('build');
+
+        $mediaRepository = $this->createMock(MediaRepository::class);
+        $mediaRepository->expects(self::never())->method('findByIds');
+
+        $renderer          = new HtmlFeedRenderer();
+        $thumbnailResolver = new ThumbnailPathResolver();
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects(self::once())
+            ->method('title')
+            ->with('📰 HTML-Vorschau des Rückblick-Feeds');
+        $io->expects(self::once())
+            ->method('warning')
+            ->with('Keine Cluster in der Datenbank gefunden.');
+
+        $service = new HtmlFeedExportService(
+            $clusterRepository,
+            $feedBuilder,
+            $consolidator,
+            $mapper,
+            $mediaRepository,
+            $renderer,
+            $thumbnailResolver,
+        );
+
+        $result = $service->export($request, $io);
+
+        self::assertInstanceOf(FeedExportResult::class, $result);
+        self::assertFalse($result->hasIndexFile());
+        self::assertSame($request->resolveOutputDirectory(), $result->getOutputDirectory());
+        self::assertSame($request->resolveImageDirectory(), $result->getImageDirectory());
+        self::assertSame(0, $result->getCopiedFileCount());
+        self::assertSame(0, $result->getSkippedNoThumbnailCount());
+        self::assertSame(0, $result->getCardCount());
+
+        self::assertTrue(is_dir($result->getOutputDirectory()));
+        self::assertTrue(is_dir($result->getImageDirectory()));
+    }
+
+    #[Test]
+    public function exportCopiesThumbnailsAndCreatesHtml(): void
+    {
+        $baseDir = $this->createTempDir();
+        $thumbSource = $baseDir . '/source-thumb.jpg';
+        file_put_contents($thumbSource, 'thumbnail');
+
+        $request = new FeedExportRequest(
+            limitClusters: 5,
+            maxItems: 10,
+            imagesPerItem: 4,
+            thumbnailWidth: 512,
+            useSymlinks: false,
+            baseOutputDirectory: $baseDir,
+            timestamp: new DateTimeImmutable('2024-02-03 10:30:00'),
+        );
+
+        $cluster = new Cluster(
+            'algo',
+            ['group' => 'familie'],
+            ['lat' => 0.0, 'lon' => 0.0],
+            [1, 2],
+        );
+
+        $feedItem = new MemoryFeedItem('algo', 'Titel', 'Untertitel', 1, [1, 2], 0.9, ['group' => 'familie']);
+
+        $clusterRepository = $this->createMock(ClusterRepository::class);
+        $clusterRepository->expects(self::once())
+            ->method('findLatest')
+            ->with(5)
+            ->willReturn([$cluster]);
+
+        $mapper = new ClusterEntityToDraftMapper();
+
+        $consolidator = $this->createMock(ClusterConsolidatorInterface::class);
+        $consolidator->expects(self::once())
+            ->method('consolidate')
+            ->willReturnCallback(static function (array $drafts): array {
+                self::assertCount(1, $drafts);
+                self::assertInstanceOf(ClusterDraft::class, $drafts[0]);
+
+                return $drafts;
+            });
+
+        $feedBuilder = $this->createMock(FeedBuilderInterface::class);
+        $feedBuilder->expects(self::once())
+            ->method('build')
+            ->willReturnCallback(static function (array $drafts) use ($feedItem): array {
+                self::assertCount(1, $drafts);
+                self::assertInstanceOf(ClusterDraft::class, $drafts[0]);
+
+                return [$feedItem];
+            });
+
+        $mediaOne = $this->makeMedia(1, $baseDir . '/media-1.jpg');
+        $mediaOne->setThumbnails([512 => $thumbSource]);
+
+        $mediaTwo = $this->makeMedia(2, $baseDir . '/media-2.jpg');
+        $mediaTwo->setThumbnails(null);
+
+        $mediaRepository = $this->createMock(MediaRepository::class);
+        $mediaRepository->expects(self::once())
+            ->method('findByIds')
+            ->with([1, 2])
+            ->willReturn([$mediaOne, $mediaTwo]);
+
+        $thumbnailResolver = new ThumbnailPathResolver();
+        $renderer          = new HtmlFeedRenderer();
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects(self::once())
+            ->method('title')
+            ->with('📰 HTML-Vorschau des Rückblick-Feeds');
+        $io->expects(self::never())->method('warning');
+
+        $service = new HtmlFeedExportService(
+            $clusterRepository,
+            $feedBuilder,
+            $consolidator,
+            $mapper,
+            $mediaRepository,
+            $renderer,
+            $thumbnailResolver,
+        );
+
+        $result = $service->export($request, $io);
+
+        self::assertTrue($result->hasIndexFile());
+        self::assertSame(1, $result->getCopiedFileCount());
+        self::assertSame(1, $result->getSkippedNoThumbnailCount());
+        self::assertSame(1, $result->getCardCount());
+
+        $imagePath = $result->getImageDirectory() . '/m1_source-thumb.jpg';
+        self::assertTrue(file_exists($imagePath));
+        self::assertSame('m1_source-thumb.jpg', basename($imagePath));
+        self::assertNotNull($result->getIndexFilePath());
+        $indexHtml = file_get_contents($result->getIndexFilePath());
+        self::assertStringContainsString('Titel', $indexHtml);
+        self::assertStringContainsString('Untertitel', $indexHtml);
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sprintf('%s/memories-feed-%s', sys_get_temp_dir(), uniqid('', true));
+
+        if (!is_dir($dir) && !mkdir($dir) && !is_dir($dir)) {
+            throw new RuntimeException('Unable to create temporary directory: ' . $dir);
+        }
+
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo instanceof \SplFileInfo && $fileInfo->isDir()) {
+                rmdir($fileInfo->getPathname());
+
+                continue;
+            }
+
+            unlink($fileInfo->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce feed export request/result value objects and a FeedExportServiceInterface
- move the HTML feed export workflow into HtmlFeedExportService backed by a new ClusterRepository
- update FeedExportHtmlCommand to delegate to the service and add unit coverage for the service and command

## Testing
- composer ci:test *(fails: bin/php missing in environment)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --testsuite "Unit Tests"


------
https://chatgpt.com/codex/tasks/task_e_68dbfd3a35348323957c8be764b4c491