### PR TITLE
Fix autoload discovery when running from vendor directory

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -18,6 +18,8 @@ use MagicSunday\Memories\Http\Response\JsonResponse;
 use MagicSunday\Memories\Http\Response\Response;
 use Throwable;
 
+use RuntimeException;
+use function dirname;
 use function is_file;
 use function preg_match;
 use function realpath;
@@ -25,7 +27,25 @@ use function str_ends_with;
 use function str_starts_with;
 use function substr;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    dirname(__DIR__, 3) . '/autoload.php',
+];
+
+$autoloadLoaded = false;
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require_once $autoloadPath;
+        $autoloadLoaded = true;
+
+        break;
+    }
+}
+
+if ($autoloadLoaded === false) {
+    throw new RuntimeException('Composer autoload file not found.');
+}
 
 $request   = Request::fromGlobals();
 $factory   = new DependencyContainerFactory();


### PR DESCRIPTION
## Summary
- update the front controller to search common Composer autoload locations
- provide an explicit runtime error when no autoload file can be found

## Testing
- composer ci:test *(fails: bin/php not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1eb710b08323af7c744c300938fc