### PR TITLE
Add 128-bit perceptual hashing with video poster frames

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -6,11 +6,14 @@ parameters:
     memories.index.video_ext: []
 #    memories.index.video_ext: ['mp4','m4v','mov','3gp','3g2','avi','mkv','webm']
 
-    memories.video.poster_frame_second: 1.0
+    memories.video.poster_frame_second: 1.5
+    memories.video.ffmpeg_path: '%env(default::string:FFMPEG_PATH)%'
+    memories.video.ffprobe_path: '%env(default::string:FFPROBE_PATH)%'
 
     # Hash Defaults
     memories.hash.dct_sample: 32
-    memories.hash.lowfreq: 8
+    memories.hash.lowfreq: 16
+    memories.hash.phash_prefix_length: 16
 
     # Home configuration
     memories.home.version_hash: '%env(default::string:MEMORIES_HOME_VERSION_HASH)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -147,8 +147,8 @@ services:
     MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor:
         arguments:
             $sampleSize: 320
-            $ffmpegBinary: '%env(default::string:FFMPEG_PATH)%'
-            $ffprobeBinary: '%env(string:FFPROBE_PATH)%'
+            $ffmpegBinary: '%memories.video.ffmpeg_path%'
+            $ffprobeBinary: '%memories.video.ffprobe_path%'
             $posterFrameSecond: '%memories.video.poster_frame_second%'
 
     MagicSunday\Memories\Service\Metadata\VisionSceneTagModelInterface:
@@ -170,6 +170,10 @@ services:
         arguments:
             $dctSampleSize: '%memories.hash.dct_sample%'
             $lowFreqSize: '%memories.hash.lowfreq%'
+            $phashPrefixLength: '%memories.hash.phash_prefix_length%'
+            $ffmpegBinary: '%memories.video.ffmpeg_path%'
+            $ffprobeBinary: '%memories.video.ffprobe_path%'
+            $posterFrameSecond: '%memories.video.poster_frame_second%'
 
     MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor:
         arguments:
@@ -890,7 +894,9 @@ services:
 
     MagicSunday\Memories\Service\Feed\DefaultCoverPicker: ~
 
-    MagicSunday\Memories\Repository\MediaRepository: ~
+    MagicSunday\Memories\Repository\MediaRepository:
+        arguments:
+            $phashPrefixLength: '%memories.hash.phash_prefix_length%'
 
     MagicSunday\Memories\Service\Feed\MemoryFeedBuilder:
         arguments:

--- a/migrations/Version20250304000000.php
+++ b/migrations/Version20250304000000.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250304000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Expand phashPrefix column to 32 characters for 128-bit hashes.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media CHANGE phashPrefix phashPrefix VARCHAR(32) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media CHANGE phashPrefix phashPrefix VARCHAR(16) DEFAULT NULL');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -449,17 +449,17 @@ class Media
     /**
      * Prefix of the perceptual hash for quick similarity checks.
      */
-    #[ORM\Column(type: Types::STRING, length: 16, nullable: true)]
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
     private ?string $phashPrefix = null;
 
     /**
-     * Complete perceptual hash of the media.
+     * Complete perceptual hash of the media (128-bit hexadecimal string).
      */
     #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
     private ?string $phash = null;
 
     /**
-     * Complete perceptual hash represented as an unsigned 64-bit integer.
+     * High 64 bits of the perceptual hash represented as an unsigned integer string.
      */
     #[ORM\Column(type: Types::BIGINT, nullable: true, options: ['unsigned' => true])]
     private ?string $phash64 = null;
@@ -827,7 +827,14 @@ class Media
      */
     public function setPhash(?string $phash): void
     {
-        $this->phash = $phash;
+        if ($phash === null) {
+            $this->phash = null;
+
+            return;
+        }
+
+        $hash = strtolower($phash);
+        $this->phash = substr($hash, 0, 32);
     }
 
     /**
@@ -1805,7 +1812,13 @@ class Media
      */
     public function setPhashPrefix(?string $v): void
     {
-        $this->phashPrefix = $v === null ? null : substr($v, 0, 16);
+        if ($v === null) {
+            $this->phashPrefix = null;
+
+            return;
+        }
+
+        $this->phashPrefix = substr(strtolower($v), 0, 32);
     }
 
     /**

--- a/src/Service/Metadata/Support/VideoPosterFrameTrait.php
+++ b/src/Service/Metadata/Support/VideoPosterFrameTrait.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+use function is_file;
+use function is_numeric;
+use function is_string;
+use function max;
+use function min;
+use function sprintf;
+use function str_starts_with;
+use function sys_get_temp_dir;
+use function tempnam;
+use function trim;
+use function unlink;
+
+/**
+ * Shared helper to extract poster frames from videos via ffmpeg/ffprobe.
+ */
+trait VideoPosterFrameTrait
+{
+    private function isVideoMedia(Media $media): bool
+    {
+        if ($media->isVideo()) {
+            return true;
+        }
+
+        $mime = $media->getMime();
+
+        return is_string($mime) && str_starts_with($mime, 'video/');
+    }
+
+    private function createPosterFrame(string $videoPath): ?string
+    {
+        if (!is_file($videoPath)) {
+            return null;
+        }
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'mem_poster_');
+        if (!is_string($tempFile)) {
+            return null;
+        }
+
+        $posterPath = $tempFile . '.jpg';
+        if (is_file($tempFile)) {
+            unlink($tempFile);
+        }
+
+        $targetTime = $this->resolvePosterTime($videoPath);
+
+        $command = [$this->ffmpegBinary, '-y', '-loglevel', 'error'];
+
+        if ($targetTime > 0.0) {
+            $command[] = '-ss';
+            $command[] = sprintf('%.3f', $targetTime);
+        }
+
+        $command[] = '-i';
+        $command[] = $videoPath;
+        $command[] = '-frames:v';
+        $command[] = '1';
+        $command[] = $posterPath;
+
+        $process = new Process($command);
+        $process->setTimeout(20.0);
+
+        try {
+            $process->run();
+        } catch (Throwable) {
+            $this->cleanupPosterFrame($posterPath);
+
+            return null;
+        }
+
+        if (!$process->isSuccessful() || !is_file($posterPath)) {
+            $this->cleanupPosterFrame($posterPath);
+
+            return null;
+        }
+
+        return $posterPath;
+    }
+
+    private function cleanupPosterFrame(?string $posterPath): void
+    {
+        if (is_string($posterPath) && $posterPath !== '' && is_file($posterPath)) {
+            unlink($posterPath);
+        }
+    }
+
+    private function resolvePosterTime(string $videoPath): float
+    {
+        $targetTime = max(0.0, min(2.0, $this->posterFrameSecond));
+        if ($targetTime < 1.0) {
+            $targetTime = 1.0;
+        }
+
+        $duration = $this->probeVideoDuration($videoPath);
+        if ($duration !== null && $duration > 0.0 && $targetTime > $duration) {
+            $targetTime = max(0.0, $duration - 0.1);
+        }
+
+        return $targetTime;
+    }
+
+    private function probeVideoDuration(string $videoPath): ?float
+    {
+        $process = new Process([
+            $this->ffprobeBinary,
+            '-v',
+            'error',
+            '-select_streams',
+            'v:0',
+            '-show_entries',
+            'format=duration',
+            '-of',
+            'default=noprint_wrappers=1:nokey=1',
+            $videoPath,
+        ]);
+        $process->setTimeout(10.0);
+
+        try {
+            $process->run();
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (!$process->isSuccessful()) {
+            return null;
+        }
+
+        $output = $process->getOutput();
+        if ($output === '') {
+            $output = $process->getErrorOutput();
+        }
+
+        $output = trim($output);
+        if ($output === '') {
+            return null;
+        }
+
+        if (!is_numeric($output)) {
+            return null;
+        }
+
+        $duration = (float) $output;
+
+        return $duration > 0.0 ? $duration : null;
+    }
+}

--- a/test/Unit/Entity/MediaPhashPrefixTest.php
+++ b/test/Unit/Entity/MediaPhashPrefixTest.php
@@ -17,15 +17,15 @@ use PHPUnit\Framework\Attributes\Test;
 final class MediaPhashPrefixTest extends TestCase
 {
     #[Test]
-    public function truncatesPhashPrefixToSixteenCharacters(): void
+    public function truncatesPhashPrefixToThirtyTwoCharacters(): void
     {
         $media = $this->makeMedia(
             id: 201,
             path: '/library/phash-prefix.jpg',
         );
 
-        $media->setPhashPrefix('0123456789abcdefcafebabe');
+        $media->setPhashPrefix('0123456789abcdefcafebabe112233445566');
 
-        self::assertSame('0123456789abcdef', $media->getPhashPrefix());
+        self::assertSame('0123456789abcdefcafebabe11223344', $media->getPhashPrefix());
     }
 }

--- a/test/Unit/Repository/MediaRepositoryTest.php
+++ b/test/Unit/Repository/MediaRepositoryTest.php
@@ -37,8 +37,8 @@ final class MediaRepositoryTest extends TestCase
             ->with(
                 self::callback(static fn (string $sql): bool => str_contains($sql, 'phashPrefix = :phashPrefix')),
                 [
-                    'phashHex'    => 'abcdef',
-                    'phashPrefix' => 'abcdef',
+                    'phashHex'    => 'abcdef0123456789',
+                    'phashPrefix' => 'abcdef0123456789',
                     'maxHamming'  => 3,
                     'limit'       => 5,
                 ],
@@ -64,9 +64,9 @@ final class MediaRepositoryTest extends TestCase
                 [Media::class, 11, null, null, $mediaB],
             ]);
 
-        $repository = new MediaRepository($em);
+        $repository = new MediaRepository($em, 16);
 
-        $result = $repository->findNearestByPhash('ABCDEF', 3, 5);
+        $result = $repository->findNearestByPhash('ABCDEF0123456789ABCDEF0123456789', 3, 5);
 
         self::assertCount(2, $result);
         self::assertSame($mediaA, $result[0]['media']);

--- a/test/Unit/Service/Metadata/PerceptualHashExtractorTest.php
+++ b/test/Unit/Service/Metadata/PerceptualHashExtractorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function file_put_contents;
+use function imagecolorallocate;
+use function imagecreatetruecolor;
+use function imagefilledrectangle;
+use function imagejpeg;
+use function imagedestroy;
+use function is_file;
+use function strlen;
+use function substr;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class PerceptualHashExtractorTest extends TestCase
+{
+    #[Test]
+    public function computesStable128BitHashForImage(): void
+    {
+        $imagePath = $this->createGradientImage();
+
+        try {
+            $media = $this->makeMedia(
+                id: 501,
+                path: $imagePath,
+                configure: static function (Media $media): void {
+                    $media->setMime('image/jpeg');
+                    $media->setWidth(64);
+                    $media->setHeight(64);
+                },
+            );
+
+            $extractor = new PerceptualHashExtractor(32, 16, 16);
+            $extractor->extract($imagePath, $media);
+
+            $phash = $media->getPhash();
+            self::assertNotNull($phash);
+            self::assertSame(32, strlen($phash ?? ''));
+            self::assertSame('942a01442c9b996343c1becc632c9a7b', $phash);
+
+            $prefix = $media->getPhashPrefix();
+            self::assertSame(substr($phash, 0, 16), $prefix);
+
+            $phash64 = $media->getPhash64();
+            self::assertNotNull($phash64);
+            self::assertMatchesRegularExpression('/^\d+$/', $phash64 ?? '');
+        } finally {
+            unlink($imagePath);
+        }
+    }
+
+    #[Test]
+    public function hashesVideoViaPosterFrame(): void
+    {
+        $videoBase = tempnam(sys_get_temp_dir(), 'vid_');
+        if ($videoBase === false) {
+            self::fail('Unable to create temporary video fixture.');
+        }
+
+        $videoPath = $videoBase . '.mp4';
+        unlink($videoBase);
+
+        // Placeholder payload – ffmpeg stub ignores contents.
+        file_put_contents($videoPath, 'video');
+
+        $ffmpeg  = $this->fixturePath('bin/mock-ffmpeg');
+        $ffprobe = $this->fixturePath('bin/mock-ffprobe');
+
+        try {
+            $media = $this->makeMedia(
+                id: 502,
+                path: $videoPath,
+                configure: static function (Media $media): void {
+                    $media->setMime('video/mp4');
+                    $media->setIsVideo(true);
+                    $media->setWidth(1920);
+                    $media->setHeight(1080);
+                },
+            );
+
+            $extractor = new PerceptualHashExtractor(32, 16, 16, $ffmpeg, $ffprobe, 1.5);
+            $extractor->extract($videoPath, $media);
+
+            $phash = $media->getPhash();
+            self::assertSame('d059af7420d10949cfd82a170af08d0d', $phash);
+            self::assertSame(substr($phash, 0, 16), $media->getPhashPrefix());
+            self::assertNotNull($media->getPhash64());
+        } finally {
+            if (is_file($videoPath)) {
+                unlink($videoPath);
+            }
+        }
+    }
+
+    private function createGradientImage(): string
+    {
+        $base = tempnam(sys_get_temp_dir(), 'hash_');
+        if ($base === false) {
+            self::fail('Unable to create temporary image.');
+        }
+
+        $path = $base . '.jpg';
+        unlink($base);
+
+        $image = imagecreatetruecolor(64, 64);
+        for ($y = 0; $y < 64; ++$y) {
+            for ($x = 0; $x < 64; ++$x) {
+                $gray = (int) (($x + $y) % 256);
+                $color = imagecolorallocate($image, $gray, $gray, $gray);
+                imagefilledrectangle($image, $x, $y, $x, $y, $color);
+            }
+        }
+
+        if (imagejpeg($image, $path, 90) !== true) {
+            imagedestroy($image);
+            self::fail('Unable to write gradient image.');
+        }
+
+        imagedestroy($image);
+
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- extend the perceptual hash extractor to compute 128-bit hashes, derive the high 64-bit integer, and support video poster-frame hashing via ffmpeg
- share video poster-frame handling through a reusable trait and wire optional ffmpeg/ffprobe paths plus the configurable hash prefix length
- widen Media persistence for the new hash prefix, adjust the repository lookup, add a schema migration, and cover the new behaviour with dedicated unit tests

## Testing
- `php vendor/bin/phpunit --configuration .build/phpunit.xml test/Unit/Service/Metadata/PerceptualHashExtractorTest.php`
- `php vendor/bin/phpunit --configuration .build/phpunit.xml test/Unit/Service/Metadata/VisionSignatureExtractorTest.php`
- `composer ci:test:php:unit` *(fails: existing suite still expects slideshow and thumbnail fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e1424401148323bb437f7f5e63667f