### PR TITLE
Add pHash64 support, burst metadata, and live pair linking

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -120,6 +120,8 @@ services:
 
     MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor: ~
 
+    MagicSunday\Memories\Service\Metadata\BurstIndexExtractor: ~
+
     MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher:
         arguments:
             $homeLat: '%env(float:MEMORIES_HOME_LAT)%'
@@ -158,6 +160,7 @@ services:
                 - '@MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor'
+                - '@MagicSunday\Memories\Service\Metadata\BurstIndexExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\DaypartEnricher'

--- a/migrations/Version20250401090000.php
+++ b/migrations/Version20250401090000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250401090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add pHash64 storage, burst index and live pair relation to media table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+ALTER TABLE media
+    ADD phash64 BIGINT UNSIGNED DEFAULT NULL,
+    ADD burstIndex INT DEFAULT NULL,
+    ADD livePairMediaId BIGINT DEFAULT NULL
+SQL
+        );
+
+        $this->addSql("CREATE INDEX idx_phash64 ON media (phash64)");
+        $this->addSql("CREATE INDEX idx_live_pair_checksum ON media (livePairChecksum)");
+        $this->addSql(<<<'SQL'
+ALTER TABLE media
+    ADD CONSTRAINT FK_media_live_pair
+        FOREIGN KEY (livePairMediaId)
+        REFERENCES media (id)
+        ON DELETE SET NULL
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP FOREIGN KEY FK_media_live_pair');
+        $this->addSql('DROP INDEX idx_phash64 ON media');
+        $this->addSql('DROP INDEX idx_live_pair_checksum ON media');
+        $this->addSql('ALTER TABLE media DROP phash64, DROP burstIndex, DROP livePairMediaId');
+    }
+}

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -11,9 +11,14 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Repository;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Clusterer\Pipeline\MemberMediaLookupInterface;
+
+use function strtolower;
+use function trim;
 
 /**
  * Minimal repository wrapper to load Media by IDs efficiently.
@@ -48,5 +53,104 @@ readonly class MediaRepository implements MemberMediaLookupInterface
         $items = $q->getResult();
 
         return $items;
+    }
+
+    /**
+     * Finds media items within the provided Hamming distance of the given pHash.
+     *
+     * @return list<array{media: Media, distance: int}>
+     */
+    public function findNearestByPhash(string $phashHex, int $maxHamming, int $limit = 20): array
+    {
+        $phashHex = trim(strtolower($phashHex));
+        if ($phashHex === '' || $maxHamming < 0) {
+            return [];
+        }
+
+        $limit = $limit < 1 ? 1 : $limit;
+
+        $conn = $this->em->getConnection();
+        $sql  = <<<'SQL'
+SELECT id,
+       BIT_COUNT(
+           CAST(CONV(HEX(phash64), 16, 10) AS UNSIGNED) ^
+           CAST(CONV(:phashHex, 16, 10) AS UNSIGNED)
+       ) AS hamming
+FROM media
+WHERE phash64 IS NOT NULL
+  AND noShow = 0
+HAVING hamming <= :maxHamming
+ORDER BY hamming ASC, id ASC
+LIMIT :limit
+SQL;
+
+        $rows = $conn->fetchAllAssociative(
+            $sql,
+            [
+                'phashHex'   => $phashHex,
+                'maxHamming' => $maxHamming,
+                'limit'      => $limit,
+            ],
+            [
+                'phashHex'   => ParameterType::STRING,
+                'maxHamming' => ParameterType::INTEGER,
+                'limit'      => ParameterType::INTEGER,
+            ]
+        );
+
+        if ($rows === []) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($rows as $row) {
+            $id = isset($row['id']) ? (int) $row['id'] : 0;
+            if ($id <= 0) {
+                continue;
+            }
+
+            $media = $this->em->find(Media::class, $id);
+            if (!$media instanceof Media) {
+                continue;
+            }
+
+            $result[] = [
+                'media'    => $media,
+                'distance' => (int) ($row['hamming'] ?? 0),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Attempts to find the counterpart of a live photo pair by checksum.
+     */
+    public function findLivePairCandidate(string $checksum, string $path): ?Media
+    {
+        $checksum = trim($checksum);
+        $path     = trim($path);
+
+        if ($checksum === '' || $path === '') {
+            return null;
+        }
+
+        /** @var ObjectRepository<Media> $repo */
+        $repo       = $this->em->getRepository(Media::class);
+        $candidates = $repo->findBy(['livePairChecksum' => $checksum], ['id' => 'ASC'], 8);
+
+        foreach ($candidates as $candidate) {
+            if (!$candidate instanceof Media) {
+                continue;
+            }
+
+            if ($candidate->getPath() === $path || $candidate->isNoShow()) {
+                continue;
+            }
+
+            return $candidate;
+        }
+
+        return null;
     }
 }

--- a/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
+++ b/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
@@ -21,6 +21,7 @@ use function array_map;
 use function array_values;
 use function count;
 use function max;
+use function is_string;
 use function usort;
 
 /**
@@ -354,11 +355,21 @@ final class MemberQualityRankingStage extends AbstractClusterScoreHeuristic impl
      */
     private function computeDuplicatePenalty(Media $media, array &$seenPhash, array &$seenDhash, array &$seenBurst): float
     {
-        $penalty  = $this->registerDuplicate($this->stringOrNull($media->getPhash()), $seenPhash, $this->phashPenalty);
+        $penalty  = $this->registerDuplicate($this->phashDuplicateKey($media), $seenPhash, $this->phashPenalty);
         $penalty += $this->registerDuplicate($this->stringOrNull($media->getDhash()), $seenDhash, $this->dhashPenalty);
         $penalty += $this->registerDuplicate($this->stringOrNull($media->getBurstUuid()), $seenBurst, $this->burstPenalty);
 
         return $penalty > 0.9 ? 0.9 : $penalty;
+    }
+
+    private function phashDuplicateKey(Media $media): ?string
+    {
+        $hash64 = $media->getPhash64();
+        if (is_string($hash64) && $hash64 !== '') {
+            return $hash64;
+        }
+
+        return $this->stringOrNull($media->getPhash());
     }
 
     /**

--- a/test/Unit/Repository/MediaRepositoryTest.php
+++ b/test/Unit/Repository/MediaRepositoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function str_contains;
+
+final class MediaRepositoryTest extends TestCase
+{
+    #[Test]
+    public function findNearestByPhashReturnsMediaWithDistances(): void
+    {
+        $mediaA = $this->makeMedia(10, 'a.jpg');
+        $mediaB = $this->makeMedia(11, 'b.jpg');
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::callback(static fn (string $sql): bool => str_contains($sql, 'BIT_COUNT')),
+                [
+                    'phashHex'   => 'abcdef',
+                    'maxHamming' => 3,
+                    'limit'      => 5,
+                ],
+                [
+                    'phashHex'   => ParameterType::STRING,
+                    'maxHamming' => ParameterType::INTEGER,
+                    'limit'      => ParameterType::INTEGER,
+                ]
+            )
+            ->willReturn([
+                ['id' => '10', 'hamming' => '1'],
+                ['id' => '11', 'hamming' => '2'],
+            ]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($connection);
+        $em
+            ->expects(self::exactly(2))
+            ->method('find')
+            ->willReturnMap([
+                [Media::class, 10, null, null, $mediaA],
+                [Media::class, 11, null, null, $mediaB],
+            ]);
+
+        $repository = new MediaRepository($em);
+
+        $result = $repository->findNearestByPhash('ABCDEF', 3, 5);
+
+        self::assertCount(2, $result);
+        self::assertSame($mediaA, $result[0]['media']);
+        self::assertSame(1, $result[0]['distance']);
+        self::assertSame($mediaB, $result[1]['media']);
+        self::assertSame(2, $result[1]['distance']);
+    }
+
+    #[Test]
+    public function findLivePairCandidateReturnsFirstNonHiddenMatch(): void
+    {
+        $existing = $this->makeMedia(21, 'existing.mov', configure: static function (Media $media): void {
+            $media->setNoShow(true);
+        });
+        $candidate = $this->makeMedia(22, 'candidate.heic');
+
+        $repoMock = $this->createMock(EntityRepository::class);
+        $repoMock
+            ->expects(self::once())
+            ->method('findBy')
+            ->with(['livePairChecksum' => 'checksum'], ['id' => 'ASC'], 8)
+            ->willReturn([$existing, $candidate]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($this->createMock(Connection::class));
+        $em->method('getRepository')->with(Media::class)->willReturn($repoMock);
+
+        $repository = new MediaRepository($em);
+
+        $result = $repository->findLivePairCandidate(' checksum ', ' candidate-video.mov ');
+
+        self::assertSame($candidate, $result);
+    }
+}

--- a/test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php
+++ b/test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php
@@ -118,6 +118,7 @@ final class MemberQualityRankingStageTest extends TestCase
                 entropy: 0.63,
                 colorfulness: 0.68,
                 phash: 'unique-phash',
+                phash64: '1001',
                 dhash: 'unique-dhash',
                 burstUuid: null,
             ),
@@ -132,6 +133,7 @@ final class MemberQualityRankingStageTest extends TestCase
                 entropy: 0.60,
                 colorfulness: 0.66,
                 phash: 'duplicate-phash',
+                phash64: '2002',
                 dhash: 'duplicate-dhash',
                 burstUuid: 'burst-1',
             ),
@@ -146,6 +148,7 @@ final class MemberQualityRankingStageTest extends TestCase
                 entropy: 0.60,
                 colorfulness: 0.66,
                 phash: 'duplicate-phash',
+                phash64: '2002',
                 dhash: 'duplicate-dhash',
                 burstUuid: 'burst-1',
             ),
@@ -321,8 +324,9 @@ final class MemberQualityRankingStageTest extends TestCase
         float $entropy,
         float $colorfulness,
         ?string $phash,
-        ?string $dhash,
-        ?string $burstUuid,
+        ?string $phash64 = null,
+        ?string $dhash = null,
+        ?string $burstUuid = null,
         ?float $qualityScore = null,
         ?float $qualityExposure = null,
         ?float $qualityNoise = null,
@@ -344,6 +348,9 @@ final class MemberQualityRankingStageTest extends TestCase
         $media->setEntropy($entropy);
         $media->setColorfulness($colorfulness);
         $media->setPhash($phash);
+        if ($phash64 !== null) {
+            $media->setPhash64($phash64);
+        }
         $media->setDhash($dhash);
         $media->setBurstUuid($burstUuid);
 

--- a/test/Unit/Service/Metadata/BurstIndexExtractorTest.php
+++ b/test/Unit/Service/Metadata/BurstIndexExtractorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Metadata\BurstIndexExtractor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class BurstIndexExtractorTest extends TestCase
+{
+    #[Test]
+    public function usesSubSecondComponentAndLinksLivePair(): void
+    {
+        $media = $this->makeMedia(1, 'movie.mov', configure: static function (Media $media): void {
+            $media->setMime('video/quicktime');
+            $media->setBurstUuid('burst-uuid');
+            $media->setSubSecOriginal(42);
+            $media->setLivePairChecksum('pair-checksum');
+        });
+
+        $counterpart = $this->makeMedia(2, 'photo.heic', configure: static function (Media $media): void {
+            $media->setMime('image/heic');
+        });
+
+        $repository = $this->createMock(MediaRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findLivePairCandidate')
+            ->with('pair-checksum', $media->getPath())
+            ->willReturn($counterpart);
+
+        $extractor = new BurstIndexExtractor($repository);
+
+        self::assertTrue($extractor->supports($media->getPath(), $media));
+
+        $result = $extractor->extract($media->getPath(), $media);
+
+        self::assertSame(42, $result->getBurstIndex());
+        self::assertSame($counterpart, $result->getLivePairMedia());
+        self::assertSame($result, $counterpart->getLivePairMedia());
+    }
+
+    #[Test]
+    public function derivesBurstIndexFromFilenameWhenAvailable(): void
+    {
+        $media = $this->makeMedia(3, 'IMG_1001-BURST-0003.JPG', configure: static function (Media $media): void {
+            $media->setMime('image/jpeg');
+            $media->setBurstUuid('burst-uuid');
+        });
+
+        $repository = $this->createMock(MediaRepository::class);
+        $repository->expects(self::never())->method('findLivePairCandidate');
+
+        $extractor = new BurstIndexExtractor($repository);
+
+        $result = $extractor->extract($media->getPath(), $media);
+
+        self::assertSame(3, $result->getBurstIndex());
+    }
+}


### PR DESCRIPTION
## Summary
- extend the media schema with pHash64 storage, burst indices, and live photo pairing including a migration
- update perceptual hash extraction, duplicate scoring, and media repository helpers plus add a burst index extractor
- add focused unit coverage for the new repository helpers, burst extractor, and duplicate penalty expectations

## Testing
- composer ci:test *(fails: bin/php vendor wrapper not available in container)*
- ./vendor/bin/phpunit -c .build/phpunit.xml test/Unit/Repository/MediaRepositoryTest.php
- ./vendor/bin/phpunit -c .build/phpunit.xml test/Unit/Service/Metadata/BurstIndexExtractorTest.php
- ./vendor/bin/phpunit -c .build/phpunit.xml test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php


------
https://chatgpt.com/codex/tasks/task_e_68e11a0dda608323bcd0f3dda9676121