### PR TITLE
Ensure vacation clusters preserve day-balanced ordering

### DIFF
--- a/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
+++ b/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
@@ -18,6 +18,7 @@ use MagicSunday\Memories\Service\Clusterer\Scoring\AbstractClusterScoreHeuristic
 
 use function array_keys;
 use function array_map;
+use function array_values;
 use function count;
 use function max;
 use function usort;
@@ -155,8 +156,8 @@ final class MemberQualityRankingStage extends AbstractClusterScoreHeuristic impl
                 $positions[(int) $memberId] = $idx;
             }
 
-            $ordered = $members;
-            usort($ordered, function (int $a, int $b) use ($details, $positions): int {
+            $qualityOrdered = $members;
+            usort($qualityOrdered, function (int $a, int $b) use ($details, $positions): int {
                 $detailA = $details[(string) $a]['score'] ?? 0.0;
                 $detailB = $details[(string) $b]['score'] ?? 0.0;
 
@@ -168,7 +169,7 @@ final class MemberQualityRankingStage extends AbstractClusterScoreHeuristic impl
             });
 
             $ranked = [];
-            foreach ($ordered as $memberId) {
+            foreach ($qualityOrdered as $memberId) {
                 $detail   = $details[(string) $memberId];
                 $ranked[] = [
                     'id'          => $memberId,
@@ -180,9 +181,12 @@ final class MemberQualityRankingStage extends AbstractClusterScoreHeuristic impl
             }
 
             $draft->setParam('member_quality', [
-                'ordered' => $ordered,
+                'ordered' => array_values($members),
                 'members' => $details,
-                'ranked'  => $ranked,
+                'quality_ranked' => [
+                    'ordered' => $qualityOrdered,
+                    'members' => $ranked,
+                ],
                 'summary' => [
                     'quality_avg'       => $avgQuality,
                     'aesthetics_avg'    => $avgAesthetics,

--- a/test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php
+++ b/test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php
@@ -90,10 +90,12 @@ final class MemberQualityRankingStageTest extends TestCase
         $params = $draft->getParams();
         self::assertArrayHasKey('member_quality', $params);
 
-        /** @var array{ordered:list<int>,members:array<string,array{score:float,quality:float,aesthetics:float,penalty:float}>} $meta */
+        /** @var array{ordered:list<int>,quality_ranked:array{ordered:list<int>,members:list<array{id:int,score:float,quality:float,aesthetics:float,penalty:float}>},members:array<string,array{score:float,quality:float,aesthetics:float,penalty:float}>} $meta */
         $meta = $params['member_quality'];
 
         self::assertSame([101, 102, 103], $meta['ordered']);
+        self::assertSame([101, 102, 103], $meta['quality_ranked']['ordered']);
+        self::assertSame([101, 102, 103], array_map(static fn (array $entry): int => $entry['id'], $meta['quality_ranked']['members']));
 
         $members = $meta['members'];
         self::assertGreaterThan($members['102']['score'], $members['101']['score']);
@@ -170,6 +172,7 @@ final class MemberQualityRankingStageTest extends TestCase
         $members = $meta['members'];
 
         self::assertSame([201, 202, 203], $meta['ordered']);
+        self::assertSame([201, 202, 203], $meta['quality_ranked']['ordered']);
         self::assertSame(0.0, $members['202']['penalty']);
         self::assertGreaterThan($members['202']['penalty'], $members['203']['penalty']);
         self::assertGreaterThan($members['202']['score'], $members['203']['score']);


### PR DESCRIPTION
## Summary
- keep the member_quality metadata aligned with the day-balanced order while exposing the quality ranking separately
- prefer the balanced ordering for vacation clusters during persistence with fallbacks to the quality ranking if required
- extend unit coverage to assert the balanced ordering survives clamping and adjust existing stage tests for the new metadata shape

## Testing
- `composer ci:test` *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc03230608323be430b19e3cdd720