### PR TITLE
Add capture time sources with timezone handling

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -153,6 +153,7 @@ services:
             $extractors:
                 - '@MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\XmpIptcExtractor'
+                - '@MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher'

--- a/migrations/Version20250305090000.php
+++ b/migrations/Version20250305090000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250305090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add capture time metadata columns (timeSource, tzId, capturedLocal) to media table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+ALTER TABLE media
+    ADD timeSource ENUM('EXIF', 'VIDEO_QUICKTIME', 'FILE_MTIME') DEFAULT NULL,
+    ADD tzId VARCHAR(128) DEFAULT NULL,
+    ADD capturedLocal DATETIME DEFAULT NULL
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP timeSource, DROP tzId, DROP capturedLocal');
+    }
+}

--- a/src/Entity/Enum/TimeSource.php
+++ b/src/Entity/Enum/TimeSource.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Entity\Enum;
+
+/**
+ * Enumerates the possible sources for capture timestamps.
+ */
+enum TimeSource: string
+{
+    case EXIF = 'EXIF';
+    case VIDEO_QUICKTIME = 'VIDEO_QUICKTIME';
+    case FILE_MTIME = 'FILE_MTIME';
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Entity;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use MagicSunday\Memories\Entity\Enum\TimeSource;
 
 /**
  * Doctrine entity describing an imported photo or video including its metadata.
@@ -67,6 +68,24 @@ class Media
      */
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $takenAt = null;
+
+    /**
+     * Source system that provided the capture timestamp.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true, enumType: TimeSource::class)]
+    private ?TimeSource $timeSource = null;
+
+    /**
+     * Timezone identifier associated with the capture event.
+     */
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
+    private ?string $tzId = null;
+
+    /**
+     * Capture timestamp expressed in local wall time.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $capturedLocal = null;
 
     /**
      * Timezone offset in minutes derived from the capture moment.
@@ -484,6 +503,54 @@ class Media
     public function setTakenAt(?DateTimeImmutable $takenAt): void
     {
         $this->takenAt = $takenAt;
+    }
+
+    /**
+     * Returns the origin of the capture timestamp.
+     */
+    public function getTimeSource(): ?TimeSource
+    {
+        return $this->timeSource;
+    }
+
+    /**
+     * Sets the origin of the capture timestamp.
+     */
+    public function setTimeSource(?TimeSource $timeSource): void
+    {
+        $this->timeSource = $timeSource;
+    }
+
+    /**
+     * Returns the timezone identifier of the capture event.
+     */
+    public function getTzId(): ?string
+    {
+        return $this->tzId;
+    }
+
+    /**
+     * Sets the timezone identifier of the capture event.
+     */
+    public function setTzId(?string $tzId): void
+    {
+        $this->tzId = $tzId;
+    }
+
+    /**
+     * Returns the capture timestamp expressed in local wall time.
+     */
+    public function getCapturedLocal(): ?DateTimeImmutable
+    {
+        return $this->capturedLocal;
+    }
+
+    /**
+     * Sets the capture timestamp expressed in local wall time.
+     */
+    public function setCapturedLocal(?DateTimeImmutable $capturedLocal): void
+    {
+        $this->capturedLocal = $capturedLocal;
     }
 
     /**

--- a/src/Service/Metadata/FileStatMetadataExtractor.php
+++ b/src/Service/Metadata/FileStatMetadataExtractor.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Entity\Enum\TimeSource;
+use MagicSunday\Memories\Entity\Media;
+
+use function date_default_timezone_get;
+use function filemtime;
+use function is_file;
+use function is_int;
+use function sprintf;
+
+/**
+ * Fills missing capture timestamps using file system metadata.
+ */
+final class FileStatMetadataExtractor implements SingleMetadataExtractorInterface
+{
+    public function supports(string $filepath, Media $media): bool
+    {
+        return $media->getTakenAt() === null && is_file($filepath);
+    }
+
+    public function extract(string $filepath, Media $media): Media
+    {
+        $timestamp = @filemtime($filepath);
+        if (!is_int($timestamp)) {
+            return $media;
+        }
+
+        $timezoneName = date_default_timezone_get();
+        $timezone     = new DateTimeZone($timezoneName);
+
+        $takenAt = (new DateTimeImmutable(sprintf('@%d', $timestamp)))->setTimezone($timezone);
+
+        $media->setTakenAt($takenAt);
+        $media->setCapturedLocal($takenAt);
+        $media->setTzId($timezoneName);
+        $media->setTimeSource(TimeSource::FILE_MTIME);
+
+        return $media;
+    }
+}

--- a/src/Service/Metadata/Support/CaptureTimeResolver.php
+++ b/src/Service/Metadata/Support/CaptureTimeResolver.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use MagicSunday\Memories\Clusterer\Contract\TimezoneResolverInterface;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+
+use function abs;
+use function intdiv;
+use function is_string;
+use function sprintf;
+
+/**
+ * Resolves the best available local capture timestamp for media items.
+ */
+final class CaptureTimeResolver
+{
+    /**
+     * @param array{lat:float,lon:float,radius_km:float,country:?string,timezone_offset:?int} $home
+     */
+    public function __construct(
+        private readonly TimezoneResolverInterface $timezoneResolver,
+        private array $home = [
+            'lat' => 0.0,
+            'lon' => 0.0,
+            'radius_km' => 0.0,
+            'country' => null,
+            'timezone_offset' => null,
+        ],
+    ) {
+    }
+
+    public function resolve(Media $media): ?DateTimeImmutable
+    {
+        $capturedLocal = $media->getCapturedLocal();
+        if ($capturedLocal instanceof DateTimeImmutable) {
+            return $capturedLocal;
+        }
+
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return null;
+        }
+
+        $timezone = $this->determineTimezone($media, $takenAt);
+        if ($timezone instanceof DateTimeZone) {
+            $local = $takenAt->setTimezone($timezone);
+            $media->setCapturedLocal($local);
+            if ($media->getTzId() === null) {
+                $media->setTzId($timezone->getName());
+            }
+
+            return $local;
+        }
+
+        $offset = $media->getTimezoneOffsetMin();
+        if ($offset !== null) {
+            $local = $this->applyOffset($takenAt, $offset);
+            $media->setCapturedLocal($local);
+            if ($media->getTzId() === null) {
+                $media->setTzId($local->getTimezone()->getName());
+            }
+
+            return $local;
+        }
+
+        $media->setCapturedLocal($takenAt);
+
+        return $takenAt;
+    }
+
+    private function determineTimezone(Media $media, DateTimeImmutable $takenAt): ?DateTimeZone
+    {
+        $tzId = $media->getTzId();
+        if (is_string($tzId) && $tzId !== '') {
+            try {
+                return new DateTimeZone($tzId);
+            } catch (Exception) {
+                $media->setTzId(null);
+            }
+        }
+
+        $location = $media->getLocation();
+        if (!$location instanceof Location) {
+            return null;
+        }
+
+        try {
+            return $this->timezoneResolver->resolveMediaTimezone($media, $takenAt, $this->home);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function applyOffset(DateTimeImmutable $instant, int $offsetMinutes): DateTimeImmutable
+    {
+        $sign = $offsetMinutes >= 0 ? '+' : '-';
+        $abs  = abs($offsetMinutes);
+        $hours = intdiv($abs, 60);
+        $minutes = $abs % 60;
+        $spec = sprintf('%s%02d:%02d', $sign, $hours, $minutes);
+
+        try {
+            $timezone = new DateTimeZone($spec);
+        } catch (Exception) {
+            return $instant;
+        }
+
+        return $instant->setTimezone($timezone);
+    }
+}

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -15,6 +15,7 @@ use Closure;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use MagicSunday\Memories\Entity\Enum\TimeSource;
 use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -56,7 +57,11 @@ abstract class TestCase extends BaseTestCase
         $this->assignId($media, $id);
 
         if ($takenAt !== null) {
-            $media->setTakenAt($this->normaliseDateTime($takenAt));
+            $normalised = $this->normaliseDateTime($takenAt);
+            $media->setTakenAt($normalised);
+            $media->setCapturedLocal($normalised);
+            $media->setTimeSource(TimeSource::EXIF);
+            $media->setTzId($normalised->getTimezone()->getName());
         }
 
         if ($lat !== null) {

--- a/test/Unit/Http/Controller/FeedControllerTest.php
+++ b/test/Unit/Http/Controller/FeedControllerTest.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Test\Unit\Http\Controller;
 
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
+use MagicSunday\Memories\Entity\Enum\TimeSource;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Feed\MemoryFeedItem;
 use MagicSunday\Memories\Http\Controller\FeedController;
@@ -101,9 +102,24 @@ final class FeedControllerTest extends TestCase
         $idProperty->setValue($mediaTwo, 2);
         $idProperty->setValue($mediaThree, 3);
 
-        $mediaOne->setTakenAt(new DateTimeImmutable('2024-01-01T10:00:00+00:00'));
-        $mediaTwo->setTakenAt(new DateTimeImmutable('2024-01-02T11:15:00+00:00'));
-        $mediaThree->setTakenAt(new DateTimeImmutable('2024-01-03T12:30:00+00:00'));
+        $mediaOneTakenAt   = new DateTimeImmutable('2024-01-01T10:00:00+00:00');
+        $mediaTwoTakenAt   = new DateTimeImmutable('2024-01-02T11:15:00+00:00');
+        $mediaThreeTakenAt = new DateTimeImmutable('2024-01-03T12:30:00+00:00');
+
+        $mediaOne->setTakenAt($mediaOneTakenAt);
+        $mediaOne->setCapturedLocal($mediaOneTakenAt);
+        $mediaOne->setTimeSource(TimeSource::EXIF);
+        $mediaOne->setTzId('UTC');
+
+        $mediaTwo->setTakenAt($mediaTwoTakenAt);
+        $mediaTwo->setCapturedLocal($mediaTwoTakenAt);
+        $mediaTwo->setTimeSource(TimeSource::EXIF);
+        $mediaTwo->setTzId('UTC');
+
+        $mediaThree->setTakenAt($mediaThreeTakenAt);
+        $mediaThree->setCapturedLocal($mediaThreeTakenAt);
+        $mediaThree->setTimeSource(TimeSource::EXIF);
+        $mediaThree->setTzId('UTC');
 
         $mediaRepo->expects(self::once())
             ->method('findByIds')


### PR DESCRIPTION
## Summary
- add a TimeSource enum and persist capture provenance, timezone identifier, and local timestamp on the Media entity
- enrich capture times via EXIF, new filesystem fallback, and extended QuickTime ffprobe parsing while reordering metadata extractors
- introduce a capture time resolver shared by Daypart and Solar enrichers, propagate timezone data into tests, and add a matching migration

## Testing
- `composer ci:test` *(fails: bin/php helper not available in the container)*
- `./vendor/bin/phpunit --configuration .build/phpunit.xml` *(fails: pre-existing private makeMedia override in MemberQualityRankingStageTest)*

------
https://chatgpt.com/codex/tasks/task_e_68e10ba15e3c832396d6b46ccf079d92