### PR TITLE
Add capture timestamps to feed gallery output

### DIFF
--- a/public/app/src/main.js
+++ b/public/app/src/main.js
@@ -18,6 +18,13 @@ const dateFormatter = new Intl.DateTimeFormat('de-DE', {
   month: 'short',
   year: 'numeric',
 });
+const dateTimeFormatter = new Intl.DateTimeFormat('de-DE', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
 
 document.title = 'Rückblick-Galerie';
 
@@ -238,7 +245,13 @@ function createCard(item) {
 
   const images = Array.isArray(item.galerie) && item.galerie.length > 0
     ? item.galerie
-    : (item.cover ? [{ mediaId: item.coverMediaId, thumbnail: item.cover }] : []);
+    : (item.cover
+        ? [{
+            mediaId: item.coverMediaId,
+            thumbnail: item.cover,
+            aufgenommenAm: item.coverAufgenommenAm ?? null,
+          }]
+        : []);
 
   if (images.length === 0) {
     const placeholder = document.createElement('figure');
@@ -256,10 +269,21 @@ function createCard(item) {
       const figure = document.createElement('figure');
       const img = document.createElement('img');
       img.src = image.thumbnail;
-      img.alt = `Medien-ID ${image.mediaId ?? ''}`;
+      const takenAtLabel = formatDateTime(image.aufgenommenAm);
+      const mediaIdLabel = image.mediaId ? `Medien-ID ${image.mediaId}` : 'Medienvorschau';
+      img.alt = takenAtLabel ? `${mediaIdLabel}, aufgenommen am ${takenAtLabel}` : mediaIdLabel;
       img.loading = 'lazy';
       img.decoding = 'async';
+      if (takenAtLabel) {
+        img.title = `Aufgenommen am ${takenAtLabel}`;
+      }
       figure.appendChild(img);
+
+      if (takenAtLabel) {
+        const caption = document.createElement('figcaption');
+        caption.textContent = `Aufgenommen am ${takenAtLabel}`;
+        figure.appendChild(caption);
+      }
       gallery.appendChild(figure);
     });
   }
@@ -392,4 +416,17 @@ function formatDate(value) {
   }
 
   return dateFormatter.format(date);
+}
+
+function formatDateTime(value) {
+  if (typeof value !== 'string' || value === '') {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return dateTimeFormatter.format(date);
 }

--- a/public/app/src/style.css
+++ b/public/app/src/style.css
@@ -209,19 +209,37 @@ body {
 }
 
 .gallery figcaption {
-  height: 100%;
-  width: 100%;
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 6px 8px 8px;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 12px;
-  color: var(--muted);
-  font-size: 12px;
-  text-align: center;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 6px;
+  background: linear-gradient(180deg, rgba(11, 12, 16, 0) 0%, rgba(11, 12, 16, 0.82) 90%);
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.2;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
 .gallery figure:hover img {
   transform: scale(1.04);
+}
+
+.gallery figure.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gallery figure.empty figcaption {
+  position: static;
+  inset: auto;
+  padding: 12px;
+  background: none;
+  color: var(--muted);
+  text-shadow: none;
 }
 
 .empty-state {

--- a/src/Http/Controller/FeedController.php
+++ b/src/Http/Controller/FeedController.php
@@ -36,6 +36,7 @@ use function array_slice;
 use function count;
 use function hash;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_numeric;
 use function is_string;
@@ -367,8 +368,13 @@ final class FeedController
         $members = $item->getMemberIds();
 
         $previewMembers = array_slice($members, 0, $this->previewImageCount);
+        $mediaIdsToLoad = $previewMembers;
+        if ($coverId !== null && !in_array($coverId, $mediaIdsToLoad, true)) {
+            $mediaIdsToLoad[] = $coverId;
+        }
+
         $memberPayload = [];
-        $memberMediaMap = $this->loadMediaMap($previewMembers);
+        $memberMediaMap = $this->loadMediaMap($mediaIdsToLoad);
         foreach ($previewMembers as $memberId) {
             $media = $memberMediaMap[$memberId] ?? null;
 
@@ -379,6 +385,8 @@ final class FeedController
             ];
         }
 
+        $coverMedia = $coverId !== null ? ($memberMediaMap[$coverId] ?? null) : null;
+
         return [
             'id'            => $this->createItemId($item),
             'algorithmus'   => $item->getAlgorithm(),
@@ -388,6 +396,7 @@ final class FeedController
             'score'         => $item->getScore(),
             'coverMediaId'  => $coverId,
             'cover'         => $coverId !== null ? $this->buildThumbnailUrl($coverId, $this->defaultCoverWidth) : null,
+            'coverAufgenommenAm' => $this->formatTakenAt($coverMedia),
             'mitglieder'    => $previewMembers,
             'galerie'       => $memberPayload,
             'zeitspanne'    => $this->extractTimeRange($item),

--- a/test/Unit/Http/Controller/FeedControllerTest.php
+++ b/test/Unit/Http/Controller/FeedControllerTest.php
@@ -127,6 +127,7 @@ final class FeedControllerTest extends TestCase
         self::assertArrayHasKey('items', $payload);
         self::assertCount(1, $payload['items']);
         self::assertSame('holiday_event', $payload['items'][0]['algorithmus']);
+        self::assertSame('2024-01-01T10:00:00+00:00', $payload['items'][0]['coverAufgenommenAm']);
 
         $gallery = $payload['items'][0]['galerie'];
         self::assertSame('2024-01-01T10:00:00+00:00', $gallery[0]['aufgenommenAm']);


### PR DESCRIPTION
## Summary
- enrich feed gallery entries with capture timestamps loaded from cached media entities
- extend the feed controller unit test to cover the new timestamp payload

## Testing
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb93a54a083239348e022e409c0bf