### PR TITLE
Add content classifier and respect hidden media flag

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -138,6 +138,8 @@ services:
         arguments:
             $sampleSize: 320
 
+    MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor: ~
+
     MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor:
         arguments:
             $ffprobePath: '%env(string:FFPROBE_PATH)%'
@@ -161,6 +163,7 @@ services:
                 - '@MagicSunday\Memories\Service\Metadata\DaypartEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\SolarEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor'
+                - '@MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor'
 

--- a/migrations/Version20250327093000.php
+++ b/migrations/Version20250327093000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250327093000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add content kind classification and no-show flag to media table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+ALTER TABLE media
+    ADD contentKind VARCHAR(32) DEFAULT NULL,
+    ADD noShow TINYINT(1) NOT NULL DEFAULT 0
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP contentKind, DROP noShow');
+    }
+}

--- a/src/Entity/Enum/ContentKind.php
+++ b/src/Entity/Enum/ContentKind.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Entity\Enum;
+
+/**
+ * Broad content category markers assigned to media assets.
+ */
+enum ContentKind: string
+{
+    case PHOTO = 'photo';
+    case SCREENSHOT = 'screenshot';
+    case DOCUMENT = 'document';
+    case MAP = 'map';
+    case SCREEN_RECORDING = 'screenrecord';
+    case OTHER = 'other';
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Entity;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use MagicSunday\Memories\Entity\Enum\ContentKind;
 use MagicSunday\Memories\Entity\Enum\TimeSource;
 
 /**
@@ -322,6 +323,12 @@ class Media
     private ?bool $isPanorama = null;
 
     /**
+     * Categorised content kind describing non-standard assets.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true, enumType: ContentKind::class)]
+    private ?ContentKind $contentKind = null;
+
+    /**
      * Calculated sharpness score used for quality metrics.
      */
     #[ORM\Column(type: Types::FLOAT, nullable: true)]
@@ -374,6 +381,12 @@ class Media
      */
     #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
     private bool $lowQuality = false;
+
+    /**
+     * Marker indicating whether the media should be hidden from downstream feeds.
+     */
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $noShow = false;
 
     /**
      * Prefix of the perceptual hash for quick similarity checks.
@@ -1324,6 +1337,24 @@ class Media
     }
 
     /**
+     * Returns the assigned content kind.
+     */
+    public function getContentKind(): ?ContentKind
+    {
+        return $this->contentKind;
+    }
+
+    /**
+     * Assigns the content kind.
+     *
+     * @param ContentKind|null $contentKind Categorised content kind.
+     */
+    public function setContentKind(?ContentKind $contentKind): void
+    {
+        $this->contentKind = $contentKind;
+    }
+
+    /**
      * Returns the calculated sharpness score.
      */
     public function getSharpness(): ?float
@@ -1481,6 +1512,24 @@ class Media
     public function setLowQuality(bool $lowQuality): void
     {
         $this->lowQuality = $lowQuality;
+    }
+
+    /**
+     * Indicates whether the media should be hidden from downstream feeds.
+     */
+    public function isNoShow(): bool
+    {
+        return $this->noShow;
+    }
+
+    /**
+     * Marks the media as hidden for downstream feeds.
+     *
+     * @param bool $noShow True to exclude the media from feeds.
+     */
+    public function setNoShow(bool $noShow): void
+    {
+        $this->noShow = $noShow;
     }
 
     /**

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -39,6 +39,7 @@ readonly class MediaRepository implements MemberMediaLookupInterface
             ->select('m')
             ->from(Media::class, 'm')
             ->where('m.id IN (:ids)')
+            ->andWhere('m.noShow = false')
             ->setParameter('ids', $ids);
 
         $q = $qb->getQuery();

--- a/src/Service/Feed/MemoryFeedBuilder.php
+++ b/src/Service/Feed/MemoryFeedBuilder.php
@@ -19,7 +19,9 @@ use MagicSunday\Memories\Feed\MemoryFeedItem;
 use MagicSunday\Memories\Repository\MediaRepository;
 use MagicSunday\Memories\Service\Clusterer\TitleGeneratorInterface;
 
+use function array_filter;
 use function array_map;
+use function array_values;
 use function count;
 use function is_array;
 use function is_string;
@@ -136,6 +138,15 @@ final readonly class MemoryFeedBuilder implements FeedBuilderInterface
 
             // 4) resolve Media + pick cover
             $members = $this->mediaRepo->findByIds($c->getMembers());
+            if ($members === []) {
+                continue;
+            }
+
+            $members = array_values(array_filter(
+                $members,
+                static fn (Media $media): bool => $media->isNoShow() === false,
+            ));
+
             if ($members === []) {
                 continue;
             }

--- a/src/Service/Metadata/ContentClassifierExtractor.php
+++ b/src/Service/Metadata/ContentClassifierExtractor.php
@@ -1,0 +1,332 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Enum\ContentKind;
+use MagicSunday\Memories\Entity\Media;
+
+use function array_filter;
+use function array_unique;
+use function array_values;
+use function basename;
+use function is_array;
+use function is_string;
+use function max;
+use function min;
+use function preg_split;
+use function str_contains;
+use function str_ends_with;
+use function str_replace;
+use function str_starts_with;
+use function strtolower;
+
+/**
+ * Classifies media into broad content categories to support downstream filtering.
+ */
+final class ContentClassifierExtractor implements SingleMetadataExtractorInterface
+{
+    /** @var array<int, string> */
+    private const SCREENSHOT_KEYWORDS = [
+        'screenshot',
+        'screen-shot',
+        'screen_capture',
+        'screen-capture',
+        'screencap',
+        'bildschirmfoto',
+        'bildschirmaufnahme',
+    ];
+
+    /** @var array<int, string> */
+    private const DOCUMENT_KEYWORDS = [
+        'document',
+        'scan',
+        'scanned',
+        'rechnung',
+        'beleg',
+        'invoice',
+        'note',
+        'notiz',
+        'vertrag',
+        'certificate',
+    ];
+
+    /** @var array<int, string> */
+    private const MAP_KEYWORDS = [
+        'map',
+        'maps',
+        'karte',
+        'stadtplan',
+        'navigation',
+        'route',
+        'navi',
+        'osm',
+    ];
+
+    /** @var array<int, string> */
+    private const SCREEN_RECORD_KEYWORDS = [
+        'screenrecord',
+        'screen-record',
+        'screen_record',
+        'screenrecording',
+        'screen-recording',
+        'bildschirmaufnahme',
+        'screenrec',
+    ];
+
+    public function supports(string $filepath, Media $media): bool
+    {
+        $mime = $media->getMime();
+        if ($mime === null) {
+            return true;
+        }
+
+        return str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/');
+    }
+
+    public function extract(string $filepath, Media $media): Media
+    {
+        $kind = $this->classify($media, $filepath);
+        if ($kind === null) {
+            return $media;
+        }
+
+        $media->setContentKind($kind);
+        if ($this->shouldHide($kind)) {
+            $media->setNoShow(true);
+        }
+
+        return $media;
+    }
+
+    private function classify(Media $media, string $filepath): ?ContentKind
+    {
+        $tokens = $this->tokensFromMedia($media, $filepath);
+
+        if ($media->isVideo() && $this->isScreenRecording($media, $tokens)) {
+            return ContentKind::SCREEN_RECORDING;
+        }
+
+        if ($this->isScreenshot($media, $tokens)) {
+            return ContentKind::SCREENSHOT;
+        }
+
+        if ($this->isMap($media, $tokens)) {
+            return ContentKind::MAP;
+        }
+
+        if ($this->isDocument($media, $tokens)) {
+            return ContentKind::DOCUMENT;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private function isScreenshot(Media $media, array $tokens): bool
+    {
+        if ($this->matchesAnyKeyword($tokens, self::SCREENSHOT_KEYWORDS)) {
+            return true;
+        }
+
+        $width  = $media->getWidth();
+        $height = $media->getHeight();
+        if ($width === null || $height === null) {
+            return false;
+        }
+
+        $cameraMake  = $media->getCameraMake();
+        $cameraModel = $media->getCameraModel();
+        $iso         = $media->getIso();
+
+        if ($cameraMake !== null || $cameraModel !== null || ($iso !== null && $iso > 0)) {
+            return false;
+        }
+
+        $longSide  = max($width, $height);
+        $shortSide = min($width, $height);
+        if ($shortSide === 0) {
+            return false;
+        }
+
+        $ratio = $longSide / (float) $shortSide;
+        if ($longSide < 720 || $ratio < 1.55 || $ratio > 2.40) {
+            return false;
+        }
+
+        $sharpness = $media->getSharpness();
+        if ($sharpness !== null && $sharpness > 0.35) {
+            return false;
+        }
+
+        $colorfulness = $media->getColorfulness();
+        if ($colorfulness !== null && $colorfulness > 0.45) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private function isDocument(Media $media, array $tokens): bool
+    {
+        if ($this->matchesAnyKeyword($tokens, self::DOCUMENT_KEYWORDS)) {
+            return true;
+        }
+
+        $colorfulness = $media->getColorfulness();
+        $contrast     = $media->getContrast();
+        $brightness   = $media->getBrightness();
+
+        if ($colorfulness !== null && $colorfulness <= 0.2) {
+            if ($contrast !== null && $contrast >= 0.55) {
+                return true;
+            }
+
+            if ($brightness !== null && ($brightness <= 0.18 || $brightness >= 0.82)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private function isMap(Media $media, array $tokens): bool
+    {
+        if ($this->matchesAnyKeyword($tokens, self::MAP_KEYWORDS)) {
+            return true;
+        }
+
+        $colorfulness = $media->getColorfulness();
+        $entropy      = $media->getEntropy();
+
+        if ($colorfulness !== null && $colorfulness >= 0.45 && $entropy !== null && $entropy <= 0.55) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private function isScreenRecording(Media $media, array $tokens): bool
+    {
+        if ($this->matchesAnyKeyword($tokens, self::SCREEN_RECORD_KEYWORDS)) {
+            return true;
+        }
+
+        $fps   = $media->getVideoFps();
+        $codec = $media->getVideoCodec();
+
+        if ($fps !== null && $fps >= 45.0) {
+            $cameraMake  = $media->getCameraMake();
+            $cameraModel = $media->getCameraModel();
+
+            if ($cameraMake === null && $cameraModel === null) {
+                return true;
+            }
+        }
+
+        if ($codec !== null) {
+            $codecLower = strtolower($codec);
+            if (str_contains($codecLower, 'screen') || str_contains($codecLower, 'display')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function shouldHide(ContentKind $kind): bool
+    {
+        return match ($kind) {
+            ContentKind::SCREENSHOT,
+            ContentKind::DOCUMENT,
+            ContentKind::MAP,
+            ContentKind::SCREEN_RECORDING => true,
+            default => false,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function tokensFromMedia(Media $media, string $filepath): array
+    {
+        $tokens = [];
+        $features = $media->getFeatures();
+        if (is_array($features)) {
+            $pathTokens = $features['pathTokens'] ?? null;
+            if (is_array($pathTokens)) {
+                foreach ($pathTokens as $token) {
+                    if (!is_string($token) || $token === '') {
+                        continue;
+                    }
+
+                    $tokens[] = strtolower($token);
+                }
+            }
+
+            $hint = $features['filenameHint'] ?? null;
+            if (is_string($hint) && $hint !== '') {
+                $tokens[] = strtolower($hint);
+            }
+        }
+
+        $basename = strtolower(basename($filepath));
+        $tokens[] = str_replace([' ', '_'], '-', $basename);
+
+        $extra = preg_split('/[^a-z0-9]+/i', $basename) ?: [];
+        foreach ($extra as $token) {
+            if ($token !== '') {
+                $tokens[] = strtolower($token);
+            }
+        }
+
+        /** @var list<string> $filtered */
+        $filtered = array_values(array_unique(array_filter($tokens, static fn (string $token): bool => $token !== '')));
+
+        return $filtered;
+    }
+
+    /**
+     * @param list<string> $tokens
+     * @param list<string> $keywords
+     */
+    private function matchesAnyKeyword(array $tokens, array $keywords): bool
+    {
+        if ($tokens === []) {
+            return false;
+        }
+
+        foreach ($keywords as $keyword) {
+            foreach ($tokens as $token) {
+                if ($token === $keyword || str_contains($token, $keyword)) {
+                    return true;
+                }
+
+                if (str_ends_with($token, '-' . $keyword)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Unit/Service/Feed/MemoryFeedBuilderTest.php
+++ b/test/Unit/Service/Feed/MemoryFeedBuilderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Feed;
+
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Clusterer\TitleGeneratorInterface;
+use MagicSunday\Memories\Service\Feed\CoverPickerInterface;
+use MagicSunday\Memories\Service\Feed\MemoryFeedBuilder;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+
+final class MemoryFeedBuilderTest extends TestCase
+{
+    #[Test]
+    public function filtersHiddenMediaFromFeedItems(): void
+    {
+        $titleGen = $this->createMock(TitleGeneratorInterface::class);
+        $titleGen->method('makeTitle')->willReturn('Titel');
+        $titleGen->method('makeSubtitle')->willReturn('Untertitel');
+
+        $coverPicker = $this->createMock(CoverPickerInterface::class);
+        $coverPicker->method('pickCover')->willReturnCallback(static function (array $members): ?Media {
+            return $members[0] ?? null;
+        });
+
+        $visible = $this->buildMedia(1, false);
+        $hidden  = $this->buildMedia(2, true);
+
+        $mediaRepository = $this->createMock(MediaRepository::class);
+        $mediaRepository
+            ->expects(self::once())
+            ->method('findByIds')
+            ->with([1, 2])
+            ->willReturn([$visible, $hidden]);
+
+        $builder = new MemoryFeedBuilder(
+            $titleGen,
+            $coverPicker,
+            $mediaRepository,
+            minScore: 0.0,
+            minMembers: 1,
+            maxPerDay: 5,
+            maxTotal: 10,
+            maxPerAlgorithm: 5,
+        );
+
+        $cluster = new ClusterDraft(
+            algorithm: 'test',
+            params: [
+                'score' => 0.5,
+                'time_range' => ['to' => 1],
+            ],
+            centroid: ['lat' => 0.0, 'lon' => 0.0],
+            members: [1, 2],
+        );
+
+        $result = $builder->build([$cluster]);
+
+        self::assertCount(1, $result);
+        $item = $result[0];
+
+        self::assertSame([1], $item->getMemberIds());
+        self::assertSame(1, $item->getCoverMediaId());
+    }
+
+    private function buildMedia(int $id, bool $noShow): Media
+    {
+        $media = new Media('path-' . $id . '.jpg', 'checksum-' . $id, 1024);
+
+        $ref = new ReflectionProperty(Media::class, 'id');
+        $ref->setAccessible(true);
+        $ref->setValue($media, $id);
+
+        $media->setNoShow($noShow);
+
+        return $media;
+    }
+}


### PR DESCRIPTION
## Summary
- add a ContentKind enum plus no-show flag on media with Doctrine migration and accessors
- implement a ContentClassifierExtractor and register it in the metadata pipeline
- ensure feed and cluster processing ignore hidden media and expand coverage

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e112f681308323a8b6003c288812ab