### PR TITLE
Fix SPA stylesheet loading

### DIFF
--- a/public/app/index.html
+++ b/public/app/index.html
@@ -5,10 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Rückblick-Galerie</title>
     <meta name="description" content="Interaktive Vorschau des Photo-Memories-Feeds" />
+    <link rel="stylesheet" href="/app/src/style.css" />
   </head>
   <body>
     <noscript>Diese Anwendung benötigt JavaScript.</noscript>
     <div id="app"></div>
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="/app/src/main.js"></script>
   </body>
 </html>

--- a/public/app/src/main.js
+++ b/public/app/src/main.js
@@ -1,5 +1,3 @@
-import './style.css';
-
 const defaultFilters = {
   score: '0.35',
   strategie: '',


### PR DESCRIPTION
## Summary
- load the SPA stylesheet via the HTML shell instead of an unsupported ES module import
- keep the JavaScript bundle focused on application logic so static browsers no longer block CSS requests

## Testing
- composer ci:test *(fails: bin/php not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de0f3e3c0083238bcd8c452f200a97