### PR TITLE
BUGFIX: implement member quality stage interface

### DIFF
--- a/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
+++ b/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
@@ -45,6 +45,28 @@ final class MemberQualityRankingStage extends AbstractClusterScoreHeuristic impl
         return 'Medienbewertung';
     }
 
+    public function supports(ClusterDraft $cluster): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<int, Media> $mediaMap
+     */
+    public function enrich(ClusterDraft $cluster, array $mediaMap): void
+    {
+    }
+
+    public function score(ClusterDraft $cluster): float
+    {
+        return 0.0;
+    }
+
+    public function weightKey(): string
+    {
+        return 'member_quality';
+    }
+
     /**
      * @param list<ClusterDraft> $drafts
      *


### PR DESCRIPTION
## Summary
- implement the ClusterScoreHeuristicInterface methods on MemberQualityRankingStage so it no longer remains abstract

## Testing
- composer ci:test *(fails: bin/php not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa2c60efc8323aeadfa1aa7ff3199