### PR TITLE
Refactor dependency container bootstrap

### DIFF
--- a/public/app/index.php
+++ b/public/app/index.php
@@ -9,9 +9,11 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\Memories;
+use MagicSunday\Memories\DependencyContainerFactory;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
 
 $factory = new DependencyContainerFactory();
 $factory->ensure();
+
+require_once __DIR__ . '/index.html';

--- a/public/index.php
+++ b/public/index.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 use MagicSunday\Memories\DependencyContainer;
+use MagicSunday\Memories\DependencyContainerFactory;
 use MagicSunday\Memories\Http\Controller\FeedController;
 use MagicSunday\Memories\Http\Request;
 use MagicSunday\Memories\Http\Response\BinaryFileResponse;
@@ -25,11 +26,10 @@ use function str_starts_with;
 use function substr;
 
 require_once __DIR__ . '/../vendor/autoload.php';
-require_once __DIR__ . '/../src/Dependencies.php';
-require_once __DIR__ . '/../var/cache/DependencyContainer.php';
 
 $request   = Request::fromGlobals();
-$container = new DependencyContainer();
+$factory   = new DependencyContainerFactory();
+$container = $factory->create();
 
 $method = $request->getMethod();
 $path   = $request->getPath();

--- a/src/DependencyContainerFactory.php
+++ b/src/DependencyContainerFactory.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories;
+
+use Phar;
+use RuntimeException;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function class_exists;
+use function dirname;
+use function file_put_contents;
+use function getenv;
+use function is_dir;
+use function is_file;
+use function mkdir;
+use function sprintf;
+
+/**
+ * Factory responsible for compiling and loading the dependency container.
+ */
+final class DependencyContainerFactory
+{
+    private const CONTAINER_CLASS = 'DependencyContainer';
+
+    private const CONTAINER_NAMESPACE = __NAMESPACE__;
+
+    private string $cacheDirectory;
+
+    private string $cacheFile;
+
+    public function __construct()
+    {
+        $this->cacheDirectory = __DIR__ . '/../var/cache';
+        $this->cacheFile      = $this->cacheDirectory . '/' . self::CONTAINER_CLASS . '.php';
+    }
+
+    /**
+     * Ensures that the cached container exists on disk.
+     */
+    public function ensure(): void
+    {
+        EnvironmentBootstrap::boot();
+
+        $this->createCacheDirectoryIfMissing();
+
+        if (is_file($this->cacheFile)) {
+            return;
+        }
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.project_dir', $this->resolveProjectDir());
+        $containerBuilder->setParameter('kernel.environment', getenv('APP_ENV') ?: 'prod');
+        $containerBuilder->setParameter('kernel.debug', (bool) (getenv('APP_DEBUG') ?: false));
+
+        $yamlFileLoader = new YamlFileLoader($containerBuilder, new FileLocator(__DIR__ . '/../config'));
+        $yamlFileLoader->load('services.yaml');
+
+        $containerBuilder
+            ->register(SymfonyStyle::class)
+            ->setPublic(true)
+            ->setSynthetic(true);
+
+        $containerBuilder->compile();
+
+        $dumper = new PhpDumper($containerBuilder);
+
+        file_put_contents(
+            $this->cacheFile,
+            $dumper->dump(
+                [
+                    'class'     => self::CONTAINER_CLASS,
+                    'namespace' => self::CONTAINER_NAMESPACE,
+                ]
+            )
+        );
+    }
+
+    /**
+     * Creates and returns the dependency container instance.
+     */
+    public function create(): DependencyContainer
+    {
+        $this->ensure();
+
+        require_once $this->cacheFile;
+
+        return new DependencyContainer();
+    }
+
+    private function createCacheDirectoryIfMissing(): void
+    {
+        if (is_dir($this->cacheDirectory)) {
+            return;
+        }
+
+        if (!mkdir($concurrentDirectory = $this->cacheDirectory, 0775, true) && !is_dir($concurrentDirectory)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Directory "%s" was not created',
+                    $this->cacheDirectory
+                )
+            );
+        }
+    }
+
+    private function resolveProjectDir(): string
+    {
+        if (class_exists(Phar::class) && Phar::running() !== '') {
+            return dirname(Phar::running(false));
+        }
+
+        return dirname(__DIR__);
+    }
+}

--- a/src/Memories.php
+++ b/src/Memories.php
@@ -15,11 +15,11 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-require_once __DIR__ . '/Dependencies.php';
-require_once __DIR__ . '/../var/cache/DependencyContainer.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 // Create the container
-$container = new DependencyContainer();
+$factory   = new DependencyContainerFactory();
+$container = $factory->create();
 
 // Create and set the SymfonyStyle instance
 $input  = new ArgvInput();


### PR DESCRIPTION
## Summary
- extract the container compilation logic into a dedicated `DependencyContainerFactory`
- update CLI and HTTP front controllers to build the container via the factory
- add a public/app index bootstrap that ensures the container cache exists before serving the SPA

## Testing
- composer ci:test *(fails: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de0ca346d08323a882ad556cc123f7