### PR TITLE
Handle GD resample failure

### DIFF
--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -155,7 +155,10 @@ class ThumbnailService implements ThumbnailServiceInterface
                 }
 
                 try {
-                    imagecopyresampled($dst, $src, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+                    $resampleResult = imagecopyresampled($dst, $src, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+                    if ($resampleResult === false) {
+                        throw new RuntimeException('Unable to resample image for thumbnail.');
+                    }
 
                     $out         = $this->buildThumbnailPath($checksum, $size);
                     $writeResult = @imagejpeg($dst, $out, 85);


### PR DESCRIPTION
## Summary
- throw a RuntimeException when GD's imagecopyresampled fails while generating thumbnails
- provide a test double for imagecopyresampled to simulate GD resample failure and cover the new exception path

## Testing
- `composer ci:test:php:unit` *(fails: sh: 1: bin/php: not found)*
- `php vendor/bin/phpunit --configuration .build/phpunit.xml --filter ThumbnailServiceTest`


------
https://chatgpt.com/codex/tasks/task_e_68de833c08b48323a3682fdd5cac4060