### PR TITLE
Ensure pHash prefix setter truncates values

### DIFF
--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -1756,7 +1756,7 @@ class Media
      */
     public function setPhashPrefix(?string $v): void
     {
-        $this->phashPrefix = $v;
+        $this->phashPrefix = $v === null ? null : substr($v, 0, 16);
     }
 
     /**

--- a/test/Unit/Entity/MediaPhashPrefixTest.php
+++ b/test/Unit/Entity/MediaPhashPrefixTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Entity;
+
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MediaPhashPrefixTest extends TestCase
+{
+    #[Test]
+    public function truncatesPhashPrefixToSixteenCharacters(): void
+    {
+        $media = $this->makeMedia(
+            id: 201,
+            path: '/library/phash-prefix.jpg',
+        );
+
+        $media->setPhashPrefix('0123456789abcdefcafebabe');
+
+        self::assertSame('0123456789abcdef', $media->getPhashPrefix());
+    }
+}


### PR DESCRIPTION
## Summary
- clamp `Media::setPhashPrefix()` to at most 16 characters to match `setPhash()`
- add a unit test covering truncation of overly long perceptual hash prefixes

## Testing
- composer ci:test *(fails: `bin/php` not found in container environment)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter MediaPhashPrefixTest


------
https://chatgpt.com/codex/tasks/task_e_68e133386cb08323aa36d2706394ac57