### PR TITLE
Add hash tracking for home geo features

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -30,6 +30,8 @@ MEMORIES_HOME_LAT=
 MEMORIES_HOME_LON=
 # Radius around the home location (in kilometres) that still counts as being at home.
 MEMORIES_HOME_RADIUS_KM=15
+# Optional version seed that forces recomputation of cached home metrics.
+MEMORIES_HOME_VERSION_HASH=
 
 # --- Clustering ---
 # Maximum number of media entries stored per cluster after consolidation.

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -10,6 +10,9 @@ parameters:
     memories.hash.dct_sample: 32
     memories.hash.lowfreq: 8
 
+    # Home configuration
+    memories.home.version_hash: '%env(default::string:MEMORIES_HOME_VERSION_HASH)%'
+
     # Geocoding Defaults
     memories.geocoding.nominatim.base_url: '%env(string:NOMINATIM_BASE_URL)%'
     memories.geocoding.nominatim.email:    '%env(string:NOMINATIM_EMAIL)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -126,6 +126,8 @@ services:
         arguments:
             $homeLat: '%env(float:MEMORIES_HOME_LAT)%'
             $homeLon: '%env(float:MEMORIES_HOME_LON)%'
+            $homeRadiusKm: '%env(default::float:MEMORIES_HOME_RADIUS_KM)%'
+            $homeVersionHash: '%memories.home.version_hash%'
             $cellDegrees: 0.01
 
     MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser: ~

--- a/migrations/Version20250204120000.php
+++ b/migrations/Version20250204120000.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250204120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add home_config_hash column to media table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media ADD home_config_hash VARCHAR(64) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP home_config_hash');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -296,6 +296,12 @@ class Media
     private ?float $distanceKmFromHome = null;
 
     /**
+     * Hash describing the configuration used for home distance calculations.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
+    private ?string $homeConfigHash = null;
+
+    /**
      * Identifier linking related burst captures.
      */
     #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
@@ -1322,6 +1328,24 @@ class Media
     public function setDistanceKmFromHome(?float $v): void
     {
         $this->distanceKmFromHome = $v;
+    }
+
+    /**
+     * Returns the hash describing the home configuration.
+     */
+    public function getHomeConfigHash(): ?string
+    {
+        return $this->homeConfigHash;
+    }
+
+    /**
+     * Stores the hash describing the home configuration.
+     *
+     * @param string|null $hash Hash computed from the home parameters.
+     */
+    public function setHomeConfigHash(?string $hash): void
+    {
+        $this->homeConfigHash = $hash;
     }
 
     /**

--- a/test/Unit/Service/Metadata/GeoFeatureEnricherTest.php
+++ b/test/Unit/Service/Metadata/GeoFeatureEnricherTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher;
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\MediaMath;
+use PHPUnit\Framework\Attributes\Test;
+
+use function floor;
+use function hash;
+use function sprintf;
+
+final class GeoFeatureEnricherTest extends TestCase
+{
+    private const float HOME_LAT = 48.137154;
+
+    private const float HOME_LON = 11.576124;
+
+    private const float HOME_RADIUS_KM = 15.0;
+
+    private const string HOME_VERSION = 'v1';
+
+    private const float CELL_DEGREES = 0.01;
+
+    #[Test]
+    public function recomputesMetricsWhenConfigurationChanges(): void
+    {
+        $media = $this->makeMedia(
+            id: 1,
+            path: '/fixtures/outdated-home.jpg',
+            lat: 48.137154,
+            lon: 11.576124,
+            configure: static function (Media $media): void {
+                $media->setGeoCell8('legacy-cell');
+                $media->setDistanceKmFromHome(42.0);
+                $media->setHomeConfigHash('legacy');
+            },
+        );
+
+        $enricher = $this->createEnricher();
+        $result   = $enricher->extract($media->getPath(), $media);
+
+        $expectedHash = $this->computeHomeConfigHash();
+        $expectedCell = $this->expectedCell(48.137154, 11.576124);
+        $expectedDistance = $this->expectedDistanceKm(48.137154, 11.576124);
+
+        self::assertSame($expectedHash, $result->getHomeConfigHash());
+        self::assertSame($expectedCell, $result->getGeoCell8());
+        self::assertSame($expectedDistance, $result->getDistanceKmFromHome());
+        self::assertTrue($result->needsGeocode());
+    }
+
+    #[Test]
+    public function skipsRecomputeWhenHashMatches(): void
+    {
+        $expectedHash = $this->computeHomeConfigHash();
+
+        $media = $this->makeMedia(
+            id: 2,
+            path: '/fixtures/current-home.jpg',
+            lat: 48.200321,
+            lon: 11.601234,
+            configure: static function (Media $media) use ($expectedHash): void {
+                $media->setGeoCell8('custom-cell');
+                $media->setDistanceKmFromHome(12.5);
+                $media->setHomeConfigHash($expectedHash);
+            },
+        );
+
+        $enricher = $this->createEnricher();
+        $result   = $enricher->extract($media->getPath(), $media);
+
+        self::assertSame($expectedHash, $result->getHomeConfigHash());
+        self::assertSame('custom-cell', $result->getGeoCell8());
+        self::assertSame(12.5, $result->getDistanceKmFromHome());
+        self::assertTrue($result->needsGeocode());
+    }
+
+    #[Test]
+    public function recomputesMissingMetricsWhenHashMatches(): void
+    {
+        $expectedHash = $this->computeHomeConfigHash();
+        $lat          = 48.190123;
+        $lon          = 11.602345;
+
+        $media = $this->makeMedia(
+            id: 3,
+            path: '/fixtures/missing-metrics.jpg',
+            lat: $lat,
+            lon: $lon,
+            configure: static function (Media $media) use ($expectedHash): void {
+                $media->setGeoCell8(null);
+                $media->setDistanceKmFromHome(null);
+                $media->setHomeConfigHash($expectedHash);
+            },
+        );
+
+        $enricher = $this->createEnricher();
+        $result   = $enricher->extract($media->getPath(), $media);
+
+        $expectedCell     = $this->expectedCell($lat, $lon);
+        $expectedDistance = $this->expectedDistanceKm($lat, $lon);
+
+        self::assertSame($expectedHash, $result->getHomeConfigHash());
+        self::assertSame($expectedCell, $result->getGeoCell8());
+        self::assertSame($expectedDistance, $result->getDistanceKmFromHome());
+        self::assertTrue($result->needsGeocode());
+    }
+
+    private function createEnricher(): GeoFeatureEnricher
+    {
+        return new GeoFeatureEnricher(
+            self::HOME_LAT,
+            self::HOME_LON,
+            self::HOME_RADIUS_KM,
+            self::HOME_VERSION,
+            self::CELL_DEGREES,
+        );
+    }
+
+    private function computeHomeConfigHash(): string
+    {
+        return hash(
+            'sha256',
+            sprintf(
+                '%.8f|%.8f|%.8f|%s',
+                self::HOME_LAT,
+                self::HOME_LON,
+                self::HOME_RADIUS_KM,
+                self::HOME_VERSION,
+            ),
+        );
+    }
+
+    private function expectedCell(float $lat, float $lon): string
+    {
+        $rlat = self::CELL_DEGREES * floor($lat / self::CELL_DEGREES);
+        $rlon = self::CELL_DEGREES * floor($lon / self::CELL_DEGREES);
+
+        return sprintf('%.4f,%.4f', $rlat, $rlon);
+    }
+
+    private function expectedDistanceKm(float $lat, float $lon): float
+    {
+        $distanceM = MediaMath::haversineDistanceInMeters(self::HOME_LAT, self::HOME_LON, $lat, $lon);
+
+        return $distanceM / 1000.0;
+    }
+}


### PR DESCRIPTION
## Summary
- add a nullable `home_config_hash` column to the media entity together with a migration
- update `GeoFeatureEnricher` to compare the stored home configuration hash before recomputing geo metrics
- expose a configurable home version hash parameter/env var and add unit coverage for the new behaviour

## Testing
- composer ci:test *(fails: `bin/php` wrapper is missing in the execution environment)*
- php vendor/bin/phpunit --configuration .build/phpunit.xml test/Unit/Service/Metadata/GeoFeatureEnricherTest.php


------
https://chatgpt.com/codex/tasks/task_e_68e13b43b9b4832386b9c351d497b3f2