### PR TITLE
Add face metadata fields and populate them via XMP extraction

### DIFF
--- a/migrations/Version20250418103000.php
+++ b/migrations/Version20250418103000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250418103000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add face detection flags to media table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+ALTER TABLE media
+    ADD hasFaces TINYINT(1) NOT NULL DEFAULT 0,
+    ADD facesCount INT NOT NULL DEFAULT 0
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP hasFaces, DROP facesCount');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use MagicSunday\Memories\Entity\Enum\ContentKind;
 use MagicSunday\Memories\Entity\Enum\TimeSource;
+use function count;
 
 /**
  * Doctrine entity describing an imported photo or video including its metadata.
@@ -448,6 +449,18 @@ class Media
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $persons = null;
+
+    /**
+     * Flag indicating whether the media contains detected faces.
+     */
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $hasFaces = false;
+
+    /**
+     * Number of detected or tagged faces associated with the media.
+     */
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+    private int $facesCount = 0;
 
     /**
      * Feature set describing the scene (labels, categories, etc.).
@@ -1699,6 +1712,47 @@ class Media
     public function setPersons(?array $v): void
     {
         $this->persons = $v;
+
+        $count = $v !== null ? count($v) : 0;
+
+        $this->hasFaces = $count > 0;
+        $this->facesCount = $count;
+    }
+
+    /**
+     * Returns whether the media contains detected faces.
+     */
+    public function hasFaces(): bool
+    {
+        return $this->hasFaces;
+    }
+
+    /**
+     * Sets whether the media contains detected faces.
+     *
+     * @param bool $value True when at least one face is detected.
+     */
+    public function setHasFaces(bool $value): void
+    {
+        $this->hasFaces = $value;
+    }
+
+    /**
+     * Returns the number of detected faces.
+     */
+    public function getFacesCount(): int
+    {
+        return $this->facesCount;
+    }
+
+    /**
+     * Stores the number of detected faces.
+     *
+     * @param int $count Total number of detected faces.
+     */
+    public function setFacesCount(int $count): void
+    {
+        $this->facesCount = $count;
     }
 
     /**

--- a/src/Service/Metadata/XmpIptcExtractor.php
+++ b/src/Service/Metadata/XmpIptcExtractor.php
@@ -77,7 +77,11 @@ final class XmpIptcExtractor implements SingleMetadataExtractorInterface
         }
 
         $media->setKeywords($keywords !== [] ? $keywords : null);
+
+        $personCount = count($persons);
         $media->setPersons($persons !== [] ? $persons : null);
+        $media->setHasFaces($personCount > 0);
+        $media->setFacesCount($personCount);
 
         return $media;
     }

--- a/test/Unit/Service/Metadata/XmpIptcExtractorTest.php
+++ b/test/Unit/Service/Metadata/XmpIptcExtractorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\XmpIptcExtractor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function file_exists;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class XmpIptcExtractorTest extends TestCase
+{
+    #[Test]
+    public function populatesFaceFlagsFromXmpSidecar(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'mem-xmp-');
+        self::assertIsString($path);
+
+        /** @var string $path */
+        file_put_contents($path, 'fake-image');
+        file_put_contents($path . '.xmp', <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:mwg-rs="http://www.metadataworkinggroup.com/schemas/regions/">
+  <rdf:RDF>
+    <rdf:Description>
+      <mwg-rs:Regions>
+        <rdf:Bag>
+          <rdf:li>
+            <mwg-rs:Name>Alice</mwg-rs:Name>
+          </rdf:li>
+          <rdf:li>
+            <mwg-rs:Name>Bob</mwg-rs:Name>
+          </rdf:li>
+        </rdf:Bag>
+      </mwg-rs:Regions>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <rdf:Bag>
+          <rdf:li>holiday</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+XML
+        );
+
+        try {
+            $media = $this->makeMedia(200, $path, configure: static function (Media $media): void {
+                $media->setMime('image/jpeg');
+            });
+
+            $extractor = new XmpIptcExtractor();
+            $extractor->extract($path, $media);
+
+            $keywords = $media->getKeywords();
+            self::assertIsArray($keywords);
+            self::assertContains('holiday', $keywords);
+            self::assertSame(['Alice', 'Bob'], $media->getPersons());
+            self::assertTrue($media->hasFaces());
+            self::assertSame(2, $media->getFacesCount());
+        } finally {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+
+            $sidecar = $path . '.xmp';
+            if (file_exists($sidecar)) {
+                unlink($sidecar);
+            }
+        }
+    }
+
+    #[Test]
+    public function resetsFaceFlagsWhenNoPersonsPresent(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'mem-xmp-');
+        self::assertIsString($path);
+
+        /** @var string $path */
+        file_put_contents($path, 'fake-image');
+        file_put_contents($path . '.xmp', <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:RDF>
+    <rdf:Description>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <rdf:Bag>
+          <rdf:li>landscape</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+XML
+        );
+
+        try {
+            $media = $this->makeMedia(201, $path, configure: static function (Media $media): void {
+                $media->setMime('image/jpeg');
+                $media->setHasFaces(true);
+                $media->setFacesCount(3);
+            });
+
+            $extractor = new XmpIptcExtractor();
+            $extractor->extract($path, $media);
+
+            $keywords = $media->getKeywords();
+            self::assertIsArray($keywords);
+            self::assertContains('landscape', $keywords);
+            self::assertNull($media->getPersons());
+            self::assertFalse($media->hasFaces());
+            self::assertSame(0, $media->getFacesCount());
+        } finally {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+
+            $sidecar = $path . '.xmp';
+            if (file_exists($sidecar)) {
+                unlink($sidecar);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `hasFaces` and `facesCount` fields to the media entity with a schema migration
- update the XMP/IPTC extractor to derive face flags from detected person tags
- add unit coverage that exercises the new face flag handling with sample XMP payloads

## Testing
- composer ci:test *(fails: `bin/php` is not available in the container)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter XmpIptcExtractorTest


------
https://chatgpt.com/codex/tasks/task_e_68e1221bc5148323934a1ba06cf2fa86