### PR TITLE
Fix thumbnail orientation handling

### DIFF
--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Thumbnail;
 
+use GdImage;
 use Imagick;
 use MagicSunday\Memories\Entity\Media;
 use RuntimeException;
@@ -43,7 +44,7 @@ class ThumbnailService implements ThumbnailServiceInterface
     {
         $results = [];
         foreach ($this->sizes as $size) {
-            $path = $this->generateThumbnail($filepath, $size);
+            $path = $this->generateThumbnail($filepath, $size, $media);
             if ($path !== null) {
                 $results[$size] = $path;
             }
@@ -52,40 +53,49 @@ class ThumbnailService implements ThumbnailServiceInterface
         return $results;
     }
 
-    private function generateThumbnail(string $filepath, int $width): ?string
+    private function generateThumbnail(string $filepath, int $width, Media $media): ?string
     {
+        $orientation = $media->getOrientation();
+
         if (extension_loaded('imagick')) {
-            return $this->generateWithImagick($filepath, $width);
+            return $this->generateWithImagick($filepath, $width, $orientation);
         }
 
         if (function_exists('imagecreatefromstring')) {
-            return $this->generateWithGd($filepath, $width);
+            return $this->generateWithGd($filepath, $width, $orientation);
         }
 
         throw new RuntimeException('No available image library (Imagick or GD) to create thumbnails');
     }
 
-    private function generateWithImagick(string $filepath, int $width): ?string
+    private function generateWithImagick(string $filepath, int $width, ?int $orientation): ?string
     {
         $im = new Imagick();
         $im->setOption('jpeg:preserve-settings', 'true');
         $im->readImage($filepath . '[0]');
+        if ($orientation !== null && $orientation >= 1 && $orientation <= 8) {
+            $im->setImageOrientation($orientation);
+        }
+        $im->autoOrientImage();
+        $im->setImageOrientation(Imagick::ORIENTATION_TOPLEFT);
         $im->thumbnailImage($width, 0);
 
         $hash = hash('crc32b', $filepath . ':' . $width);
         $out  = $this->thumbnailDir . DIRECTORY_SEPARATOR . $hash . '.jpg';
         if ($im->writeImage($out)) {
             $im->clear();
+            $im->destroy();
 
             return $out;
         }
 
         $im->clear();
+        $im->destroy();
 
         return null;
     }
 
-    private function generateWithGd(string $filepath, int $width): ?string
+    private function generateWithGd(string $filepath, int $width, ?int $orientation): ?string
     {
         $data = @file_get_contents($filepath);
         if ($data === false) {
@@ -96,6 +106,8 @@ class ThumbnailService implements ThumbnailServiceInterface
         if ($src === false) {
             return null;
         }
+
+        $src = $this->applyOrientationWithGd($src, $orientation);
 
         $w     = imagesx($src);
         $h     = imagesy($src);
@@ -111,5 +123,91 @@ class ThumbnailService implements ThumbnailServiceInterface
         imagedestroy($src);
 
         return $out;
+    }
+
+    private function applyOrientationWithGd(GdImage $image, ?int $orientation): GdImage
+    {
+        if ($orientation === null || $orientation === 1) {
+            return $image;
+        }
+
+        switch ($orientation) {
+            case 2:
+                return $this->flipImage($image, IMG_FLIP_HORIZONTAL);
+            case 3:
+                return $this->rotateImage($image, 180);
+            case 4:
+                return $this->flipImage($image, IMG_FLIP_VERTICAL);
+            case 5:
+                $image = $this->flipImage($image, IMG_FLIP_HORIZONTAL);
+
+                return $this->rotateImage($image, 90);
+            case 6:
+                return $this->rotateImage($image, -90);
+            case 7:
+                $image = $this->flipImage($image, IMG_FLIP_HORIZONTAL);
+
+                return $this->rotateImage($image, -90);
+            case 8:
+                return $this->rotateImage($image, 90);
+        }
+
+        return $image;
+    }
+
+    private function rotateImage(GdImage $image, float $degrees): GdImage
+    {
+        $rotated = imagerotate($image, $degrees, 0);
+        if ($rotated === false) {
+            return $image;
+        }
+
+        imagedestroy($image);
+
+        return $rotated;
+    }
+
+    private function flipImage(GdImage $image, int $mode): GdImage
+    {
+        if (function_exists('imageflip')) {
+            imageflip($image, $mode);
+
+            return $image;
+        }
+
+        $width   = imagesx($image);
+        $height  = imagesy($image);
+        $flipped = imagecreatetruecolor($width, $height);
+
+        switch ($mode) {
+            case IMG_FLIP_HORIZONTAL:
+                for ($x = 0; $x < $width; ++$x) {
+                    imagecopy($flipped, $image, $width - $x - 1, 0, $x, 0, 1, $height);
+                }
+
+                break;
+            case IMG_FLIP_VERTICAL:
+                for ($y = 0; $y < $height; ++$y) {
+                    imagecopy($flipped, $image, 0, $height - $y - 1, 0, $y, $width, 1);
+                }
+
+                break;
+            case IMG_FLIP_BOTH:
+                for ($x = 0; $x < $width; ++$x) {
+                    for ($y = 0; $y < $height; ++$y) {
+                        imagecopy($flipped, $image, $width - $x - 1, $height - $y - 1, $x, $y, 1, 1);
+                    }
+                }
+
+                break;
+            default:
+                imagedestroy($flipped);
+
+                return $image;
+        }
+
+        imagedestroy($image);
+
+        return $flipped;
     }
 }

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Thumbnail;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Thumbnail\ThumbnailService;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ThumbnailServiceTest extends TestCase
+{
+    #[Test]
+    public function rotatesImageAccordingToOrientationSix(): void
+    {
+        if (!function_exists('imagecreatetruecolor')) {
+            self::markTestSkipped('GD extension is required for this test.');
+        }
+
+        $thumbnailDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'memories-thumb-' . uniqid('', true);
+        if (!@mkdir($thumbnailDir) && !is_dir($thumbnailDir)) {
+            self::fail('Unable to create thumbnail directory.');
+        }
+
+        $sourcePath = $thumbnailDir . DIRECTORY_SEPARATOR . 'source.jpg';
+        $image      = imagecreatetruecolor(400, 200);
+        $color      = imagecolorallocate($image, 200, 100, 50);
+        imagefilledrectangle($image, 0, 0, 399, 199, $color);
+        imagejpeg($image, $sourcePath);
+        imagedestroy($image);
+
+        $media = new Media($sourcePath, hash('sha256', 'source'), 1024);
+        $media->setOrientation(6);
+
+        $service        = new ThumbnailService($thumbnailDir, [200]);
+        $thumbnailPath  = null;
+
+        try {
+            $thumbnails = $service->generateAll($sourcePath, $media);
+
+            self::assertArrayHasKey(200, $thumbnails);
+            $thumbnailPath = $thumbnails[200];
+            self::assertFileExists($thumbnailPath);
+
+            [$width, $height] = getimagesize($thumbnailPath);
+
+            self::assertGreaterThan($width, $height);
+        } finally {
+            if (is_file($sourcePath)) {
+                @unlink($sourcePath);
+            }
+
+            if ($thumbnailPath !== null && is_file($thumbnailPath)) {
+                @unlink($thumbnailPath);
+            }
+
+            if (is_dir($thumbnailDir)) {
+                @rmdir($thumbnailDir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- pass media orientation metadata into thumbnail generation
- auto-orient Imagick thumbnails and normalize the stored orientation to top-left
- rotate and flip GD thumbnails for EXIF orientations 2–8 and add a regression test for orientation 6

## Testing
- ./vendor/bin/phpunit --configuration .build/phpunit.xml --filter ThumbnailServiceTest

------
https://chatgpt.com/codex/tasks/task_e_68de0f9e115883239772e63f2246ed55