### PR TITLE
Fix slideshow video manager dependency wiring

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -92,6 +92,8 @@ services:
     MagicSunday\Memories\Service\Slideshow\SlideshowVideoGeneratorInterface:
         alias: MagicSunday\Memories\Service\Slideshow\SlideshowVideoGenerator
 
+    Symfony\Component\Process\PhpExecutableFinder: ~
+
     MagicSunday\Memories\Service\Slideshow\SlideshowVideoManager:
         arguments:
             $videoDirectory: '%memories.slideshow.video_dir%'


### PR DESCRIPTION
## Summary
- register the Symfony Process PhpExecutableFinder as a service so the slideshow video manager can be autowired correctly

## Testing
- composer ci:test *(fails: phpstan reports existing baseline issues in clusterer and utility code)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdd7b57b883239aa436829dd6bae2