### PR TITLE
Limit persisted cluster members

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -31,6 +31,10 @@ MEMORIES_HOME_LON=
 # Radius around the home location (in kilometres) that still counts as being at home.
 MEMORIES_HOME_RADIUS_KM=15
 
+# --- Clustering ---
+# Maximum number of media entries stored per cluster after consolidation.
+MEMORIES_CLUSTER_MAX_MEMBERS=20
+
 # --- Directories ---
 # Absolute path where original media files are stored.
 MEMORIES_MEDIA_DIR=/var/lib/memories/media

--- a/README.md
+++ b/README.md
@@ -82,3 +82,10 @@ MEMORIES_PREFERRED_LOCALE=de
 ```
 
 Leave the variable unset to retain the previous behaviour of using the generic `name` tag provided by Overpass.
+
+## Cluster-Konfiguration
+
+Die Persistierung der berechneten Cluster wird jetzt begrenzt, damit Feeds und Oberflächen nicht mit hunderten Medien pro Block
+überladen werden. Über die neue Umgebungsvariable `MEMORIES_CLUSTER_MAX_MEMBERS` (Standard: `20`) legst du fest, wie viele
+Medien pro Cluster maximal gespeichert werden. Für eine abweichende Konfiguration kannst du den Wert entweder direkt in deiner
+`.env` oder über einen passenden Symfony-Parameter überschreiben (`memories.cluster.persistence.max_members`).

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -119,6 +119,7 @@ parameters:
         video_stories: 0.25
     memories.cluster.consolidate.require_valid_time: true
     memories.cluster.consolidate.min_valid_year: 1990
+    memories.cluster.persistence.max_members: '%env(int:MEMORIES_CLUSTER_MAX_MEMBERS)%'
 
     # Cluster Strategy Priorities
     # Higher numbers run earlier; values normalized to an evenly spaced 40-100 range.


### PR DESCRIPTION
## Summary
- cap the number of media IDs stored per cluster via the persistence service
- expose the cap through a new MEMORIES_CLUSTER_MAX_MEMBERS environment variable and document it

## Testing
- composer ci:test *(fails: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de3aaf49a08323953e2b643251dda5