### PR TITLE
Add configuration toggle for thumbnail orientation handling

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -40,6 +40,8 @@ MEMORIES_CLUSTER_MAX_MEMBERS=20
 MEMORIES_MEDIA_DIR=/var/lib/memories/media
 # Absolute path where generated thumbnails will be written.
 MEMORIES_THUMBNAIL_DIR=/var/lib/memories/thumbnails
+# Set to 1 to rotate thumbnails based on the EXIF orientation flag. Defaults to 0 (disabled).
+MEMORIES_THUMBNAIL_APPLY_ORIENTATION=0
 
 # --- Locale ---
 # Preferred locale for CLI output and formatting (ISO language code).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ MEMORIES_PREFERRED_LOCALE=de
 
 Leave the variable unset to retain the previous behaviour of using the generic `name` tag provided by Overpass.
 
+## Thumbnail-Ausrichtung
+
+Die Thumbnail-Pipeline ignoriert EXIF-Orientierungsflags jetzt standardmäßig und erzeugt die verkleinerten JPEGs genau so, wie
+die Pixeldaten auf der Platte liegen. Falls du weiterhin automatische Rotationen anhand des Flags benötigst, setzt du in deiner
+`.env` den Schalter `MEMORIES_THUMBNAIL_APPLY_ORIENTATION=1`. Mit dem Standardwert `0` bleibt das frühere Verhalten deaktiviert,
+was insbesondere für bereits physisch gedrehte Bilder mit inkonsistentem Orientation-Tag Fehler vermeidet.
+
 ## Cluster-Konfiguration
 
 Die Persistierung der berechneten Cluster wird jetzt begrenzt, damit Feeds und Oberflächen nicht mit hunderten Medien pro Block

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -26,6 +26,7 @@ parameters:
 
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]
+    memories.thumbnail.apply_orientation: '%env(default::bool:MEMORIES_THUMBNAIL_APPLY_ORIENTATION)%'
 
     # Consolidation Defaults
     memories.cluster.consolidate.min_score: 0.30

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -73,6 +73,7 @@ services:
         arguments:
             $thumbnailDir: '%env(string:MEMORIES_THUMBNAIL_DIR)%'
             $sizes: '%memories.thumbnail_sizes%'
+            $applyOrientation: '%memories.thumbnail.apply_orientation%'
 
     MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface:
         alias: MagicSunday\Memories\Service\Thumbnail\ThumbnailService

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -1530,7 +1530,7 @@ final class OrientationThumbnailServiceStub extends ThumbnailService
     {
         $this->orientationDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'memories-orientation-' . uniqid('', true);
 
-        parent::__construct($this->orientationDir, [1]);
+        parent::__construct($this->orientationDir, [1], true);
     }
 
     public function __destruct()


### PR DESCRIPTION
## Summary
- add an opt-in flag on the thumbnail service to apply EXIF orientation only when explicitly enabled
- expose the MEMORIES_THUMBNAIL_APPLY_ORIENTATION environment variable with defaults and documentation

## Testing
- `composer ci:test` *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb8f226208323afab7867c7c3453c