### PR TITLE
Add capture time normalizer based on metadata priority

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -24,6 +24,8 @@ parameters:
     memories.geocoding.overpass.allowed_pois: []
     memories.localization.preferred_locale: '%env(default::string:MEMORIES_PREFERRED_LOCALE)%'
 
+    memories.timezone.default: 'UTC'
+
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]
     memories.thumbnail.apply_orientation: '%env(default::bool:MEMORIES_THUMBNAIL_APPLY_ORIENTATION)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -128,6 +128,12 @@ services:
             $homeLon: '%env(float:MEMORIES_HOME_LON)%'
             $cellDegrees: 0.01
 
+    MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser: ~
+
+    MagicSunday\Memories\Service\Metadata\TimeNormalizer:
+        arguments:
+            $defaultTimezone: '%memories.timezone.default%'
+
     MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher: ~
 
     MagicSunday\Memories\Service\Metadata\DaypartEnricher: ~
@@ -170,6 +176,7 @@ services:
                 - '@MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\BurstIndexExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher'
+                - '@MagicSunday\Memories\Service\Metadata\TimeNormalizer'
                 - '@MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\DaypartEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\SolarEnricher'

--- a/src/Entity/Enum/TimeSource.php
+++ b/src/Entity/Enum/TimeSource.php
@@ -18,5 +18,6 @@ enum TimeSource: string
 {
     case EXIF = 'EXIF';
     case VIDEO_QUICKTIME = 'VIDEO_QUICKTIME';
+    case FILENAME = 'FILENAME';
     case FILE_MTIME = 'FILE_MTIME';
 }

--- a/src/Service/Metadata/Support/FilenameDateParser.php
+++ b/src/Service/Metadata/Support/FilenameDateParser.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
+use function basename;
+use function pathinfo;
+use function preg_match;
+use function sprintf;
+
+use const PATHINFO_FILENAME;
+
+/**
+ * Parses capture timestamps from common filename patterns.
+ */
+final class FilenameDateParser
+{
+    public function parse(string $filepath, DateTimeZone $timezone): ?DateTimeImmutable
+    {
+        $filename = basename($filepath);
+        $stem     = pathinfo($filename, PATHINFO_FILENAME);
+
+        $patterns = [
+            '/(?<!\d)(\d{4})(\d{2})(\d{2})[_-]?(\d{2})(\d{2})(\d{2})(?!\d)/',
+            '/(?<!\d)(\d{4})[-_.](\d{2})[-_.](\d{2})[ T_-](\d{2})[-_.](\d{2})[-_.](\d{2})(?!\d)/',
+            '/(?:IMG|DSC|VID|MOV|PXL|PHOTO)[_-]?(\d{4})(\d{2})(\d{2})[_-]?(\d{2})(\d{2})(\d{2})/i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            $matches = [];
+            if (preg_match($pattern, $stem, $matches) !== 1) {
+                continue;
+            }
+
+            $date = sprintf(
+                '%s-%s-%s %s:%s:%s',
+                $matches[1],
+                $matches[2],
+                $matches[3],
+                $matches[4],
+                $matches[5],
+                $matches[6],
+            );
+
+            try {
+                return new DateTimeImmutable($date, $timezone);
+            } catch (Exception) {
+                continue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Service/Metadata/TimeNormalizer.php
+++ b/src/Service/Metadata/TimeNormalizer.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use MagicSunday\Memories\Entity\Enum\TimeSource;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
+use MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser;
+
+use function filemtime;
+use function intdiv;
+use function is_int;
+use function sprintf;
+
+/**
+ * Normalises capture timestamps and timezone metadata based on priority sources.
+ */
+final class TimeNormalizer implements SingleMetadataExtractorInterface
+{
+    public function __construct(
+        private readonly CaptureTimeResolver $captureTimeResolver,
+        private readonly string $defaultTimezone,
+        private readonly FilenameDateParser $filenameDateParser,
+    ) {
+    }
+
+    public function supports(string $filepath, Media $media): bool
+    {
+        return true;
+    }
+
+    public function extract(string $filepath, Media $media): Media
+    {
+        $this->applyPrioritisedTakenAt($filepath, $media);
+        $this->normaliseTimezone($media);
+        $this->appendSummaryLog($media);
+
+        return $media;
+    }
+
+    private function applyPrioritisedTakenAt(string $filepath, Media $media): void
+    {
+        $source  = $media->getTimeSource();
+        $takenAt = $media->getTakenAt();
+
+        if ($source === TimeSource::EXIF) {
+            return;
+        }
+
+        if ($source === TimeSource::VIDEO_QUICKTIME && $takenAt instanceof DateTimeImmutable) {
+            return;
+        }
+
+        if ($source === null || $source === TimeSource::FILE_MTIME || !$takenAt instanceof DateTimeImmutable) {
+            $parsed = $this->filenameDateParser->parse($filepath, $this->defaultTimezone());
+            if ($parsed instanceof DateTimeImmutable) {
+                $media->setTakenAt($parsed);
+                $media->setCapturedLocal($parsed);
+                $media->setTimeSource(TimeSource::FILENAME);
+                $media->setTzId($parsed->getTimezone()->getName());
+
+                return;
+            }
+        }
+
+        if (!$takenAt instanceof DateTimeImmutable) {
+            $fileInstant = $this->fileModificationInstant($filepath);
+            if ($fileInstant instanceof DateTimeImmutable) {
+                $media->setTakenAt($fileInstant);
+                $media->setCapturedLocal($fileInstant);
+                $media->setTzId($fileInstant->getTimezone()->getName());
+                $media->setTimeSource(TimeSource::FILE_MTIME);
+            }
+        }
+    }
+
+    private function fileModificationInstant(string $filepath): ?DateTimeImmutable
+    {
+        $timestamp = @filemtime($filepath);
+        if (!is_int($timestamp)) {
+            return null;
+        }
+
+        try {
+            return (new DateTimeImmutable(sprintf('@%d', $timestamp)))->setTimezone($this->defaultTimezone());
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function normaliseTimezone(Media $media): void
+    {
+        $takenAt = $media->getTakenAt();
+        if (!$takenAt instanceof DateTimeImmutable) {
+            return;
+        }
+
+        $local = $this->captureTimeResolver->resolve($media);
+        if (!$local instanceof DateTimeImmutable) {
+            $timezone = $this->defaultTimezone();
+            $local    = $takenAt->setTimezone($timezone);
+            $media->setCapturedLocal($local);
+            if ($media->getTzId() === null) {
+                $media->setTzId($timezone->getName());
+            }
+        }
+
+        if ($media->getTimezoneOffsetMin() === null) {
+            $media->setTimezoneOffsetMin(intdiv($local->getOffset(), 60));
+        }
+    }
+
+    private function appendSummaryLog(Media $media): void
+    {
+        $source = $media->getTimeSource();
+        $offset = $media->getTimezoneOffsetMin();
+        $tzId   = $media->getTzId() ?? $this->defaultTimezone()->getName();
+
+        $summary = sprintf(
+            'time=%s; tz=%s; off=%s',
+            $source instanceof TimeSource ? $source->value : 'none',
+            $tzId,
+            $offset !== null ? sprintf('%+d', $offset) : 'n/a',
+        );
+
+        $existing = $media->getIndexLog();
+        if ($existing === null || $existing === '') {
+            $media->setIndexLog($summary);
+
+            return;
+        }
+
+        $media->setIndexLog($existing . "\n" . $summary);
+    }
+
+    private function defaultTimezone(): DateTimeZone
+    {
+        try {
+            return new DateTimeZone($this->defaultTimezone);
+        } catch (Exception) {
+            return new DateTimeZone('UTC');
+        }
+    }
+}

--- a/test/Unit/Service/Metadata/TimeNormalizerTest.php
+++ b/test/Unit/Service/Metadata/TimeNormalizerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Contract\TimezoneResolverInterface;
+use MagicSunday\Memories\Entity\Enum\TimeSource;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
+use MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser;
+use MagicSunday\Memories\Service\Metadata\TimeNormalizer;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+use function sprintf;
+use function strtotime;
+use function sys_get_temp_dir;
+use function tempnam;
+use function rename;
+use function touch;
+use function unlink;
+use function file_exists;
+
+final class TimeNormalizerTest extends TestCase
+{
+    #[Test]
+    public function keepsExifTimestampAndAppendsSummary(): void
+    {
+        $normalizer = $this->createNormalizer();
+
+        $media = $this->makeMedia(
+            id: 1,
+            path: '/library/IMG_20240101_101112.jpg',
+            takenAt: '2024-01-01T09:11:12+00:00',
+            configure: static function (Media $item): void {
+                $item->setIndexLog('initial');
+            },
+        );
+
+        $result = $normalizer->extract($media->getPath(), $media);
+
+        self::assertSame(TimeSource::EXIF, $result->getTimeSource());
+        $expectedSummary = sprintf(
+            'time=%s; tz=%s; off=%+d',
+            TimeSource::EXIF->value,
+            (string) $result->getTzId(),
+            (int) $result->getTimezoneOffsetMin(),
+        );
+        self::assertSame('initial' . "\n" . $expectedSummary, $result->getIndexLog());
+    }
+
+    #[Test]
+    public function doesNotOverrideQuickTimeTimestamp(): void
+    {
+        $normalizer = $this->createNormalizer();
+
+        $media = $this->makeMedia(
+            id: 2,
+            path: '/library/PXL_20221105_141516.mp4',
+            takenAt: new DateTimeImmutable('2022-11-05T14:15:16+01:00'),
+            configure: static function (Media $item): void {
+                $item->setTimeSource(TimeSource::VIDEO_QUICKTIME);
+                $item->setIndexLog('video');
+            },
+        );
+
+        $result = $normalizer->extract($media->getPath(), $media);
+
+        self::assertSame(TimeSource::VIDEO_QUICKTIME, $result->getTimeSource());
+        $expectedSummary = sprintf(
+            'time=%s; tz=%s; off=%+d',
+            TimeSource::VIDEO_QUICKTIME->value,
+            (string) $result->getTzId(),
+            (int) $result->getTimezoneOffsetMin(),
+        );
+        self::assertSame('video' . "\n" . $expectedSummary, $result->getIndexLog());
+    }
+
+    #[Test]
+    public function parsesTimestampFromFilename(): void
+    {
+        $normalizer = $this->createNormalizer(defaultTimezone: 'Europe/Berlin');
+
+        $media = $this->makeMedia(
+            id: 3,
+            path: '/library/20230721_141516.jpg',
+        );
+
+        $result = $normalizer->extract($media->getPath(), $media);
+
+        self::assertSame(TimeSource::FILENAME, $result->getTimeSource());
+        self::assertSame('Europe/Berlin', $result->getTzId());
+        self::assertSame(120, $result->getTimezoneOffsetMin());
+        self::assertSame('time=FILENAME; tz=Europe/Berlin; off=+120', $result->getIndexLog());
+    }
+
+    #[Test]
+    public function fallsBackToFileModificationTime(): void
+    {
+        $normalizer = $this->createNormalizer(defaultTimezone: 'Europe/Berlin');
+
+        $tmp = tempnam(sys_get_temp_dir(), 'pm_time_');
+        self::assertIsString($tmp);
+
+        $filename = sprintf('%s/no-pattern-file.jpg', sys_get_temp_dir());
+        if (file_exists($filename)) {
+            unlink($filename);
+        }
+        self::assertTrue(rename($tmp, $filename));
+
+        $timestamp = strtotime('2020-02-03T04:05:06Z');
+        self::assertNotFalse($timestamp);
+        self::assertTrue(touch($filename, $timestamp));
+
+        $media = $this->makeMedia(
+            id: 4,
+            path: $filename,
+        );
+
+        $result = $normalizer->extract($media->getPath(), $media);
+
+        self::assertSame(TimeSource::FILE_MTIME, $result->getTimeSource());
+        self::assertSame('Europe/Berlin', $result->getTzId());
+        self::assertSame(60, $result->getTimezoneOffsetMin());
+        $expectedSummary = sprintf(
+            'time=%s; tz=%s; off=%+d',
+            TimeSource::FILE_MTIME->value,
+            (string) $result->getTzId(),
+            (int) $result->getTimezoneOffsetMin(),
+        );
+        self::assertSame($expectedSummary, $result->getIndexLog());
+
+        if (file_exists($filename)) {
+            unlink($filename);
+        }
+    }
+
+    #[Test]
+    public function resolvesTimezoneFromResolver(): void
+    {
+        $rome = new DateTimeZone('Europe/Rome');
+        $normalizer = $this->createNormalizer(resolvedTimezone: $rome, defaultTimezone: 'UTC');
+
+        $media = $this->makeMedia(
+            id: 5,
+            path: '/library/IMG_20230812_101112.jpg',
+        );
+        $media->setGpsLat(41.902782);
+        $media->setGpsLon(12.496366);
+
+        $result = $normalizer->extract($media->getPath(), $media);
+
+        self::assertSame(TimeSource::FILENAME, $result->getTimeSource());
+        self::assertSame('Europe/Rome', $result->getTzId());
+        self::assertSame(120, $result->getTimezoneOffsetMin());
+        self::assertStringContainsString('tz=Europe/Rome', (string) $result->getIndexLog());
+    }
+
+    private function createNormalizer(
+        ?DateTimeZone $resolvedTimezone = null,
+        string $defaultTimezone = 'UTC'
+    ): TimeNormalizer {
+        $timezoneResolver = new class($resolvedTimezone) implements TimezoneResolverInterface {
+            public function __construct(private readonly ?DateTimeZone $timezone)
+            {
+            }
+
+            public function resolveMediaTimezone(Media $media, DateTimeImmutable $takenAt, array $home): DateTimeZone
+            {
+                if ($this->timezone instanceof DateTimeZone) {
+                    return $this->timezone;
+                }
+
+                throw new RuntimeException('No timezone available');
+            }
+
+            public function resolveSummaryTimezone(array $summary, array $home): DateTimeZone
+            {
+                if ($this->timezone instanceof DateTimeZone) {
+                    return $this->timezone;
+                }
+
+                return new DateTimeZone('UTC');
+            }
+
+            public function determineLocalTimezoneOffset(array $offsetVotes, array $home): ?int
+            {
+                return null;
+            }
+
+            public function determineLocalTimezoneIdentifier(array $identifierVotes, array $home, ?int $offset): string
+            {
+                if ($this->timezone instanceof DateTimeZone) {
+                    return $this->timezone->getName();
+                }
+
+                return 'UTC';
+            }
+        };
+
+        $captureTimeResolver = new CaptureTimeResolver($timezoneResolver);
+
+        return new TimeNormalizer(
+            captureTimeResolver: $captureTimeResolver,
+            defaultTimezone: $defaultTimezone,
+            filenameDateParser: new FilenameDateParser(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a time normalizer that keeps EXIF/QuickTime capture timestamps and falls back to filename patterns or file mtimes
- register the normalizer with a configurable default timezone and reusable filename date parser
- extend metadata unit tests to cover priority handling, timezone enrichment, and log summaries

## Testing
- composer ci:test *(fails: phpstan reports pre-existing strictness violations across scoring utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68e1385b0a848323b66b8502d9db6903