### PR TITLE
Prevent thumbnail upscaling

### DIFF
--- a/src/Http/Controller/FeedController.php
+++ b/src/Http/Controller/FeedController.php
@@ -259,8 +259,16 @@ final class FeedController
     private function resolveOrGenerateThumbnail(Media $media, int $width): ?string
     {
         $resolved = $this->thumbnailResolver->resolveBest($media, $width);
-        if (is_string($resolved) && $resolved !== $media->getPath()) {
-            return $resolved;
+        if (is_string($resolved)) {
+            if ($resolved !== $media->getPath()) {
+                return $resolved;
+            }
+
+            $existing = $media->getThumbnails();
+
+            if (is_array($existing) && $existing !== []) {
+                return $resolved;
+            }
         }
 
         try {

--- a/src/Http/Response/BinaryFileResponse.php
+++ b/src/Http/Response/BinaryFileResponse.php
@@ -70,6 +70,11 @@ final class BinaryFileResponse extends Response
         parent::__construct('', $status, $resolvedHeaders);
     }
 
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+
     public function send(): void
     {
         if ($this->contentLoaded) {


### PR DESCRIPTION
## Summary
- clamp GD and Imagick thumbnail generation to the source image width to avoid upscaling and skip duplicate target sizes
- expose the served file path on BinaryFileResponse and avoid regenerating thumbnails when an existing one already matches the original path
- add coverage that verifies oversized requests never exceed the source width and adjust thumbnail colour assertions for the GD alpha test

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: `bin/php` wrapper not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df9a6192fc8323ac87836cecdca183