### PR TITLE
BUGFIX: Validate thumbnail directory creation

### DIFF
--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -30,8 +30,8 @@ class ThumbnailService implements ThumbnailServiceInterface
     {
         $this->thumbnailDir = $thumbnailDir;
         $this->sizes        = $sizes;
-        if (!is_dir($this->thumbnailDir)) {
-            @mkdir($this->thumbnailDir, 0755, true);
+        if (!is_dir($this->thumbnailDir) && !mkdir($this->thumbnailDir, 0755, true) && !is_dir($this->thumbnailDir)) {
+            throw new RuntimeException(sprintf('Failed to create thumbnail directory "%s".', $this->thumbnailDir));
         }
     }
 

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -15,9 +15,40 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Thumbnail\ThumbnailService;
 use MagicSunday\Memories\Test\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 
 final class ThumbnailServiceTest extends TestCase
 {
+    #[Test]
+    public function throwsExceptionWhenThumbnailDirectoryCannotBeCreated(): void
+    {
+        $thumbnailDirParent = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'memories-thumb-parent-' . uniqid('', true);
+        $thumbnailDir       = $thumbnailDirParent . DIRECTORY_SEPARATOR . 'child';
+
+        if (!mkdir($thumbnailDirParent) && !is_dir($thumbnailDirParent)) {
+            self::fail('Unable to create thumbnail parent directory.');
+        }
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(sprintf('Failed to create thumbnail directory "%s".', $thumbnailDir));
+
+            if (file_put_contents($thumbnailDir, '') === false) {
+                self::fail('Unable to create thumbnail directory placeholder file.');
+            }
+
+            new ThumbnailService($thumbnailDir, [200]);
+        } finally {
+            if (is_file($thumbnailDir)) {
+                unlink($thumbnailDir);
+            }
+
+            if (is_dir($thumbnailDirParent)) {
+                rmdir($thumbnailDirParent);
+            }
+        }
+    }
+
     #[Test]
     public function rotatesImageAccordingToOrientationSix(): void
     {


### PR DESCRIPTION
## Summary
- validate that the thumbnail output directory is created successfully during service construction
- raise a RuntimeException when the directory cannot be created and cover the scenario with a unit test

## Testing
- composer ci:test *(fails: `bin/php` not found in container environment)*
- vendor/bin/phpunit test/Unit/Service/Thumbnail/ThumbnailServiceTest.php


------
https://chatgpt.com/codex/tasks/task_e_68de155f38b483238c034db9f99ea629