### PR TITLE
Ensure Imagick thumbnails use JPEG compression

### DIFF
--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -119,6 +119,10 @@ class ThumbnailService implements ThumbnailServiceInterface
                         $clone = $flattened;
                     }
 
+                    $clone->setImageFormat('jpeg');
+                    $clone->setImageCompression(Imagick::COMPRESSION_JPEG);
+                    $clone->setImageCompressionQuality(85);
+
                     $out         = $this->buildThumbnailPath($checksum, $size);
                     $writeResult = $clone->writeImage($out);
 

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -105,6 +105,9 @@ final class ThumbnailServiceTest extends TestCase
         $imagick->expects(self::once())->method('autoOrientImage')->willReturn(true);
         $imagick->expects(self::once())->method('setImageOrientation')->with(Imagick::ORIENTATION_TOPLEFT)->willReturn(true);
         $imagick->expects(self::once())->method('thumbnailImage')->with(200, 0)->willReturn(true);
+        $imagick->expects(self::once())->method('setImageFormat')->with('jpeg')->willReturn(true);
+        $imagick->expects(self::once())->method('setImageCompression')->with(Imagick::COMPRESSION_JPEG)->willReturn(true);
+        $imagick->expects(self::once())->method('setImageCompressionQuality')->with(85)->willReturn(true);
         $imagick->expects(self::once())->method('writeImage')->with($expectedOutput)->willReturn(false);
         $imagick->expects(self::exactly(2))->method('clear');
         $imagick->expects(self::exactly(2))->method('destroy');


### PR DESCRIPTION
## Summary
- set the Imagick thumbnail clones to JPEG and apply compression before writing images
- update the Imagick-based unit test expectations for the new compression calls

## Testing
- composer ci:test *(fails: bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68debcb786e4832399118a2496bdf789