### PR TITLE
Set batch size to 10 across command workflows

### DIFF
--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -31,7 +31,7 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
 {
     public function __construct(
         private EntityManagerInterface $em,
-        private int $defaultBatchSize = 250,
+        private int $defaultBatchSize = 10,
         #[Autowire('%memories.cluster.persistence.max_members%')]
         private int $maxMembers = 20,
     ) {

--- a/src/Service/Clusterer/DefaultClusterJobRunner.php
+++ b/src/Service/Clusterer/DefaultClusterJobRunner.php
@@ -146,7 +146,7 @@ final class DefaultClusterJobRunner implements ClusterJobRunnerInterface
         } else {
             $persisted = $this->persistence->persistBatched(
                 $drafts,
-                250,
+                10,
                 function (int $persistedInBatch) use (&$persisted, $persistHandle, $persistStart): void {
                     $persisted += $persistedInBatch;
                     $persistHandle->setRate($this->formatRate($persisted, $persistStart, 'Cluster'));

--- a/src/Service/Indexing/Stage/PersistenceBatchStage.php
+++ b/src/Service/Indexing/Stage/PersistenceBatchStage.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class PersistenceBatchStage implements FinalizableMediaIngestionStageInterface
 {
-    private const BATCH_SIZE = 50;
+    private const BATCH_SIZE = 10;
 
     private int $batchCount = 0;
 

--- a/test/Unit/Service/Clusterer/DefaultClusterJobRunnerTest.php
+++ b/test/Unit/Service/Clusterer/DefaultClusterJobRunnerTest.php
@@ -137,7 +137,7 @@ final class DefaultClusterJobRunnerTest extends TestCase
         $persistence->expects(self::once())
             ->method('persistBatched')
             ->willReturnCallback(function (array $persistedDrafts, int $batchSize, ?callable $callback): int {
-                self::assertSame(250, $batchSize);
+                self::assertSame(10, $batchSize);
                 self::assertCount(1, $persistedDrafts);
                 self::assertNotNull($callback);
                 $callback(1);


### PR DESCRIPTION
## Summary
- reduce the persistence batch size for media indexing to 10 items
- align cluster persistence defaults and job runner batch size with the new value
- update unit tests to reflect the lowered cluster batch size

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e123e88fd88323b1514c4b2174c0e8