### PR TITLE
Add heuristic burst grouping and live pair pairing

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -183,6 +183,8 @@ services:
                 - '@MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor'
+                - '@MagicSunday\Memories\Service\Metadata\BurstDetector'
+                - '@MagicSunday\Memories\Service\Metadata\LivePairLinker'
                 - '@MagicSunday\Memories\Service\Metadata\BurstIndexExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\TimeNormalizer'

--- a/src/Service/Metadata/BurstDetector.php
+++ b/src/Service/Metadata/BurstDetector.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+
+use function abs;
+use function array_map;
+use function count;
+use function implode;
+use function is_string;
+use function sha1;
+use function str_starts_with;
+use function strcmp;
+use function substr;
+use function trim;
+use function usort;
+
+/**
+ * Detects burst groups heuristically based on capture time and perceptual hash.
+ */
+final class BurstDetector implements SingleMetadataExtractorInterface
+{
+    public function __construct(private readonly MediaRepository $mediaRepository)
+    {
+    }
+
+    public function supports(string $filepath, Media $media): bool
+    {
+        $mime = $media->getMime();
+
+        return is_string($mime) && (str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/'));
+    }
+
+    public function extract(string $filepath, Media $media): Media
+    {
+        if ($media->getBurstUuid() !== null) {
+            return $media;
+        }
+
+        $takenAt = $media->getTakenAt();
+        $phash   = $media->getPhash();
+
+        if (!$takenAt instanceof DateTimeImmutable || $phash === null || trim($phash) === '') {
+            return $media;
+        }
+
+        $members = $this->collectMembers($media, $takenAt, $phash);
+        if (count($members) < 2) {
+            return $media;
+        }
+
+        $sorted  = $this->sortMembers($members);
+        $burstId = $this->buildBurstIdentifier($sorted);
+
+        foreach ($sorted as $index => $member) {
+            if ($member->getBurstUuid() === null) {
+                $member->setBurstUuid($burstId);
+            }
+
+            if ($member->getBurstIndex() === null) {
+                $member->setBurstIndex($index);
+            }
+        }
+
+        return $media;
+    }
+
+    /**
+     * @return list<Media>
+     */
+    private function collectMembers(Media $media, DateTimeImmutable $takenAt, string $phash): array
+    {
+        $seenPaths = [$media->getPath() => true];
+        $members   = [$media];
+
+        $candidates = $this->mediaRepository->findNearestByPhash($phash, 8, 16);
+        foreach ($candidates as $candidateRow) {
+            $candidate = $candidateRow['media'];
+            if (!$candidate instanceof Media) {
+                continue;
+            }
+
+            $path = $candidate->getPath();
+            if (isset($seenPaths[$path])) {
+                continue;
+            }
+
+            $candidateTaken = $candidate->getTakenAt();
+            if (!$candidateTaken instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            if ($this->secondsBetween($takenAt, $candidateTaken) > 3) {
+                continue;
+            }
+
+            if ($candidate->getBurstUuid() !== null) {
+                continue;
+            }
+
+            $seenPaths[$path] = true;
+            $members[]        = $candidate;
+        }
+
+        return $members;
+    }
+
+    /**
+     * @param list<Media> $members
+     *
+     * @return list<Media>
+     */
+    private function sortMembers(array $members): array
+    {
+        usort(
+            $members,
+            static function (Media $left, Media $right): int {
+                $leftTaken  = $left->getTakenAt();
+                $rightTaken = $right->getTakenAt();
+
+                if ($leftTaken instanceof DateTimeImmutable && $rightTaken instanceof DateTimeImmutable) {
+                    $cmp = $leftTaken->getTimestamp() <=> $rightTaken->getTimestamp();
+                    if ($cmp !== 0) {
+                        return $cmp;
+                    }
+                }
+
+                return strcmp($left->getChecksum(), $right->getChecksum());
+            }
+        );
+
+        return $members;
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    private function buildBurstIdentifier(array $members): string
+    {
+        $parts = array_map(
+            static function (Media $item): string {
+                $takenAt = $item->getTakenAt();
+                $stamp   = $takenAt instanceof DateTimeImmutable ? $takenAt->format(DateTimeImmutable::ATOM) : '0';
+
+                return $stamp . ':' . $item->getChecksum();
+            },
+            $members
+        );
+
+        return 'heuristic-burst-' . substr(sha1(implode('|', $parts)), 0, 16);
+    }
+
+    private function secondsBetween(DateTimeImmutable $a, DateTimeImmutable $b): int
+    {
+        return abs($a->getTimestamp() - $b->getTimestamp());
+    }
+}

--- a/src/Service/Metadata/BurstIndexExtractor.php
+++ b/src/Service/Metadata/BurstIndexExtractor.php
@@ -12,25 +12,20 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Metadata;
 
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Repository\MediaRepository;
-
 use function is_string;
 use function ltrim;
 use function pathinfo;
-use function preg_replace;
 use function preg_match;
+use function preg_replace;
 use function str_starts_with;
 
 use const PATHINFO_FILENAME;
 
 /**
- * Derives burst indices and links live photo pairs.
+ * Derives burst indices from existing metadata.
  */
 final class BurstIndexExtractor implements SingleMetadataExtractorInterface
 {
-    public function __construct(private readonly MediaRepository $mediaRepository)
-    {
-    }
 
     public function supports(string $filepath, Media $media): bool
     {
@@ -45,8 +40,6 @@ final class BurstIndexExtractor implements SingleMetadataExtractorInterface
         if ($index !== null) {
             $media->setBurstIndex($index);
         }
-
-        $this->linkLivePair($media);
 
         return $media;
     }
@@ -80,24 +73,6 @@ final class BurstIndexExtractor implements SingleMetadataExtractorInterface
         }
 
         return null;
-    }
-
-    private function linkLivePair(Media $media): void
-    {
-        $checksum = $media->getLivePairChecksum();
-        if ($checksum === null || $checksum === '') {
-            return;
-        }
-
-        $counterpart = $this->mediaRepository->findLivePairCandidate($checksum, $media->getPath());
-        if (!$counterpart instanceof Media) {
-            return;
-        }
-
-        $media->setLivePairMedia($counterpart);
-        if ($counterpart->getLivePairMedia() === null) {
-            $counterpart->setLivePairMedia($media);
-        }
     }
 
     private function normaliseIndex(string $digits): int

--- a/src/Service/Metadata/LivePairLinker.php
+++ b/src/Service/Metadata/LivePairLinker.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+
+use function abs;
+use function array_map;
+use function implode;
+use function is_string;
+use function sha1;
+use function str_starts_with;
+use function trim;
+use function usort;
+
+/**
+ * Links photo/video live pairs using Apple metadata and heuristic fallbacks.
+ */
+final class LivePairLinker implements SingleMetadataExtractorInterface
+{
+    public function __construct(private readonly MediaRepository $mediaRepository)
+    {
+    }
+
+    public function supports(string $filepath, Media $media): bool
+    {
+        $mime = $media->getMime();
+
+        return is_string($mime) && (str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/'));
+    }
+
+    public function extract(string $filepath, Media $media): Media
+    {
+        $this->linkApplePair($media);
+
+        if ($media->getLivePairMedia() instanceof Media) {
+            return $media;
+        }
+
+        $this->linkHeuristicPair($media);
+
+        return $media;
+    }
+
+    private function linkApplePair(Media $media): void
+    {
+        $checksum = $media->getLivePairChecksum();
+        if ($checksum === null || trim($checksum) === '') {
+            return;
+        }
+
+        $counterpart = $this->mediaRepository->findLivePairCandidate($checksum, $media->getPath());
+        if (!$counterpart instanceof Media) {
+            return;
+        }
+
+        $this->establishPair($media, $counterpart, $checksum);
+    }
+
+    private function linkHeuristicPair(Media $media): void
+    {
+        $takenAt = $media->getTakenAt();
+        $phash   = $media->getPhash();
+
+        if (!$takenAt instanceof DateTimeImmutable || $phash === null || trim($phash) === '') {
+            return;
+        }
+
+        $candidates = $this->mediaRepository->findNearestByPhash($phash, 8, 16);
+        $best       = null;
+        $bestScore  = null;
+
+        foreach ($candidates as $row) {
+            $candidate = $row['media'];
+            if (!$candidate instanceof Media) {
+                continue;
+            }
+
+            if ($candidate->getPath() === $media->getPath()) {
+                continue;
+            }
+
+            if ($candidate->isVideo() === $media->isVideo()) {
+                continue;
+            }
+
+            if ($candidate->isNoShow()) {
+                continue;
+            }
+
+            $candidateTaken = $candidate->getTakenAt();
+            if (!$candidateTaken instanceof DateTimeImmutable) {
+                continue;
+            }
+
+            $timeDiff = $this->secondsBetween($takenAt, $candidateTaken);
+            if ($timeDiff > 3) {
+                continue;
+            }
+
+            if ($this->hasConflictingPair($media, $candidate)) {
+                continue;
+            }
+
+            $distance = (int) ($row['distance'] ?? 0);
+            if ($distance > 8) {
+                continue;
+            }
+
+            $score = $timeDiff * 100 + $distance;
+            if ($bestScore === null || $score < $bestScore) {
+                $best      = $candidate;
+                $bestScore = $score;
+            }
+        }
+
+        if (!$best instanceof Media) {
+            return;
+        }
+
+        $checksum = $media->getLivePairChecksum();
+        if ($checksum === null || trim($checksum) === '') {
+            $counterChecksum = $best->getLivePairChecksum();
+            if ($counterChecksum === null || trim($counterChecksum) === '') {
+                $checksum = $this->buildHeuristicChecksum($media, $best);
+            } else {
+                $checksum = $counterChecksum;
+            }
+        }
+
+        $this->establishPair($media, $best, $checksum);
+    }
+
+    private function hasConflictingPair(Media $media, Media $candidate): bool
+    {
+        $existing = $candidate->getLivePairMedia();
+        if ($existing instanceof Media && $existing !== $media) {
+            return true;
+        }
+
+        $mediaChecksum     = $media->getLivePairChecksum();
+        $candidateChecksum = $candidate->getLivePairChecksum();
+
+        return $mediaChecksum !== null
+            && $candidateChecksum !== null
+            && trim($mediaChecksum) !== ''
+            && trim($candidateChecksum) !== ''
+            && $mediaChecksum !== $candidateChecksum;
+    }
+
+    private function establishPair(Media $media, Media $counterpart, string $checksum): void
+    {
+        if ($media->getLivePairChecksum() === null || trim($media->getLivePairChecksum()) === '') {
+            $media->setLivePairChecksum($checksum);
+        }
+
+        if ($counterpart->getLivePairChecksum() === null || trim($counterpart->getLivePairChecksum()) === '') {
+            $counterpart->setLivePairChecksum($checksum);
+        }
+
+        $media->setLivePairMedia($counterpart);
+        if ($counterpart->getLivePairMedia() !== $media) {
+            $counterpart->setLivePairMedia($media);
+        }
+    }
+
+    private function buildHeuristicChecksum(Media $a, Media $b): string
+    {
+        $pair = [$a, $b];
+        usort(
+            $pair,
+            static fn (Media $left, Media $right): int => $left->getId() <=> $right->getId()
+        );
+
+        $parts = array_map(static fn (Media $item): string => $item->getChecksum(), $pair);
+
+        return sha1('heuristic-live|' . implode('|', $parts));
+    }
+
+    private function secondsBetween(DateTimeImmutable $a, DateTimeImmutable $b): int
+    {
+        return abs($a->getTimestamp() - $b->getTimestamp());
+    }
+}

--- a/test/Unit/Service/Metadata/BurstDetectorTest.php
+++ b/test/Unit/Service/Metadata/BurstDetectorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Metadata\BurstDetector;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class BurstDetectorTest extends TestCase
+{
+    #[Test]
+    public function skipsMediaWithExistingBurstInformation(): void
+    {
+        $media = $this->makeMedia(1, 'photo.heic', '2024-02-02T12:00:00+00:00', configure: static function (Media $media): void {
+            $media->setMime('image/heic');
+            $media->setBurstUuid('apple-burst');
+        });
+
+        $repository = $this->createMock(MediaRepository::class);
+        $repository->expects(self::never())->method('findNearestByPhash');
+
+        $detector = new BurstDetector($repository);
+
+        $result = $detector->extract($media->getPath(), $media);
+
+        self::assertSame('apple-burst', $result->getBurstUuid());
+    }
+
+    #[Test]
+    public function assignsBurstUuidAndIndexHeuristically(): void
+    {
+        $baseTime = '2024-02-02T12:00:00+00:00';
+
+        $media = $this->makeMedia(2, 'burst-1.heic', $baseTime, configure: static function (Media $media): void {
+            $media->setMime('image/heic');
+            $media->setPhash('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+        });
+
+        $neighbor = $this->makeMedia(3, 'burst-2.heic', '2024-02-02T12:00:02+00:00', configure: static function (Media $media): void {
+            $media->setMime('image/heic');
+            $media->setPhash('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+        });
+
+        $far = $this->makeMedia(4, 'other.heic', '2024-02-02T12:00:10+00:00', configure: static function (Media $media): void {
+            $media->setMime('image/heic');
+            $media->setBurstUuid('keep-existing');
+        });
+
+        $repository = $this->createMock(MediaRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findNearestByPhash')
+            ->with('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 8, 16)
+            ->willReturn([
+                ['media' => $neighbor, 'distance' => 3],
+                ['media' => $far, 'distance' => 1],
+            ]);
+
+        $detector = new BurstDetector($repository);
+
+        $detector->extract($media->getPath(), $media);
+
+        $burstId = $media->getBurstUuid();
+        self::assertNotNull($burstId);
+        self::assertStringStartsWith('heuristic-burst-', $burstId);
+        self::assertSame($burstId, $neighbor->getBurstUuid());
+        self::assertSame(0, $media->getBurstIndex());
+        self::assertSame(1, $neighbor->getBurstIndex());
+        self::assertSame('keep-existing', $far->getBurstUuid());
+    }
+}

--- a/test/Unit/Service/Metadata/LivePairLinkerTest.php
+++ b/test/Unit/Service/Metadata/LivePairLinkerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Metadata\LivePairLinker;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class LivePairLinkerTest extends TestCase
+{
+    #[Test]
+    public function linksCounterpartViaAppleChecksum(): void
+    {
+        $photo = $this->makeMedia(10, 'IMG_0001.HEIC', '2024-01-01T10:00:00+00:00', configure: static function (Media $media): void {
+            $media->setMime('image/heic');
+            $media->setLivePairChecksum('apple-checksum');
+        });
+
+        $video = $this->makeMedia(11, 'IMG_0001.MOV', '2024-01-01T10:00:00+00:00', configure: static function (Media $media): void {
+            $media->setMime('video/quicktime');
+            $media->setIsVideo(true);
+        });
+
+        $repository = $this->createMock(MediaRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findLivePairCandidate')
+            ->with('apple-checksum', $photo->getPath())
+            ->willReturn($video);
+        $repository
+            ->expects(self::never())
+            ->method('findNearestByPhash');
+
+        $linker = new LivePairLinker($repository);
+
+        $linker->extract($photo->getPath(), $photo);
+
+        self::assertSame($video, $photo->getLivePairMedia());
+        self::assertSame($photo, $video->getLivePairMedia());
+        self::assertSame('apple-checksum', $photo->getLivePairChecksum());
+        self::assertSame('apple-checksum', $video->getLivePairChecksum());
+    }
+
+    #[Test]
+    public function pairsPhotoAndVideoHeuristically(): void
+    {
+        $photo = $this->makeMedia(20, 'LivePhoto.JPG', '2024-01-02T08:15:30+00:00', configure: static function (Media $media): void {
+            $media->setMime('image/jpeg');
+            $media->setPhash('cccccccccccccccccccccccccccccccc');
+        });
+
+        $video = $this->makeMedia(21, 'LivePhoto.MOV', '2024-01-02T08:15:31+00:00', configure: static function (Media $media): void {
+            $media->setMime('video/quicktime');
+            $media->setIsVideo(true);
+            $media->setPhash('dddddddddddddddddddddddddddddddd');
+        });
+
+        $repository = $this->createMock(MediaRepository::class);
+        $repository->expects(self::never())->method('findLivePairCandidate');
+        $repository
+            ->expects(self::once())
+            ->method('findNearestByPhash')
+            ->with('cccccccccccccccccccccccccccccccc', 8, 16)
+            ->willReturn([
+                ['media' => $video, 'distance' => 4],
+            ]);
+
+        $linker = new LivePairLinker($repository);
+
+        $linker->extract($photo->getPath(), $photo);
+
+        $expectedChecksum = sha1('heuristic-live|' . $photo->getChecksum() . '|' . $video->getChecksum());
+
+        self::assertSame($video, $photo->getLivePairMedia());
+        self::assertSame($photo, $video->getLivePairMedia());
+        self::assertSame($expectedChecksum, $photo->getLivePairChecksum());
+        self::assertSame($expectedChecksum, $video->getLivePairChecksum());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a BurstDetector service that groups captures with matching pHash and timestamps when no Apple burst metadata exists
- add a LivePairLinker that links photo/video pairs using Apple checksums or heuristic fallbacks
- register the new services ahead of BurstIndexExtractor and cover both iOS filename and heuristic flows with unit tests

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e14712320c83239dad9b49dfd9c83a