### PR TITLE
Fix slideshow PHP binary fallback

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -202,5 +202,6 @@ parameters:
     memories.slideshow.video_width: 1280
     memories.slideshow.video_height: 720
     memories.slideshow.ffmpeg_path: 'ffmpeg'
-    memories.slideshow.php_binary: '%env(default:php:string:MEMORIES_PHP_BINARY)%'
+    memories.slideshow.php_binary_default: 'php'
+    memories.slideshow.php_binary: '%env(default:memories.slideshow.php_binary_default:string:MEMORIES_PHP_BINARY)%'
 


### PR DESCRIPTION
## Summary
- add an explicit default parameter for the slideshow PHP binary
- use the new parameter as the fallback for the MEMORIES_PHP_BINARY env placeholder

## Testing
- composer ci:test *(fails: `bin/php` executable is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d6e63fc883238901f1bab8f6c026