### PR TITLE
Handle GD thumbnail read failures with exceptions

### DIFF
--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -103,12 +103,12 @@ class ThumbnailService implements ThumbnailServiceInterface
     {
         $data = @file_get_contents($filepath);
         if ($data === false) {
-            return null;
+            throw new RuntimeException(sprintf('Unable to read image data from "%s" for thumbnail generation.', $filepath));
         }
 
         $src = @imagecreatefromstring($data);
         if ($src === false) {
-            return null;
+            throw new RuntimeException(sprintf('Unable to create GD image from "%s".', $filepath));
         }
 
         $src = $this->applyOrientationWithGd($src, $orientation);


### PR DESCRIPTION
## Summary
- throw `RuntimeException` when GD cannot read image data or instantiate an image while generating thumbnails
- extend thumbnail service unit tests to assert GD failure scenarios using reflection helpers and deterministic cleanup
- adjust existing GD-related tests to operate on separate source directories so teardown remains reliable

## Testing
- composer ci:test *(fails: bin/php not found in container environment)*
- vendor/bin/phpunit test/Unit/Service/Thumbnail/ThumbnailServiceTest.php


------
https://chatgpt.com/codex/tasks/task_e_68de1a3dbb708323b32c5c46895e636a