### PR TITLE
Fix BinaryFileResponse inheritance to satisfy Response return types

### DIFF
--- a/test/Unit/Http/Response/BinaryFileResponseTest.php
+++ b/test/Unit/Http/Response/BinaryFileResponseTest.php
@@ -23,8 +23,8 @@ final class BinaryFileResponseTest extends TestCase
         $file = $this->fixturePath('assets/sample.css');
 
         $response = new BinaryFileResponse($file);
-        $result   = $response->send();
+        $headers  = $response->getHeaders();
 
-        self::assertSame('text/css', $result['headers']['Content-Type'] ?? null);
+        self::assertSame('text/css', $headers['Content-Type'] ?? null);
     }
 }


### PR DESCRIPTION
## Summary
- make BinaryFileResponse extend the base Response implementation so routing can accept it
- set binary response headers/content during construction and adjust the unit test to read them via the Response API

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de0b2d1d508323a5927299bd05f067