### PR TITLE
Add EXIF camera and composite metadata support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
     },
     "autoload": {
         "psr-4": {
-            "MagicSunday\\Memories\\": "src/"
+            "MagicSunday\\Memories\\": "src/",
+            "DoctrineMigrations\\": "migrations/"
         }
     },
     "autoload-dev": {

--- a/migrations/Version20250217120000.php
+++ b/migrations/Version20250217120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250217120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add camera ownership, lens metadata, and composite image columns to media table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media ADD cameraOwner VARCHAR(128) DEFAULT NULL, ADD cameraBodySerial VARCHAR(64) DEFAULT NULL, ADD lensMake VARCHAR(128) DEFAULT NULL, ADD lensSpecification VARCHAR(128) DEFAULT NULL, ADD lensSerialNumber VARCHAR(64) DEFAULT NULL, ADD compositeImage SMALLINT DEFAULT NULL, ADD compositeImageSourceCount INT DEFAULT NULL, ADD compositeImageExposureTimes VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP cameraOwner, DROP cameraBodySerial, DROP lensMake, DROP lensSpecification, DROP lensSerialNumber, DROP compositeImage, DROP compositeImageSourceCount, DROP compositeImageExposureTimes');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -111,10 +111,40 @@ class Media
     private ?string $cameraMake = null;
 
     /**
+     * Registered camera owner stored in the EXIF metadata.
+     */
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
+    private ?string $cameraOwner = null;
+
+    /**
+     * Serial number of the camera body.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
+    private ?string $cameraBodySerial = null;
+
+    /**
+     * Lens manufacturer name.
+     */
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
+    private ?string $lensMake = null;
+
+    /**
      * Lens model used during capture, if available.
      */
     #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
     private ?string $lensModel = null;
+
+    /**
+     * Normalized lens specification range, for example 24-70mm f/2.8-4.
+     */
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
+    private ?string $lensSpecification = null;
+
+    /**
+     * Serial number of the attached lens.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
+    private ?string $lensSerialNumber = null;
 
     /**
      * Focal length in millimetres derived from metadata.
@@ -139,6 +169,24 @@ class Media
      */
     #[ORM\Column(type: Types::FLOAT, nullable: true)]
     private ?float $exposureTimeS = null;
+
+    /**
+     * Composite image indicator as defined by the EXIF specification.
+     */
+    #[ORM\Column(type: Types::SMALLINT, nullable: true)]
+    private ?int $compositeImage = null;
+
+    /**
+     * Number of source images contributing to the composite capture.
+     */
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $compositeImageSourceCount = null;
+
+    /**
+     * Exposure times of the source images composing the final media.
+     */
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $compositeImageExposureTimes = null;
 
     /**
      * ISO sensitivity value.
@@ -621,6 +669,60 @@ class Media
     }
 
     /**
+     * Returns the registered camera owner.
+     */
+    public function getCameraOwner(): ?string
+    {
+        return $this->cameraOwner;
+    }
+
+    /**
+     * Sets the registered camera owner.
+     *
+     * @param string|null $v Camera owner name.
+     */
+    public function setCameraOwner(?string $v): void
+    {
+        $this->cameraOwner = $v;
+    }
+
+    /**
+     * Returns the camera body serial number.
+     */
+    public function getCameraBodySerial(): ?string
+    {
+        return $this->cameraBodySerial;
+    }
+
+    /**
+     * Sets the camera body serial number.
+     *
+     * @param string|null $v Serial number string.
+     */
+    public function setCameraBodySerial(?string $v): void
+    {
+        $this->cameraBodySerial = $v;
+    }
+
+    /**
+     * Returns the lens manufacturer name.
+     */
+    public function getLensMake(): ?string
+    {
+        return $this->lensMake;
+    }
+
+    /**
+     * Sets the lens manufacturer name.
+     *
+     * @param string|null $v Lens manufacturer name.
+     */
+    public function setLensMake(?string $v): void
+    {
+        $this->lensMake = $v;
+    }
+
+    /**
      * Returns the lens model information.
      */
     public function getLensModel(): ?string
@@ -636,6 +738,42 @@ class Media
     public function setLensModel(?string $v): void
     {
         $this->lensModel = $v;
+    }
+
+    /**
+     * Returns the normalized lens specification.
+     */
+    public function getLensSpecification(): ?string
+    {
+        return $this->lensSpecification;
+    }
+
+    /**
+     * Sets the normalized lens specification.
+     *
+     * @param string|null $v Lens specification description.
+     */
+    public function setLensSpecification(?string $v): void
+    {
+        $this->lensSpecification = $v;
+    }
+
+    /**
+     * Returns the lens serial number.
+     */
+    public function getLensSerialNumber(): ?string
+    {
+        return $this->lensSerialNumber;
+    }
+
+    /**
+     * Sets the lens serial number.
+     *
+     * @param string|null $v Serial number string.
+     */
+    public function setLensSerialNumber(?string $v): void
+    {
+        $this->lensSerialNumber = $v;
     }
 
     /**
@@ -708,6 +846,60 @@ class Media
     public function setExposureTimeS(?float $v): void
     {
         $this->exposureTimeS = $v;
+    }
+
+    /**
+     * Returns the composite image flag value.
+     */
+    public function getCompositeImage(): ?int
+    {
+        return $this->compositeImage;
+    }
+
+    /**
+     * Sets the composite image flag value.
+     *
+     * @param int|null $v Composite image indicator.
+     */
+    public function setCompositeImage(?int $v): void
+    {
+        $this->compositeImage = $v;
+    }
+
+    /**
+     * Returns the number of source images for the composite capture.
+     */
+    public function getCompositeImageSourceCount(): ?int
+    {
+        return $this->compositeImageSourceCount;
+    }
+
+    /**
+     * Sets the number of source images for the composite capture.
+     *
+     * @param int|null $v Source image count.
+     */
+    public function setCompositeImageSourceCount(?int $v): void
+    {
+        $this->compositeImageSourceCount = $v;
+    }
+
+    /**
+     * Returns the recorded source exposure times for the composite.
+     */
+    public function getCompositeImageExposureTimes(): ?string
+    {
+        return $this->compositeImageExposureTimes;
+    }
+
+    /**
+     * Sets the recorded source exposure times for the composite.
+     *
+     * @param string|null $v Exposure times description.
+     */
+    public function setCompositeImageExposureTimes(?string $v): void
+    {
+        $this->compositeImageExposureTimes = $v;
     }
 
     /**

--- a/src/Service/Metadata/Exif/Processor/CameraExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/CameraExifMetadataProcessor.php
@@ -15,6 +15,12 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
 use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function abs;
+use function implode;
+use function is_array;
+use function round;
+use function rtrim;
+use function sprintf;
 
 /**
  * Extracts camera and lens information from EXIF data.
@@ -39,9 +45,137 @@ final class CameraExifMetadataProcessor implements ExifMetadataProcessorInterfac
             $media->setCameraModel($model);
         }
 
+        $owner = $this->accessor->strOrNull($exif['EXIF']['CameraOwnerName'] ?? null);
+        if ($owner !== null) {
+            $media->setCameraOwner($owner);
+        }
+
+        $bodySerial = $this->accessor->strOrNull($exif['EXIF']['BodySerialNumber'] ?? null);
+        if ($bodySerial !== null) {
+            $media->setCameraBodySerial($bodySerial);
+        }
+
+        $lensMake = $this->accessor->strOrNull($exif['EXIF']['LensMake'] ?? null);
+        if ($lensMake !== null) {
+            $media->setLensMake($lensMake);
+        }
+
         $lens = $this->accessor->strOrNull($exif['EXIF']['LensModel'] ?? null);
         if ($lens !== null) {
             $media->setLensModel($lens);
         }
+
+        $lensSpecification = $this->normaliseLensSpecification($exif['EXIF']['LensSpecification'] ?? null);
+        if ($lensSpecification !== null) {
+            $media->setLensSpecification($lensSpecification);
+        }
+
+        $lensSerial = $this->accessor->strOrNull($exif['EXIF']['LensSerialNumber'] ?? null);
+        if ($lensSerial !== null) {
+            $media->setLensSerialNumber($lensSerial);
+        }
+    }
+
+    private function normaliseLensSpecification(mixed $value): ?string
+    {
+        if (!is_array($value)) {
+            return $this->accessor->strOrNull($value);
+        }
+
+        $focalMin    = $this->accessor->floatOrRational($value[0] ?? null);
+        $focalMax    = $this->accessor->floatOrRational($value[1] ?? null);
+        $apertureMin = $this->accessor->floatOrRational($value[2] ?? null);
+        $apertureMax = $this->accessor->floatOrRational($value[3] ?? null);
+
+        $parts = [];
+
+        $focal = $this->formatFocalRange($focalMin, $focalMax);
+        if ($focal !== null) {
+            $parts[] = $focal;
+        }
+
+        $aperture = $this->formatApertureRange($apertureMin, $apertureMax);
+        if ($aperture !== null) {
+            $parts[] = $aperture;
+        }
+
+        if ($parts === []) {
+            return null;
+        }
+
+        return implode(' ', $parts);
+    }
+
+    private function formatFocalRange(?float $min, ?float $max): ?string
+    {
+        $min = $this->positiveOrNull($min);
+        $max = $this->positiveOrNull($max);
+
+        if ($min === null && $max === null) {
+            return null;
+        }
+
+        if ($min === null) {
+            $min = $max;
+        }
+
+        if ($max === null) {
+            $max = $min;
+        }
+
+        if ($min === null || $max === null) {
+            return null;
+        }
+
+        if (abs($max - $min) < 0.01) {
+            return sprintf('%smm', $this->formatNumber($min));
+        }
+
+        return sprintf('%s-%smm', $this->formatNumber($min), $this->formatNumber($max));
+    }
+
+    private function formatApertureRange(?float $min, ?float $max): ?string
+    {
+        $min = $this->positiveOrNull($min);
+        $max = $this->positiveOrNull($max);
+
+        if ($min === null && $max === null) {
+            return null;
+        }
+
+        if ($min === null) {
+            $min = $max;
+        }
+
+        if ($max === null) {
+            $max = $min;
+        }
+
+        if ($min === null || $max === null) {
+            return null;
+        }
+
+        if (abs($max - $min) < 0.01) {
+            return sprintf('f/%s', $this->formatNumber($min));
+        }
+
+        return sprintf('f/%s-%s', $this->formatNumber($min), $this->formatNumber($max));
+    }
+
+    private function positiveOrNull(?float $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value > 0.0 ? $value : null;
+    }
+
+    private function formatNumber(float $value): string
+    {
+        $rounded = round($value, 2);
+        $string  = sprintf('%.2f', $rounded);
+
+        return rtrim(rtrim($string, '0'), '.');
     }
 }

--- a/src/Service/Metadata/Exif/Processor/CompositeImageExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/CompositeImageExifMetadataProcessor.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
+use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function is_array;
+
+/**
+ * Persists composite image EXIF metadata onto the media entity.
+ */
+#[AutoconfigureTag('memories.metadata.exif.processor')]
+final class CompositeImageExifMetadataProcessor implements ExifMetadataProcessorInterface
+{
+    public function __construct(
+        private readonly ExifValueAccessorInterface $accessor,
+    ) {
+    }
+
+    public function process(array $exif, Media $media): void
+    {
+        if (!isset($exif['EXIF']) || !is_array($exif['EXIF'])) {
+            return;
+        }
+
+        $compositeImage = $this->accessor->intOrNull($exif['EXIF']['CompositeImage'] ?? null);
+        if ($compositeImage !== null) {
+            $media->setCompositeImage($compositeImage);
+        }
+
+        $sourceCount = $this->accessor->intOrNull($exif['EXIF']['SourceImageNumberOfCompositeImage'] ?? null);
+        if ($sourceCount !== null) {
+            $media->setCompositeImageSourceCount($sourceCount);
+        }
+
+        $exposureTimes = $this->accessor->strOrNull($exif['EXIF']['SourceExposureTimesOfCompositeImage'] ?? null);
+        if ($exposureTimes !== null) {
+            $media->setCompositeImageExposureTimes($exposureTimes);
+        }
+    }
+}

--- a/test/Unit/Service/Metadata/Exif/Processor/CameraExifMetadataProcessorTest.php
+++ b/test/Unit/Service/Metadata/Exif/Processor/CameraExifMetadataProcessorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Service\Metadata\Exif\DefaultExifValueAccessor;
+use MagicSunday\Memories\Service\Metadata\Exif\Processor\CameraExifMetadataProcessor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CameraExifMetadataProcessorTest extends TestCase
+{
+    #[Test]
+    public function populatesCameraAndLensMetadata(): void
+    {
+        $media = $this->makeMedia(
+            id: 1,
+            path: '/fixtures/exif/camera.jpg',
+        );
+
+        $processor = new CameraExifMetadataProcessor(new DefaultExifValueAccessor());
+
+        $exif = [
+            'IFD0' => [
+                'Make'  => 'Canon',
+                'Model' => 'Canon EOS 5D Mark IV',
+            ],
+            'EXIF' => [
+                'CameraOwnerName'                => 'Rico Sonntag',
+                'BodySerialNumber'               => '123ABC456',
+                'LensMake'                       => 'Canon',
+                'LensModel'                      => 'EF 24-70mm f/2.8L II USM',
+                'LensSerialNumber'               => 'LN987654321',
+                'LensSpecification'              => ['24/1', '70/1', '28/10', '40/10'],
+            ],
+        ];
+
+        $processor->process($exif, $media);
+
+        self::assertSame('Canon', $media->getCameraMake());
+        self::assertSame('Canon EOS 5D Mark IV', $media->getCameraModel());
+        self::assertSame('Rico Sonntag', $media->getCameraOwner());
+        self::assertSame('123ABC456', $media->getCameraBodySerial());
+        self::assertSame('Canon', $media->getLensMake());
+        self::assertSame('EF 24-70mm f/2.8L II USM', $media->getLensModel());
+        self::assertSame('24-70mm f/2.8-4', $media->getLensSpecification());
+        self::assertSame('LN987654321', $media->getLensSerialNumber());
+    }
+}

--- a/test/Unit/Service/Metadata/Exif/Processor/CompositeImageExifMetadataProcessorTest.php
+++ b/test/Unit/Service/Metadata/Exif/Processor/CompositeImageExifMetadataProcessorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata\Exif\Processor;
+
+use MagicSunday\Memories\Service\Metadata\Exif\DefaultExifValueAccessor;
+use MagicSunday\Memories\Service\Metadata\Exif\Processor\CompositeImageExifMetadataProcessor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class CompositeImageExifMetadataProcessorTest extends TestCase
+{
+    #[Test]
+    public function populatesCompositeMetadata(): void
+    {
+        $media = $this->makeMedia(
+            id: 2,
+            path: '/fixtures/exif/composite.jpg',
+        );
+
+        $processor = new CompositeImageExifMetadataProcessor(new DefaultExifValueAccessor());
+
+        $exif = [
+            'EXIF' => [
+                'CompositeImage'                      => 3,
+                'SourceImageNumberOfCompositeImage'   => '5',
+                'SourceExposureTimesOfCompositeImage' => '1/200,1/100',
+            ],
+        ];
+
+        $processor->process($exif, $media);
+
+        self::assertSame(3, $media->getCompositeImage());
+        self::assertSame(5, $media->getCompositeImageSourceCount());
+        self::assertSame('1/200,1/100', $media->getCompositeImageExposureTimes());
+    }
+}


### PR DESCRIPTION
## Summary
- extend the media entity with camera ownership, lens, and composite image columns and provide a Doctrine migration
- normalise EXIF lens specifications, capture additional aliases, and persist composite metadata via dedicated processors
- cover the new fields with extractor and processor unit tests

## Testing
- composer ci:test *(fails: `bin/php` wrapper is unavailable in the container)*
- php vendor/bin/phpunit --configuration .build/phpunit.xml test/Unit/Service/Metadata/Exif


------
https://chatgpt.com/codex/tasks/task_e_68e0ec5e8e20832390dec87bd5a8748f