### PR TITLE
Clamp media quality metrics

### DIFF
--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -1662,7 +1662,9 @@ class Media
      */
     public function setQualityScore(?float $score): void
     {
-        $this->qualityScore = $score;
+        $this->qualityScore = $score === null
+            ? null
+            : max(0.0, min(1.0, $score));
     }
 
     /**
@@ -1680,7 +1682,9 @@ class Media
      */
     public function setQualityExposure(?float $score): void
     {
-        $this->qualityExposure = $score;
+        $this->qualityExposure = $score === null
+            ? null
+            : max(0.0, min(1.0, $score));
     }
 
     /**
@@ -1698,7 +1702,9 @@ class Media
      */
     public function setQualityNoise(?float $score): void
     {
-        $this->qualityNoise = $score;
+        $this->qualityNoise = $score === null
+            ? null
+            : max(0.0, min(1.0, $score));
     }
 
     /**

--- a/test/Unit/Entity/MediaQualityTest.php
+++ b/test/Unit/Entity/MediaQualityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Entity;
+
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MediaQualityTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('scoreProvider')]
+    public function clampsAggregatedQualityScore(?float $input, ?float $expected): void
+    {
+        $media = $this->makeMedia(
+            id: 101,
+            path: '/library/quality-score.jpg',
+        );
+
+        $media->setQualityScore($input);
+
+        self::assertSame($expected, $media->getQualityScore());
+    }
+
+    #[Test]
+    #[DataProvider('scoreProvider')]
+    public function clampsAggregatedQualityExposure(?float $input, ?float $expected): void
+    {
+        $media = $this->makeMedia(
+            id: 102,
+            path: '/library/quality-exposure.jpg',
+        );
+
+        $media->setQualityExposure($input);
+
+        self::assertSame($expected, $media->getQualityExposure());
+    }
+
+    #[Test]
+    #[DataProvider('scoreProvider')]
+    public function clampsAggregatedQualityNoise(?float $input, ?float $expected): void
+    {
+        $media = $this->makeMedia(
+            id: 103,
+            path: '/library/quality-noise.jpg',
+        );
+
+        $media->setQualityNoise($input);
+
+        self::assertSame($expected, $media->getQualityNoise());
+    }
+
+    /**
+     * @return iterable<string, array{?float, ?float}>
+     */
+    public static function scoreProvider(): iterable
+    {
+        yield 'null value' => [null, null];
+        yield 'below lower bound' => [-0.75, 0.0];
+        yield 'within range' => [0.65, 0.65];
+        yield 'above upper bound' => [1.25, 1.0];
+    }
+}


### PR DESCRIPTION
## Summary
- clamp Media quality setters to persist values within the 0–1 interval
- add unit coverage for the Media quality score, exposure, and noise setters

## Testing
- composer ci:test *(fails: `bin/php` missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e13253e51483239c5b8525ed3fba6f