### PR TITLE
Generate feed thumbnails on demand

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -856,6 +856,8 @@ services:
             $defaultCoverWidth: '%memories.http.feed.cover_width%'
             $defaultMemberWidth: '%memories.http.feed.member_width%'
             $maxThumbnailWidth: '%memories.http.feed.max_thumbnail_width%'
+            $thumbnailService: '@MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface'
+            $entityManager: '@Doctrine\ORM\EntityManagerInterface'
 
     # Title
     MagicSunday\Memories\Service\Clusterer\Title\TitleTemplateProvider:


### PR DESCRIPTION
## Summary
- inject the thumbnail service and entity manager into the feed controller to support on-demand thumbnail creation
- generate and persist thumbnails when missing before returning media responses
- extend feed controller unit tests to cover the new behaviour and update service wiring

## Testing
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de3a294b7c83239ddbf351aaa20378