### PR TITLE
Order feed members chronologically

### DIFF
--- a/src/Service/Feed/HtmlFeedExportService.php
+++ b/src/Service/Feed/HtmlFeedExportService.php
@@ -142,8 +142,8 @@ final class HtmlFeedExportService implements FeedExportServiceInterface
         $members = $this->mediaRepository->findByIds($memberIds);
 
         $coverId = $item->getCoverMediaId();
-        if ($coverId !== null) {
-            usort($members, static function (Media $a, Media $b) use ($coverId): int {
+        usort($members, static function (Media $a, Media $b) use ($coverId): int {
+            if ($coverId !== null) {
                 if ($a->getId() === $coverId && $b->getId() !== $coverId) {
                     return -1;
                 }
@@ -151,13 +151,13 @@ final class HtmlFeedExportService implements FeedExportServiceInterface
                 if ($b->getId() === $coverId && $a->getId() !== $coverId) {
                     return 1;
                 }
+            }
 
-                $timestampA = $a->getTakenAt()?->getTimestamp() ?? 0;
-                $timestampB = $b->getTakenAt()?->getTimestamp() ?? 0;
+            $timestampA = $a->getTakenAt()?->getTimestamp() ?? 0;
+            $timestampB = $b->getTakenAt()?->getTimestamp() ?? 0;
 
-                return $timestampA <=> $timestampB;
-            });
-        }
+            return $timestampA <=> $timestampB;
+        });
 
         $images = [];
         foreach ($members as $media) {


### PR DESCRIPTION
## Summary
- ensure feed member IDs are sorted by capture time while keeping the cover image first
- always sort exported feed images chronologically so non-cover photos appear in capture order

## Testing
- composer ci:test *(fails: bin/php not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbe8e787c8323ae0977981072273b