### PR TITLE
Add saturation clipping quality metric and video poster extraction

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -54,6 +54,8 @@ MEMORIES_PREFERRED_LOCALE=DE
 # --- External tools ---
 # PHP CLI binary used for background slideshow generation (auto-detected if empty).
 MEMORIES_PHP_BINARY=
+# Location of the ffmpeg binary used for generating poster frames and videos.
+FFMPEG_PATH=/usr/bin/ffmpeg
 # Location of the ffprobe binary used for video metadata extraction.
 FFPROBE_PATH=/usr/bin/ffprobe
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # Composer
 vendor/
 bin/
+!test/Unit/Service/Metadata/fixtures/bin/
+!test/Unit/Service/Metadata/fixtures/bin/**
 logs/
 log/
 composer.lock

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -6,6 +6,8 @@ parameters:
     memories.index.video_ext: []
 #    memories.index.video_ext: ['mp4','m4v','mov','3gp','3g2','avi','mkv','webm']
 
+    memories.video.poster_frame_second: 1.0
+
     # Hash Defaults
     memories.hash.dct_sample: 32
     memories.hash.lowfreq: 8

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -147,6 +147,9 @@ services:
     MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor:
         arguments:
             $sampleSize: 320
+            $ffmpegBinary: '%env(default::string:FFMPEG_PATH)%'
+            $ffprobeBinary: '%env(string:FFPROBE_PATH)%'
+            $posterFrameSecond: '%memories.video.poster_frame_second%'
 
     MagicSunday\Memories\Service\Metadata\VisionSceneTagModelInterface:
         alias: MagicSunday\Memories\Service\Metadata\HeuristicClipSceneTagModel

--- a/migrations/Version20250204130000.php
+++ b/migrations/Version20250204130000.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250204130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add quality_clipping column to media table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media ADD quality_clipping DOUBLE PRECISION DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP quality_clipping');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -411,6 +411,12 @@ class Media
     private ?float $colorfulness = null;
 
     /**
+     * Share of pixels affected by saturation clipping in the range [0,1].
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $qualityClipping = null;
+
+    /**
      * Aggregated quality score in the range [0,1].
      */
     #[ORM\Column(type: Types::FLOAT, nullable: true)]
@@ -1728,6 +1734,26 @@ class Media
         $this->qualityNoise = $score === null
             ? null
             : max(0.0, min(1.0, $score));
+    }
+
+    /**
+     * Returns the share of pixels affected by saturation clipping.
+     */
+    public function getQualityClipping(): ?float
+    {
+        return $this->qualityClipping;
+    }
+
+    /**
+     * Sets the share of pixels affected by saturation clipping.
+     *
+     * @param float|null $share Share in the range [0,1].
+     */
+    public function setQualityClipping(?float $share): void
+    {
+        $this->qualityClipping = $share === null
+            ? null
+            : max(0.0, min(1.0, $share));
     }
 
     /**

--- a/test/Unit/Service/Metadata/VisionSignatureExtractorTest.php
+++ b/test/Unit/Service/Metadata/VisionSignatureExtractorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Quality\MediaQualityAggregator;
+use MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function file_put_contents;
+use function filesize;
+use function imagecolorallocate;
+use function imagecreatetruecolor;
+use function imagefilledrectangle;
+use function imagepng;
+use function imagedestroy;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class VisionSignatureExtractorTest extends TestCase
+{
+    #[Test]
+    public function computesClippingForSaturatedImage(): void
+    {
+        $imagePath = $this->createSaturatedImage();
+
+        try {
+            $media = $this->makeMedia(
+                id: 101,
+                path: $imagePath,
+                configure: function (Media $media): void {
+                    $media->setMime('image/png');
+                    $media->setWidth(4000);
+                    $media->setHeight(3000);
+                    $media->setIso(100);
+                },
+                size: (int) filesize($imagePath),
+            );
+
+            $extractor = new VisionSignatureExtractor(new MediaQualityAggregator(), 16);
+            $extractor->extract($imagePath, $media);
+
+            self::assertNotNull($media->getQualityClipping());
+            self::assertEqualsWithDelta(1.0, $media->getQualityClipping() ?? 0.0, 0.0005);
+            self::assertTrue($media->isLowQuality());
+
+            $log = $media->getIndexLog();
+            self::assertNotNull($log);
+            self::assertStringContainsString('clip=1.00', $log);
+        } finally {
+            unlink($imagePath);
+        }
+    }
+
+    #[Test]
+    public function usesPosterFrameForVideo(): void
+    {
+        $videoBase = tempnam(sys_get_temp_dir(), 'vid_');
+        if ($videoBase === false) {
+            self::fail('Unable to create temporary video fixture.');
+        }
+
+        $videoPath = $videoBase . '.mp4';
+        unlink($videoBase);
+        file_put_contents($videoPath, 'dummy');
+
+        $ffmpeg  = $this->fixturePath('bin/mock-ffmpeg');
+        $ffprobe = $this->fixturePath('bin/mock-ffprobe');
+
+        try {
+            $media = $this->makeMedia(
+                id: 102,
+                path: $videoPath,
+                configure: function (Media $media): void {
+                    $media->setMime('video/mp4');
+                    $media->setIsVideo(true);
+                    $media->setWidth(3840);
+                    $media->setHeight(2160);
+                    $media->setIso(100);
+                },
+                size: (int) filesize($videoPath),
+            );
+
+            $extractor = new VisionSignatureExtractor(
+                new MediaQualityAggregator(),
+                16,
+                $ffmpeg,
+                $ffprobe,
+                1.0,
+            );
+
+            $extractor->extract($videoPath, $media);
+
+            self::assertNotNull($media->getQualityClipping());
+            self::assertEqualsWithDelta(1.0, $media->getQualityClipping() ?? 0.0, 0.0005);
+            self::assertTrue($media->isLowQuality());
+
+            $log = $media->getIndexLog();
+            self::assertNotNull($log);
+            self::assertStringContainsString('qlt=low', $log);
+            self::assertStringContainsString('clip=1.00', $log);
+        } finally {
+            unlink($videoPath);
+        }
+    }
+
+    private function createSaturatedImage(): string
+    {
+        $base = tempnam(sys_get_temp_dir(), 'img_');
+        if ($base === false) {
+            self::fail('Unable to create temporary image fixture.');
+        }
+
+        $path = $base . '.png';
+        unlink($base);
+
+        $image = imagecreatetruecolor(8, 8);
+        $red   = imagecolorallocate($image, 255, 0, 0);
+        imagefilledrectangle($image, 0, 0, 7, 7, $red);
+
+        if (imagepng($image, $path) !== true) {
+            imagedestroy($image);
+            self::fail('Unable to write saturated image fixture.');
+        }
+
+        imagedestroy($image);
+
+        return $path;
+    }
+}

--- a/test/Unit/Service/Metadata/fixtures/bin/mock-ffmpeg
+++ b/test/Unit/Service/Metadata/fixtures/bin/mock-ffmpeg
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Minimal ffmpeg stub used during unit tests to emit a JPEG poster frame.
+ */
+
+$args = $_SERVER['argv'];
+if (count($args) < 2) {
+    fwrite(STDERR, "missing output path\n");
+    exit(1);
+}
+
+$output = $args[count($args) - 1];
+
+$image = imagecreatetruecolor(8, 8);
+$red   = imagecolorallocate($image, 255, 0, 0);
+imagefilledrectangle($image, 0, 0, 7, 7, $red);
+
+if (imagejpeg($image, $output) !== true) {
+    fwrite(STDERR, "failed to write poster\n");
+    imagedestroy($image);
+    exit(1);
+}
+
+imagedestroy($image);
+exit(0);

--- a/test/Unit/Service/Metadata/fixtures/bin/mock-ffprobe
+++ b/test/Unit/Service/Metadata/fixtures/bin/mock-ffprobe
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Minimal ffprobe stub used during unit tests.
+ */
+
+fwrite(STDOUT, "2.0\n");


### PR DESCRIPTION
## Summary
- add a quality_clipping column on media including migration and entity accessors
- extend the vision signature extractor to derive saturation clipping and create poster frames for videos via ffmpeg/ffprobe while wiring new configuration defaults
- adjust the media quality aggregator to penalize clipping, append index log summaries, and cover the behaviour with new unit tests and fixtures

## Testing
- composer ci:test *(fails: bin/php is not available in the container)*
- php vendor/bin/phpunit --configuration .build/phpunit.xml *(fails: existing suite expects slideshow manager and thumbnail internals unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e13cbaa380832380b257be93fb4373