### PR TITLE
Add migration for media indexes and phash prefix length

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ CREATE INDEX idx_media_noshow_lowquality ON media (noShow, lowQuality);
 
 Passe die Empfehlung je nach Datenbankdialekt an (z. B. `CREATE INDEX` vs. `CREATE INDEX IF NOT EXISTS`).
 
+> **Hinweis:** Nach dem Update auf diese Version führst du einmal `bin/console doctrine:migrations:migrate` aus, damit alle neuen `media`-Indizes sowie die geänderte Spaltenlänge von `phashPrefix` in der Datenbank landen.
+
 ## Cluster-Konfiguration
 
 Die Persistierung der berechneten Cluster wird jetzt begrenzt, damit Feeds und Oberflächen nicht mit hunderten Medien pro Block

--- a/migrations/Version20240522150000.php
+++ b/migrations/Version20240522150000.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Align the media table with the entity metadata.
+ */
+final class Version20240522150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missing media indexes and enforce the phashPrefix length.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (! $schema->hasTable('media')) {
+            return;
+        }
+
+        $table = $schema->getTable('media');
+
+        $indexes = [
+            'idx_media_candidate' => ['noShow', 'lowQuality', 'takenAt'],
+            'idx_media_needs_geocode' => ['needsGeocode'],
+            'idx_media_live_pair_id' => ['livePairMediaId'],
+            'idx_media_location' => ['location_id'],
+            'idx_media_geocell8' => ['geoCell8'],
+            'idx_media_phash_prefix' => ['phashPrefix'],
+            'idx_media_burst_taken' => ['burstUuid', 'takenAt'],
+            'idx_media_video_taken' => ['isVideo', 'takenAt'],
+        ];
+
+        foreach ($indexes as $name => $columns) {
+            if ($table->hasIndex($name)) {
+                continue;
+            }
+
+            $table->addIndex($columns, $name);
+        }
+
+        if (! $table->hasColumn('phashPrefix')) {
+            return;
+        }
+
+        $column = $table->getColumn('phashPrefix');
+        if ($column->getLength() === 16) {
+            return;
+        }
+
+        $table->changeColumn('phashPrefix', [
+            'length'  => 16,
+            'notnull' => false,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (! $schema->hasTable('media')) {
+            return;
+        }
+
+        $table = $schema->getTable('media');
+
+        $indexes = [
+            'idx_media_candidate',
+            'idx_media_needs_geocode',
+            'idx_media_live_pair_id',
+            'idx_media_location',
+            'idx_media_geocell8',
+            'idx_media_phash_prefix',
+            'idx_media_burst_taken',
+            'idx_media_video_taken',
+        ];
+
+        foreach ($indexes as $name) {
+            if (! $table->hasIndex($name)) {
+                continue;
+            }
+
+            $table->dropIndex($name);
+        }
+
+        if (! $table->hasColumn('phashPrefix')) {
+            return;
+        }
+
+        $table->changeColumn('phashPrefix', [
+            'length'  => 255,
+            'notnull' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Doctrine migration that creates the media indexes from the entity mapping and enforces the phashPrefix column length
- document the required schema update step in the README

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e13431575c8323b0d81e0c8b69e824