### PR TITLE
Handle GD thumbnail write failures

### DIFF
--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -118,9 +118,14 @@ class ThumbnailService implements ThumbnailServiceInterface
         imagecopyresampled($dst, $src, 0, 0, 0, 0, $newW, $newH, $w, $h);
         $hash = hash('crc32b', $filepath . ':' . $width);
         $out  = $this->thumbnailDir . DIRECTORY_SEPARATOR . $hash . '.jpg';
-        imagejpeg($dst, $out, 85);
+
+        $writeResult = @imagejpeg($dst, $out, 85);
         imagedestroy($dst);
         imagedestroy($src);
+
+        if ($writeResult === false) {
+            throw new RuntimeException(sprintf('Unable to create thumbnail at path "%s".', $out));
+        }
 
         return $out;
     }

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -15,6 +15,7 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Thumbnail\ThumbnailService;
 use MagicSunday\Memories\Test\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 
 final class ThumbnailServiceTest extends TestCase
 {
@@ -60,6 +61,53 @@ final class ThumbnailServiceTest extends TestCase
 
             if ($thumbnailPath !== null && is_file($thumbnailPath)) {
                 @unlink($thumbnailPath);
+            }
+
+            if (is_dir($thumbnailDir)) {
+                @rmdir($thumbnailDir);
+            }
+        }
+    }
+
+    #[Test]
+    public function throwsExceptionWhenTargetDirectoryIsNotWritable(): void
+    {
+        if (!function_exists('imagecreatetruecolor')) {
+            self::markTestSkipped('GD extension is required for this test.');
+        }
+
+        $thumbnailDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'memories-thumb-' . uniqid('', true);
+        if (!@mkdir($thumbnailDir) && !is_dir($thumbnailDir)) {
+            self::fail('Unable to create thumbnail directory.');
+        }
+
+        $sourcePath = $thumbnailDir . DIRECTORY_SEPARATOR . 'source.jpg';
+        $image      = imagecreatetruecolor(200, 200);
+        $color      = imagecolorallocate($image, 50, 150, 200);
+        imagefilledrectangle($image, 0, 0, 199, 199, $color);
+        imagejpeg($image, $sourcePath);
+        imagedestroy($image);
+
+        $media = new Media($sourcePath, hash('sha256', 'source'), 1024);
+
+        $service = new ThumbnailService($thumbnailDir, [200]);
+
+        chmod($thumbnailDir, 0555);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Unable to create thumbnail/');
+
+        try {
+            $service->generateAll($sourcePath, $media);
+        } finally {
+            chmod($thumbnailDir, 0755);
+
+            if (is_file($sourcePath)) {
+                @unlink($sourcePath);
+            }
+
+            foreach (glob($thumbnailDir . DIRECTORY_SEPARATOR . '*.jpg') ?: [] as $file) {
+                @unlink($file);
             }
 
             if (is_dir($thumbnailDir)) {


### PR DESCRIPTION
## Summary
- stop registering thumbnails when GD fails to persist the generated JPEG and raise a clear exception
- cover the GD failure scenario with a unit test that simulates an unwritable thumbnail directory

## Testing
- composer ci:test *(fails: `bin/php` not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de155e32f88323a62d1639190820f2