### PR TITLE
Improve thumbnail hashing with media checksum

### DIFF
--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -75,7 +75,7 @@ final class ThumbnailServiceTest extends TestCase
 
         $media = new Media($sourcePath, hash('sha256', 'source'), 1024);
 
-        $expectedOutput = $thumbnailDir . DIRECTORY_SEPARATOR . hash('crc32b', $sourcePath . ':200') . '.jpg';
+        $expectedOutput = $thumbnailDir . DIRECTORY_SEPARATOR . $media->getChecksum() . '-200.jpg';
 
         $imagick = $this->createMock(Imagick::class);
         $imagick->expects(self::once())->method('setOption')->with('jpeg:preserve-settings', 'true')->willReturn(true);
@@ -203,6 +203,98 @@ final class ThumbnailServiceTest extends TestCase
     }
 
     #[Test]
+    public function differentMediaDoNotOverwriteThumbnails(): void
+    {
+        if (!extension_loaded('imagick') && !function_exists('imagecreatetruecolor')) {
+            self::markTestSkipped('Imagick or GD extension is required for this test.');
+        }
+
+        $thumbnailDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'memories-thumb-' . uniqid('', true);
+        if (!@mkdir($thumbnailDir) && !is_dir($thumbnailDir)) {
+            self::fail('Unable to create thumbnail directory.');
+        }
+
+        $sourceDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'memories-thumb-source-' . uniqid('', true);
+        if (!@mkdir($sourceDir) && !is_dir($sourceDir)) {
+            self::fail('Unable to create thumbnail source directory.');
+        }
+
+        $firstSource  = $sourceDir . DIRECTORY_SEPARATOR . 'first.jpg';
+        $secondSource = $sourceDir . DIRECTORY_SEPARATOR . 'second.jpg';
+
+        if (extension_loaded('imagick')) {
+            $image = new Imagick();
+            $image->newImage(300, 200, 'white');
+            $image->setImageFormat('jpeg');
+            $image->writeImage($firstSource);
+            $image->clear();
+            $image->destroy();
+
+            $image = new Imagick();
+            $image->newImage(200, 300, 'white');
+            $image->setImageFormat('jpeg');
+            $image->writeImage($secondSource);
+            $image->clear();
+            $image->destroy();
+        } else {
+            $image = imagecreatetruecolor(300, 200);
+            $color = imagecolorallocate($image, 80, 120, 160);
+            imagefilledrectangle($image, 0, 0, 299, 199, $color);
+            imagejpeg($image, $firstSource);
+            imagedestroy($image);
+
+            $image = imagecreatetruecolor(200, 300);
+            $color = imagecolorallocate($image, 60, 180, 90);
+            imagefilledrectangle($image, 0, 0, 199, 299, $color);
+            imagejpeg($image, $secondSource);
+            imagedestroy($image);
+        }
+
+        $service = new ThumbnailService($thumbnailDir, [200]);
+
+        $firstMedia  = new Media($firstSource, hash('sha256', 'first-source'), 100);
+        $secondMedia = new Media($secondSource, hash('sha256', 'second-source'), 200);
+
+        $firstThumbnails  = [];
+        $secondThumbnails = [];
+
+        try {
+            $firstThumbnails  = $service->generateAll($firstSource, $firstMedia);
+            $secondThumbnails = $service->generateAll($secondSource, $secondMedia);
+
+            self::assertArrayHasKey(200, $firstThumbnails);
+            self::assertArrayHasKey(200, $secondThumbnails);
+
+            $firstThumbnail  = $firstThumbnails[200];
+            $secondThumbnail = $secondThumbnails[200];
+
+            self::assertNotSame($firstThumbnail, $secondThumbnail);
+            self::assertFileExists($firstThumbnail);
+            self::assertFileExists($secondThumbnail);
+        } finally {
+            foreach (array_merge($firstThumbnails, $secondThumbnails) as $file) {
+                if (is_string($file) && is_file($file)) {
+                    @unlink($file);
+                }
+            }
+
+            foreach ([$firstSource, $secondSource] as $file) {
+                if (is_file($file)) {
+                    @unlink($file);
+                }
+            }
+
+            if (is_dir($sourceDir)) {
+                @rmdir($sourceDir);
+            }
+
+            if (is_dir($thumbnailDir)) {
+                @rmdir($thumbnailDir);
+            }
+        }
+    }
+
+    #[Test]
     public function throwsExceptionWhenGdCannotReadSourceFile(): void
     {
         if (!function_exists('imagecreatefromstring')) {
@@ -224,7 +316,7 @@ final class ThumbnailServiceTest extends TestCase
         $this->expectExceptionMessage(sprintf('Unable to read image data from "%s" for thumbnail generation.', $missingPath));
 
         try {
-            $method->invoke($service, $missingPath, 200, null);
+            $method->invoke($service, $missingPath, 200, null, hash('sha256', 'missing'));
         } finally {
             if (is_dir($thumbnailDir)) {
                 @rmdir($thumbnailDir);
@@ -258,7 +350,7 @@ final class ThumbnailServiceTest extends TestCase
         $this->expectExceptionMessage(sprintf('Unable to create GD image from "%s".', $sourcePath));
 
         try {
-            $method->invoke($service, $sourcePath, 200, null);
+            $method->invoke($service, $sourcePath, 200, null, hash('sha256', 'invalid'));
         } finally {
             if (is_file($sourcePath)) {
                 @unlink($sourcePath);
@@ -369,7 +461,7 @@ final class ThumbnailServiceTest extends TestCase
         $this->expectExceptionMessageMatches('/Unable to create thumbnail/');
 
         try {
-            $method->invoke($service, $sourcePath, 200, $media->getOrientation());
+        $method->invoke($service, $sourcePath, 200, $media->getOrientation(), $media->getChecksum());
         } finally {
             if (is_file($sourcePath)) {
                 @unlink($sourcePath);


### PR DESCRIPTION
## Summary
- update the thumbnail service to derive output file names from the media checksum while passing the checksum through the Imagick and GD paths
- expand the thumbnail service unit tests to cover the new checksum-based naming scheme and prevent path collisions between different media files

## Testing
- composer ci:test:php:unit *(fails: sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de2edf077c83239cae171b8621a8d3