### PR TITLE
Fix Imagick orientation compatibility

### DIFF
--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -191,7 +191,13 @@ final class ThumbnailServiceTest extends TestCase
         $imagick = $this->createMock(Imagick::class);
         $imagick->expects(self::once())->method('setOption')->with('jpeg:preserve-settings', 'true')->willReturn(true);
         $imagick->expects(self::once())->method('readImage')->with($sourcePath . '[0]')->willReturn(true);
-        $imagick->expects(self::once())->method('autoOrientImage')->willReturn(true);
+
+        if (method_exists(Imagick::class, 'autoOrientImage')) {
+            $imagick->expects(self::once())->method('autoOrientImage')->willReturn(true);
+        } else {
+            $imagick->expects(self::once())->method('getImageOrientation')->willReturn(Imagick::ORIENTATION_TOPLEFT);
+        }
+
         $imagick->expects(self::once())->method('setImageOrientation')->with(Imagick::ORIENTATION_TOPLEFT)->willReturn(true);
         $imagick->expects(self::once())->method('thumbnailImage')->with(200, 0)->willReturn(true);
         $imagick->expects(self::once())->method('setImageFormat')->with('jpeg')->willReturn(true);


### PR DESCRIPTION
## Summary
- guard Imagick orientation handling when `autoOrientImage()` is unavailable and perform manual corrections
- reset the orientation metadata after manual adjustments to match existing behaviour
- allow the thumbnail service unit test to run on Imagick builds without `autoOrientImage()`

## Testing
- `composer ci:test` *(fails: bin/php not found in the execution environment)*
- `vendor/bin/phpunit --configuration .build/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68df9f7d5a3c8323b4359ed1df1af2a1