### PR TITLE
Add index for live pair relation on media entity

### DIFF
--- a/migrations/Version20240516120000.php
+++ b/migrations/Version20240516120000.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add an index for the live photo pair relation.
+ */
+final class Version20240516120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the idx_media_live_pair_id index for media.livePairMediaId.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (! $schema->hasTable('media')) {
+            return;
+        }
+
+        $table = $schema->getTable('media');
+
+        if ($table->hasIndex('idx_media_live_pair_id')) {
+            return;
+        }
+
+        $table->addIndex(['livePairMediaId'], 'idx_media_live_pair_id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (! $schema->hasTable('media')) {
+            return;
+        }
+
+        $table = $schema->getTable('media');
+
+        if (! $table->hasIndex('idx_media_live_pair_id')) {
+            return;
+        }
+
+        $table->dropIndex('idx_media_live_pair_id');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -29,6 +29,7 @@ use function count;
         new ORM\Index(name: 'idx_checksum', columns: ['checksum']),
         new ORM\Index(name: 'idx_phash64', columns: ['phash64']),
         new ORM\Index(name: 'idx_live_pair_checksum', columns: ['livePairChecksum']),
+        new ORM\Index(name: 'idx_media_live_pair_id', columns: ['livePairMediaId']),
         new ORM\Index(name: 'idx_media_geocell8', columns: ['geoCell8']),
         new ORM\Index(name: 'idx_media_phash_prefix', columns: ['phashPrefix']),
         new ORM\Index(name: 'idx_media_burst_taken', columns: ['burstUuid', 'takenAt']),


### PR DESCRIPTION
## Summary
- add Doctrine table metadata for the live photo pair relation index on media
- create a Doctrine migration that adds the idx_media_live_pair_id index when updating the schema

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e13344c6dc83238b1992e766da7850