### PR TITLE
BUGFIX: register slideshow command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ Der neue HTTP-Einstiegspunkt unter `public/index.php` liefert zwei Dinge:
 
 * `GET /api/feed` – JSON-Ausgabe des Feed-Builders (Filter für Score, Strategie, Datum)
 * `GET /api/media/{id}/thumbnail` – Auslieferung der generierten Thumbnails bzw. Originaldateien
+* `GET /api/feed/{id}/video` – Auslieferung der erzeugten Rückblick-Videos
 
 Unter `public/app/` liegt eine schlanke SPA (Vanilla JS + Vite), die den Feed lädt, Filter per UI anbietet und Cover-Galerien animiert darstellt. Die Anwendung läuft sowohl gegen den lokalen PHP-Server als auch gegen den Vite-Entwicklungsserver.
+
+### Rückblick-Videos
+
+Jeder Rückblick erhält optional ein automatisch generiertes Video, das die Vorschaubilder in einer Sequenz mit Überblendungen zeigt. Die Generierung erfolgt asynchron über den neuen Konsolenbefehl `slideshow:generate`, der intern durch den HTTP-Controller angestoßen wird. Bereits erzeugte Videos landen im Verzeichnis `public/videos/` und werden beim nächsten Abruf wiederverwendet, sodass keine unnötige Rechenzeit entsteht.
+
+Die Laufzeit pro Bild sowie die Dauer der Übergänge lassen sich über die Parameter `memories.slideshow.image_duration_s` und `memories.slideshow.transition_duration_s` in `config/parameters.yaml` anpassen. Für andere Ausgabegrößen gibt es zusätzlich `memories.slideshow.video_width` und `memories.slideshow.video_height`. Standardmäßig verwendet der Generator das `ffmpeg`-Binary aus dem `PATH`. Falls es an einem anderen Ort liegt, kann der Pfad über den Parameter `memories.slideshow.ffmpeg_path` (oder die Umgebungsvariable `FFMPEG_PATH`) überschrieben werden.
 
 ### Schnelleinstieg
 

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -196,3 +196,10 @@ parameters:
     memories.http.feed.member_width: 320
     memories.http.feed.max_thumbnail_width: 2048
 
+    memories.slideshow.video_dir: '%kernel.project_dir%/public/videos'
+    memories.slideshow.image_duration_s: 3.5
+    memories.slideshow.transition_duration_s: 0.8
+    memories.slideshow.video_width: 1280
+    memories.slideshow.video_height: 720
+    memories.slideshow.ffmpeg_path: 'ffmpeg'
+

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -79,6 +79,29 @@ services:
         alias: MagicSunday\Memories\Service\Thumbnail\ThumbnailService
 
     ########################################
+    # Slideshow Videos
+    ########################################
+    MagicSunday\Memories\Service\Slideshow\SlideshowVideoGenerator:
+        arguments:
+            $ffmpegBinary: '%memories.slideshow.ffmpeg_path%'
+            $slideDuration: '%memories.slideshow.image_duration_s%'
+            $transitionDuration: '%memories.slideshow.transition_duration_s%'
+            $width: '%memories.slideshow.video_width%'
+            $height: '%memories.slideshow.video_height%'
+
+    MagicSunday\Memories\Service\Slideshow\SlideshowVideoGeneratorInterface:
+        alias: MagicSunday\Memories\Service\Slideshow\SlideshowVideoGenerator
+
+    MagicSunday\Memories\Service\Slideshow\SlideshowVideoManager:
+        arguments:
+            $videoDirectory: '%memories.slideshow.video_dir%'
+            $projectDirectory: '%kernel.project_dir%'
+            $slideDuration: '%memories.slideshow.image_duration_s%'
+
+    MagicSunday\Memories\Service\Slideshow\SlideshowVideoManagerInterface:
+        alias: MagicSunday\Memories\Service\Slideshow\SlideshowVideoManager
+
+    ########################################
     # Metadata Extractors & Enricher
     ########################################
     MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor:

--- a/public/app/src/style.css
+++ b/public/app/src/style.css
@@ -167,6 +167,40 @@ body {
   color: var(--muted);
 }
 
+.slideshow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+.slideshow__video {
+  display: block;
+  width: 100%;
+  background: #000;
+  aspect-ratio: 16 / 9;
+}
+
+.slideshow__status {
+  padding: 12px 14px;
+  font-size: 14px;
+  color: var(--muted);
+  text-align: center;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.slideshow__meta {
+  margin: 0;
+  padding: 0 14px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+}
+
 .gallery {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/public/index.php
+++ b/public/index.php
@@ -45,6 +45,14 @@ try {
         $response   = $controller->feed($request);
     }
 
+    if ($response === null && $method === 'GET' && preg_match('#^/api/feed/([a-f0-9]{40})/video$#', $path, $matches) === 1) {
+        $itemId = $matches[1];
+
+        /** @var FeedController $controller */
+        $controller = $container->get(FeedController::class);
+        $response   = $controller->slideshow($itemId);
+    }
+
     if ($response === null && $method === 'GET' && preg_match('#^/api/media/(\d+)/thumbnail$#', $path, $matches) === 1) {
         $mediaId = (int) $matches[1];
 

--- a/public/videos/.gitignore
+++ b/public/videos/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/Command/SlideshowGenerateCommand.php
+++ b/src/Command/SlideshowGenerateCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Command;
+
+use MagicSunday\Memories\Service\Slideshow\SlideshowJob;
+use MagicSunday\Memories\Service\Slideshow\SlideshowVideoGeneratorInterface;
+use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+use function file_exists;
+use function sprintf;
+use function file_put_contents;
+use function is_file;
+use function unlink;
+
+use const LOCK_EX;
+
+/**
+ * Console command that executes slideshow generation jobs.
+ */
+#[AsCommand(name: 'slideshow:generate', description: 'Erstellt ein Slideshow-Video für die angegebene Job-Datei.')]
+final class SlideshowGenerateCommand extends Command
+{
+
+    public function __construct(private readonly SlideshowVideoGeneratorInterface $generator)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('job', InputArgument::REQUIRED, 'Absolute path to the job file.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io      = new SymfonyStyle($input, $output);
+        $jobFile = (string) $input->getArgument('job');
+
+        try {
+            $job = SlideshowJob::fromJsonFile($jobFile);
+        } catch (RuntimeException $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $this->generator->generate($job);
+            $io->success(sprintf('Slideshow "%s" wurde erstellt.', $job->id()));
+            $this->cleanup($job);
+
+            return Command::SUCCESS;
+        } catch (Throwable $throwable) {
+            $this->writeError($job, $throwable);
+            $io->error($throwable->getMessage());
+
+            return Command::FAILURE;
+        } finally {
+            if (is_file($job->jobFile())) {
+                unlink($job->jobFile());
+            }
+        }
+    }
+
+    private function cleanup(SlideshowJob $job): void
+    {
+        if (file_exists($job->lockPath())) {
+            unlink($job->lockPath());
+        }
+
+        if (is_file($job->errorPath())) {
+            unlink($job->errorPath());
+        }
+    }
+
+    private function writeError(SlideshowJob $job, Throwable $throwable): void
+    {
+        file_put_contents(
+            $job->errorPath(),
+            $throwable->getMessage() ?: 'Unbekannter Fehler bei der Videoerstellung.',
+            LOCK_EX
+        );
+
+        if (file_exists($job->lockPath())) {
+            unlink($job->lockPath());
+        }
+    }
+}

--- a/src/Service/Slideshow/SlideshowJob.php
+++ b/src/Service/Slideshow/SlideshowJob.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Slideshow;
+
+use RuntimeException;
+
+use function file_get_contents;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function json_last_error_msg;
+use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Represents a scheduled slideshow generation job.
+ */
+final class SlideshowJob
+{
+    /**
+     * @param list<string> $images
+     */
+    public function __construct(
+        private readonly string $id,
+        private readonly string $jobFile,
+        private readonly string $outputPath,
+        private readonly string $lockPath,
+        private readonly string $errorPath,
+        private readonly array $images,
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function jobFile(): string
+    {
+        return $this->jobFile;
+    }
+
+    public function outputPath(): string
+    {
+        return $this->outputPath;
+    }
+
+    public function lockPath(): string
+    {
+        return $this->lockPath;
+    }
+
+    public function errorPath(): string
+    {
+        return $this->errorPath;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function images(): array
+    {
+        return $this->images;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id'     => $this->id,
+            'output' => $this->outputPath,
+            'lock'   => $this->lockPath,
+            'error'  => $this->errorPath,
+            'images' => $this->images,
+        ];
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+    }
+
+    public static function fromJsonFile(string $path): self
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new RuntimeException(sprintf('Could not read job file "%s".', $path));
+        }
+
+        $payload = json_decode($contents, true);
+        if (!is_array($payload)) {
+            throw new RuntimeException(sprintf('Invalid job description in "%s": %s', $path, json_last_error_msg()));
+        }
+
+        $id     = self::requireString($payload['id'] ?? null, 'id');
+        $output = self::requireString($payload['output'] ?? null, 'output');
+        $lock   = self::requireString($payload['lock'] ?? null, 'lock');
+        $error  = self::requireString($payload['error'] ?? null, 'error');
+
+        $imagesRaw = $payload['images'] ?? [];
+        if (!is_array($imagesRaw)) {
+            throw new RuntimeException('Job payload "images" must be an array.');
+        }
+
+        $images = [];
+        foreach ($imagesRaw as $image) {
+            if (!is_string($image) || $image === '') {
+                continue;
+            }
+
+            $images[] = $image;
+        }
+
+        if ($images === []) {
+            throw new RuntimeException('Job payload does not contain any usable images.');
+        }
+
+        return new self($id, $path, $output, $lock, $error, $images);
+    }
+
+    private static function requireString(mixed $value, string $field): string
+    {
+        if (!is_string($value) || $value === '') {
+            throw new RuntimeException(sprintf('Job payload field "%s" must be a non-empty string.', $field));
+        }
+
+        return $value;
+    }
+}

--- a/src/Service/Slideshow/SlideshowVideoGenerator.php
+++ b/src/Service/Slideshow/SlideshowVideoGenerator.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Slideshow;
+
+use RuntimeException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+use function array_merge;
+use function count;
+use function dirname;
+use function implode;
+use function is_dir;
+use function max;
+use function mkdir;
+use function sprintf;
+use function trim;
+
+/**
+ * FFmpeg based slideshow generator.
+ */
+final class SlideshowVideoGenerator implements SlideshowVideoGeneratorInterface
+{
+    /** @var list<string> */
+    private const DEFAULT_TRANSITIONS = [
+        'fade',
+        'wipeleft',
+        'wiperight',
+        'circleopen',
+        'circleclose',
+        'pixelize',
+    ];
+
+    /**
+     * @param list<string> $transitions
+     */
+    public function __construct(
+        private readonly string $ffmpegBinary = 'ffmpeg',
+        private readonly float $slideDuration = 3.0,
+        private readonly float $transitionDuration = 0.75,
+        private readonly int $width = 1280,
+        private readonly int $height = 720,
+        private readonly array $transitions = self::DEFAULT_TRANSITIONS,
+    ) {
+    }
+
+    public function generate(SlideshowJob $job): void
+    {
+        $images = $job->images();
+        $count  = count($images);
+        if ($count === 0) {
+            throw new RuntimeException('Cannot render slideshow without images.');
+        }
+
+        $directory = dirname($job->outputPath());
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException(sprintf('Could not create video directory "%s".', $directory));
+        }
+
+        $command = $this->buildCommand($images, $job->outputPath());
+
+        $process = new Process($command);
+        $process->setTimeout(null);
+        $process->disableOutput();
+
+        try {
+            $process->mustRun();
+        } catch (ProcessFailedException $exception) {
+            $message = trim($exception->getProcess()->getErrorOutput());
+            if ($message === '') {
+                $message = trim($exception->getProcess()->getOutput());
+            }
+
+            if ($message === '') {
+                $message = $exception->getMessage();
+            }
+
+            throw new RuntimeException($message, 0, $exception);
+        }
+    }
+
+    /**
+     * @param list<string> $images
+     *
+     * @return list<string>
+     */
+    private function buildCommand(array $images, string $output): array
+    {
+        if (count($images) === 1) {
+            return $this->buildSingleImageCommand($images[0], $output);
+        }
+
+        return $this->buildMultiImageCommand($images, $output);
+    }
+
+    private function buildSingleImageCommand(string $image, string $output): array
+    {
+        $filter = sprintf(
+            '[0:v]scale=%1$d:%2$d:force_original_aspect_ratio=decrease,' .
+            'pad=%1$d:%2$d:(ow-iw)/2:(oh-ih)/2:black,format=yuv420p,setsar=1,' .
+            'trim=duration=%3$.3f,setpts=PTS-STARTPTS[vout]',
+            $this->width,
+            $this->height,
+            max(0.1, $this->slideDuration)
+        );
+
+        return [
+            $this->ffmpegBinary,
+            '-y',
+            '-loglevel',
+            'error',
+            '-loop',
+            '1',
+            '-t',
+            sprintf('%0.3f', max(0.1, $this->slideDuration)),
+            '-i',
+            $image,
+            '-filter_complex',
+            $filter,
+            '-map',
+            '[vout]',
+            '-movflags',
+            '+faststart',
+            '-pix_fmt',
+            'yuv420p',
+            '-an',
+            $output,
+        ];
+    }
+
+    /**
+     * @param list<string> $images
+     *
+     * @return list<string>
+     */
+    private function buildMultiImageCommand(array $images, string $output): array
+    {
+        $command = [$this->ffmpegBinary, '-y', '-loglevel', 'error'];
+        $durationWithOverlap = max(0.1, $this->slideDuration + $this->transitionDuration);
+
+        foreach ($images as $image) {
+            $command = array_merge($command, [
+                '-loop',
+                '1',
+                '-t',
+                sprintf('%0.3f', $durationWithOverlap),
+                '-i',
+                $image,
+            ]);
+        }
+
+        $filters = [];
+        foreach ($images as $index => $image) {
+            $filters[] = sprintf(
+                '[%1$d:v]scale=%2$d:%3$d:force_original_aspect_ratio=decrease,' .
+                'pad=%2$d:%3$d:(ow-iw)/2:(oh-ih)/2:black,format=yuv420p,setsar=1,' .
+                'trim=duration=%4$.3f,setpts=PTS-STARTPTS[s%1$d]',
+                $index,
+                $this->width,
+                $this->height,
+                $durationWithOverlap
+            );
+        }
+
+        $transitionCount = count($this->transitions);
+        $current = '[s0]';
+        $offset  = max(0.1, $this->slideDuration);
+
+        for ($index = 1; $index < count($images); $index++) {
+            $transition = $this->transitions[($index - 1) % $transitionCount] ?? 'fade';
+            if ($transition === '') {
+                $transition = 'fade';
+            }
+
+            $targetLabel = $index === count($images) - 1 ? '[vout]' : sprintf('[tmp%d]', $index);
+            $filters[] = sprintf(
+                '%s[s%d]xfade=transition=%s:duration=%0.3f:offset=%0.3f:shortest=1%s',
+                $current,
+                $index,
+                $transition,
+                max(0.1, $this->transitionDuration),
+                $offset,
+                $targetLabel
+            );
+            $current = $targetLabel;
+            $offset += max(0.1, $this->slideDuration);
+        }
+
+        $filterComplex = implode(';', $filters);
+
+        $command[] = '-filter_complex';
+        $command[] = $filterComplex;
+        $command[] = '-map';
+        $command[] = '[vout]';
+        $command[] = '-movflags';
+        $command[] = '+faststart';
+        $command[] = '-pix_fmt';
+        $command[] = 'yuv420p';
+        $command[] = '-an';
+        $command[] = $output;
+
+        return $command;
+    }
+}

--- a/src/Service/Slideshow/SlideshowVideoGeneratorInterface.php
+++ b/src/Service/Slideshow/SlideshowVideoGeneratorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Slideshow;
+
+/**
+ * Generates slideshow videos for feed cards.
+ */
+interface SlideshowVideoGeneratorInterface
+{
+    public function generate(SlideshowJob $job): void;
+}

--- a/src/Service/Slideshow/SlideshowVideoManager.php
+++ b/src/Service/Slideshow/SlideshowVideoManager.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Slideshow;
+
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Process\Exception\RuntimeException as ProcessRuntimeException;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+use function fclose;
+use function file_get_contents;
+use function file_exists;
+use function file_put_contents;
+use function fopen;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function mkdir;
+use function sprintf;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
+
+/**
+ * Coordinates slideshow generation.
+ */
+final class SlideshowVideoManager implements SlideshowVideoManagerInterface
+{
+    public function __construct(
+        private readonly string $videoDirectory,
+        private readonly string $projectDirectory,
+        private readonly float $slideDuration,
+        private readonly string $phpBinary = PHP_BINARY,
+    ) {
+    }
+
+    /**
+     * @param list<int>       $memberIds
+     * @param array<int,Media> $mediaMap
+     */
+    public function ensureForItem(string $itemId, array $memberIds, array $mediaMap): SlideshowVideoStatus
+    {
+        $images = $this->collectImages($memberIds, $mediaMap);
+        if ($images === []) {
+            return SlideshowVideoStatus::unavailable($this->slideDuration);
+        }
+
+        $videoPath = $this->buildVideoPath($itemId);
+        $lockPath  = $this->buildLockPath($videoPath);
+        $errorPath = $this->buildErrorPath($videoPath);
+        $jobPath   = $this->buildJobPath($videoPath);
+
+        if (is_file($videoPath)) {
+            return SlideshowVideoStatus::ready($this->buildVideoUrl($itemId), $this->slideDuration);
+        }
+
+        if (is_file($errorPath)) {
+            $message = file_get_contents($errorPath);
+            $message = is_string($message) && $message !== '' ? $message : 'Video konnte nicht erzeugt werden.';
+
+            return SlideshowVideoStatus::error($message, $this->slideDuration);
+        }
+
+        if (is_file($lockPath)) {
+            return SlideshowVideoStatus::generating($this->slideDuration);
+        }
+
+        $this->ensureVideoDirectory();
+
+        $handle = @fopen($lockPath, 'x');
+        if ($handle === false) {
+            return SlideshowVideoStatus::generating($this->slideDuration);
+        }
+
+        try {
+            $job = new SlideshowJob($itemId, $jobPath, $videoPath, $lockPath, $errorPath, $images);
+            file_put_contents($jobPath, $job->toJson(), LOCK_EX);
+            $this->startGenerator($job);
+        } catch (Throwable $throwable) {
+            $this->handleGenerationFailure($throwable, $lockPath, $errorPath, $jobPath);
+
+            return SlideshowVideoStatus::error($throwable->getMessage(), $this->slideDuration);
+        } finally {
+            fclose($handle);
+        }
+
+        return SlideshowVideoStatus::generating($this->slideDuration);
+    }
+
+    public function resolveVideoPath(string $itemId): ?string
+    {
+        $path = $this->buildVideoPath($itemId);
+
+        return is_file($path) ? $path : null;
+    }
+
+    /**
+     * @param list<int>       $memberIds
+     * @param array<int,Media> $mediaMap
+     *
+     * @return list<string>
+     */
+    private function collectImages(array $memberIds, array $mediaMap): array
+    {
+        $images = [];
+        foreach ($memberIds as $memberId) {
+            $media = $mediaMap[$memberId] ?? null;
+            if (!$media instanceof Media) {
+                continue;
+            }
+
+            $path = $media->getPath();
+            if ($path !== '' && is_file($path)) {
+                $images[] = $path;
+            }
+        }
+
+        return $images;
+    }
+
+    private function buildVideoPath(string $itemId): string
+    {
+        return $this->videoDirectory . DIRECTORY_SEPARATOR . $itemId . '.mp4';
+    }
+
+    private function buildLockPath(string $videoPath): string
+    {
+        return $videoPath . '.lock';
+    }
+
+    private function buildJobPath(string $videoPath): string
+    {
+        return $videoPath . '.job.json';
+    }
+
+    private function buildErrorPath(string $videoPath): string
+    {
+        return $videoPath . '.error.log';
+    }
+
+    private function buildVideoUrl(string $itemId): string
+    {
+        return sprintf('/api/feed/%s/video', $itemId);
+    }
+
+    private function ensureVideoDirectory(): void
+    {
+        if (is_dir($this->videoDirectory)) {
+            return;
+        }
+
+        if (!mkdir($this->videoDirectory, 0775, true) && !is_dir($this->videoDirectory)) {
+            throw new ProcessRuntimeException(sprintf('Video directory "%s" could not be created.', $this->videoDirectory));
+        }
+    }
+
+    private function startGenerator(SlideshowJob $job): void
+    {
+        $console = $this->projectDirectory . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Memories.php';
+        if (!is_file($console)) {
+            throw new ProcessRuntimeException('Console entry point not found.');
+        }
+
+        $process = new Process([
+            $this->phpBinary,
+            $console,
+            'slideshow:generate',
+            $job->jobFile(),
+        ]);
+
+        try {
+            $process->disableOutput();
+            $process->start();
+        } catch (Throwable $throwable) {
+            throw new ProcessRuntimeException($throwable->getMessage(), 0, $throwable);
+        }
+    }
+
+    private function handleGenerationFailure(Throwable $throwable, string $lockPath, string $errorPath, string $jobPath): void
+    {
+        if (file_exists($lockPath)) {
+            unlink($lockPath);
+        }
+
+        file_put_contents($errorPath, $throwable->getMessage() ?: 'Unbekannter Fehler bei der Videoerstellung.', LOCK_EX);
+
+        if (file_exists($jobPath)) {
+            unlink($jobPath);
+        }
+    }
+}

--- a/src/Service/Slideshow/SlideshowVideoManagerInterface.php
+++ b/src/Service/Slideshow/SlideshowVideoManagerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Slideshow;
+
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Handles slideshow generation scheduling and status reporting.
+ */
+interface SlideshowVideoManagerInterface
+{
+    /**
+     * @param list<int>       $memberIds
+     * @param array<int,Media> $mediaMap
+     */
+    public function ensureForItem(string $itemId, array $memberIds, array $mediaMap): SlideshowVideoStatus;
+
+    public function resolveVideoPath(string $itemId): ?string;
+}

--- a/src/Service/Slideshow/SlideshowVideoStatus.php
+++ b/src/Service/Slideshow/SlideshowVideoStatus.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Slideshow;
+
+use function round;
+
+/**
+ * Value object describing the current slideshow video state.
+ */
+final class SlideshowVideoStatus
+{
+    public const STATUS_READY = 'bereit';
+
+    public const STATUS_GENERATING = 'in_erstellung';
+
+    public const STATUS_ERROR = 'fehlgeschlagen';
+
+    public const STATUS_UNAVAILABLE = 'nicht_verfuegbar';
+
+    public function __construct(
+        private readonly string $status,
+        private readonly ?string $url,
+        private readonly ?string $message,
+        private readonly float $secondsPerImage,
+    ) {
+    }
+
+    public static function ready(string $url, float $secondsPerImage): self
+    {
+        return new self(self::STATUS_READY, $url, null, $secondsPerImage);
+    }
+
+    public static function generating(float $secondsPerImage): self
+    {
+        return new self(self::STATUS_GENERATING, null, 'Video wird erstellt …', $secondsPerImage);
+    }
+
+    public static function unavailable(float $secondsPerImage): self
+    {
+        return new self(self::STATUS_UNAVAILABLE, null, 'Nicht genug Medien für ein Video vorhanden.', $secondsPerImage);
+    }
+
+    public static function error(string $message, float $secondsPerImage): self
+    {
+        return new self(self::STATUS_ERROR, null, $message, $secondsPerImage);
+    }
+
+    public function toArray(): array
+    {
+        $payload = [
+            'status'                => $this->status,
+            'meldung'               => $this->message,
+            'dauerProBildSekunden'  => round($this->secondsPerImage, 2),
+        ];
+
+        if ($this->url !== null) {
+            $payload['url'] = $this->url;
+        }
+
+        return $payload;
+    }
+
+    public function status(): string
+    {
+        return $this->status;
+    }
+}

--- a/test/Unit/Service/Slideshow/SlideshowJobTest.php
+++ b/test/Unit/Service/Slideshow/SlideshowJobTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Slideshow;
+
+use MagicSunday\Memories\Service\Slideshow\SlideshowJob;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+use function file_put_contents;
+use function json_encode;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const JSON_THROW_ON_ERROR;
+use const LOCK_EX;
+
+final class SlideshowJobTest extends TestCase
+{
+    #[Test]
+    public function itSerializesToJsonAndBack(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'slideshow-job-');
+        self::assertIsString($tmp);
+
+        $job = new SlideshowJob('abc', $tmp, '/tmp/out.mp4', '/tmp/out.mp4.lock', '/tmp/out.mp4.error', ['/path/one.jpg']);
+        file_put_contents($tmp, $job->toJson(), LOCK_EX);
+
+        $loaded = SlideshowJob::fromJsonFile($tmp);
+
+        self::assertSame('abc', $loaded->id());
+        self::assertSame('/tmp/out.mp4', $loaded->outputPath());
+        self::assertSame(['/path/one.jpg'], $loaded->images());
+
+        unlink($tmp);
+    }
+
+    #[Test]
+    public function itRejectsJobsWithoutImages(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'slideshow-job-');
+        self::assertIsString($tmp);
+
+        file_put_contents(
+            $tmp,
+            json_encode(
+                [
+                    'id' => 'abc',
+                    'output' => '/tmp/out.mp4',
+                    'lock' => '/tmp/out.mp4.lock',
+                    'error' => '/tmp/out.mp4.error',
+                    'images' => [],
+                ],
+                JSON_THROW_ON_ERROR
+            ),
+            LOCK_EX
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Job payload does not contain any usable images.');
+
+        try {
+            SlideshowJob::fromJsonFile($tmp);
+        } finally {
+            unlink($tmp);
+        }
+    }
+}

--- a/test/Unit/Service/Slideshow/SlideshowVideoStatusTest.php
+++ b/test/Unit/Service/Slideshow/SlideshowVideoStatusTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Slideshow;
+
+use MagicSunday\Memories\Service\Slideshow\SlideshowVideoStatus;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class SlideshowVideoStatusTest extends TestCase
+{
+    #[Test]
+    public function itSerializesReadyStatus(): void
+    {
+        $status = SlideshowVideoStatus::ready('/api/feed/foo/video', 3.45);
+        self::assertSame(
+            [
+                'status' => SlideshowVideoStatus::STATUS_READY,
+                'meldung' => null,
+                'dauerProBildSekunden' => 3.45,
+                'url' => '/api/feed/foo/video',
+            ],
+            $status->toArray()
+        );
+        self::assertSame(SlideshowVideoStatus::STATUS_READY, $status->status());
+    }
+
+    #[Test]
+    public function itSerializesGeneratingStatus(): void
+    {
+        $status = SlideshowVideoStatus::generating(2.0);
+        self::assertSame(
+            [
+                'status' => SlideshowVideoStatus::STATUS_GENERATING,
+                'meldung' => 'Video wird erstellt …',
+                'dauerProBildSekunden' => 2.0,
+            ],
+            $status->toArray()
+        );
+    }
+
+    #[Test]
+    public function itSerializesErrorStatus(): void
+    {
+        $status = SlideshowVideoStatus::error('Fehler', 1.25);
+        self::assertSame(
+            [
+                'status' => SlideshowVideoStatus::STATUS_ERROR,
+                'meldung' => 'Fehler',
+                'dauerProBildSekunden' => 1.25,
+            ],
+            $status->toArray()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- register the slideshow generation command via attribute to ensure the console name is set

## Testing
- `composer ci:test` *(fails: `bin/php` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc5caf0788323b1a48719ac10724d