### PR TITLE
Add face presence metadata detector

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -10,6 +10,13 @@ parameters:
     memories.video.ffmpeg_path: '%env(default::string:FFMPEG_PATH)%'
     memories.video.ffprobe_path: '%env(default::string:FFPROBE_PATH)%'
 
+    memories.face_detection.binary: '%env(default::string:MEMORIES_FACE_DETECTOR_BIN)%'
+    memories.face_detection.cascade: '%env(default::string:MEMORIES_FACE_DETECTOR_CASCADE)%'
+    memories.face_detection.scale_factor: 1.1
+    memories.face_detection.min_neighbors: 4
+    memories.face_detection.min_size: 72
+    memories.face_detection.timeout: 10.0
+
     # Hash Defaults
     memories.hash.dct_sample: 32
     memories.hash.lowfreq: 16

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -144,9 +144,27 @@ services:
         arguments:
             $goldenMinutes: 60
 
+    MagicSunday\Memories\Service\Metadata\Support\CommandLineFaceDetectionBackend:
+        arguments:
+            $binary: '%memories.face_detection.binary%'
+            $cascadePath: '%memories.face_detection.cascade%'
+            $scaleFactor: '%memories.face_detection.scale_factor%'
+            $minNeighbors: '%memories.face_detection.min_neighbors%'
+            $minSize: '%memories.face_detection.min_size%'
+            $timeout: '%memories.face_detection.timeout%'
+
+    MagicSunday\Memories\Service\Metadata\Support\FaceDetectionBackendInterface:
+        alias: MagicSunday\Memories\Service\Metadata\Support\CommandLineFaceDetectionBackend
+
     MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor:
         arguments:
             $sampleSize: 320
+            $ffmpegBinary: '%memories.video.ffmpeg_path%'
+            $ffprobeBinary: '%memories.video.ffprobe_path%'
+            $posterFrameSecond: '%memories.video.poster_frame_second%'
+
+    MagicSunday\Memories\Service\Metadata\FacePresenceDetector:
+        arguments:
             $ffmpegBinary: '%memories.video.ffmpeg_path%'
             $ffprobeBinary: '%memories.video.ffprobe_path%'
             $posterFrameSecond: '%memories.video.poster_frame_second%'
@@ -192,6 +210,7 @@ services:
                 - '@MagicSunday\Memories\Service\Metadata\DaypartEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\SolarEnricher'
                 - '@MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor'
+                - '@MagicSunday\Memories\Service\Metadata\FacePresenceDetector'
                 - '@MagicSunday\Memories\Service\Metadata\ClipSceneTagExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor'
                 - '@MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor'

--- a/src/Service/Metadata/FacePresenceDetector.php
+++ b/src/Service/Metadata/FacePresenceDetector.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use InvalidArgumentException;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Support\FaceDetectionBackendInterface;
+use MagicSunday\Memories\Service\Metadata\Support\VideoPosterFrameTrait;
+
+use function is_file;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Detects faces on still images or poster frames extracted from videos.
+ */
+final class FacePresenceDetector implements SingleMetadataExtractorInterface
+{
+    use VideoPosterFrameTrait;
+
+    private string $ffmpegBinary;
+
+    private string $ffprobeBinary;
+
+    private float $posterFrameSecond;
+
+    public function __construct(
+        private readonly FaceDetectionBackendInterface $backend,
+        string $ffmpegBinary = 'ffmpeg',
+        string $ffprobeBinary = 'ffprobe',
+        float $posterFrameSecond = 1.0,
+    ) {
+        if ($posterFrameSecond < 0.0) {
+            throw new InvalidArgumentException('posterFrameSecond must be greater or equal to zero.');
+        }
+
+        $this->ffmpegBinary      = $ffmpegBinary !== '' ? $ffmpegBinary : 'ffmpeg';
+        $this->ffprobeBinary     = $ffprobeBinary !== '' ? $ffprobeBinary : 'ffprobe';
+        $this->posterFrameSecond = $posterFrameSecond;
+    }
+
+    public function supports(string $filepath, Media $media): bool
+    {
+        if ($media->isNoShow() || $media->isLowQuality()) {
+            return false;
+        }
+
+        if ($this->isVideoMedia($media)) {
+            return true;
+        }
+
+        $mime = $media->getMime();
+
+        return is_string($mime) && str_starts_with($mime, 'image/');
+    }
+
+    public function extract(string $filepath, Media $media): Media
+    {
+        if (!$this->supports($filepath, $media)) {
+            return $media;
+        }
+
+        if ($media->getFacesCount() > 0 || $media->hasFaces()) {
+            return $media;
+        }
+
+        if ($media->getPersons() !== null) {
+            return $media;
+        }
+
+        $sourcePath = $filepath;
+        $posterPath = null;
+
+        if ($this->isVideoMedia($media)) {
+            $posterPath = $this->createPosterFrame($filepath);
+            if ($posterPath === null) {
+                return $media;
+            }
+
+            $sourcePath = $posterPath;
+        }
+
+        if (!is_file($sourcePath)) {
+            $this->cleanupPosterFrame($posterPath);
+
+            return $media;
+        }
+
+        try {
+            $result = $this->backend->detectFaces($sourcePath, $media);
+        } finally {
+            $this->cleanupPosterFrame($posterPath);
+        }
+
+        if (!$result->isAvailable()) {
+            return $media;
+        }
+
+        if ($media->getFacesCount() > 0 || $media->hasFaces()) {
+            return $media;
+        }
+
+        $faces = $result->getFacesCount();
+
+        if ($faces > 0) {
+            $media->setHasFaces(true);
+            $media->setFacesCount($faces);
+
+            return $media;
+        }
+
+        $media->setHasFaces(false);
+        $media->setFacesCount(0);
+
+        return $media;
+    }
+}

--- a/src/Service/Metadata/Support/CommandLineFaceDetectionBackend.php
+++ b/src/Service/Metadata/Support/CommandLineFaceDetectionBackend.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use MagicSunday\Memories\Entity\Media;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+use function array_key_exists;
+use function is_array;
+use function is_file;
+use function is_numeric;
+use function json_decode;
+use function max;
+use function sprintf;
+use function trim;
+
+/**
+ * Face-detection backend delegating to a command line utility (for example OpenCV).
+ */
+final class CommandLineFaceDetectionBackend implements FaceDetectionBackendInterface
+{
+    private string $binary;
+
+    private ?string $cascadePath;
+
+    private float $scaleFactor;
+
+    private int $minNeighbors;
+
+    private int $minSize;
+
+    private float $timeout;
+
+    public function __construct(
+        string $binary,
+        ?string $cascadePath = null,
+        float $scaleFactor = 1.1,
+        int $minNeighbors = 4,
+        int $minSize = 72,
+        float $timeout = 10.0,
+    ) {
+        $this->binary       = $binary !== '' ? $binary : '';
+        $this->cascadePath  = $cascadePath !== null && $cascadePath !== '' ? $cascadePath : null;
+        $this->scaleFactor  = $scaleFactor;
+        $this->minNeighbors = $minNeighbors;
+        $this->minSize      = $minSize;
+        $this->timeout      = $timeout;
+    }
+
+    public function detectFaces(string $imagePath, Media $media): FaceDetectionResult
+    {
+        if ($this->binary === '' || !is_file($imagePath)) {
+            return FaceDetectionResult::unavailable();
+        }
+
+        $command = [$this->binary, '--format=json', '--input', $imagePath];
+
+        if ($this->cascadePath !== null) {
+            $command[] = '--cascade';
+            $command[] = $this->cascadePath;
+        }
+
+        if ($this->scaleFactor > 0.0) {
+            $command[] = '--scale';
+            $command[] = sprintf('%.2f', $this->scaleFactor);
+        }
+
+        if ($this->minNeighbors > 0) {
+            $command[] = '--min-neighbors';
+            $command[] = (string) $this->minNeighbors;
+        }
+
+        if ($this->minSize > 0) {
+            $command[] = '--min-size';
+            $command[] = (string) $this->minSize;
+        }
+
+        $process = new Process($command);
+
+        if ($this->timeout > 0.0) {
+            $process->setTimeout($this->timeout);
+        }
+
+        try {
+            $process->run();
+        } catch (Throwable) {
+            return FaceDetectionResult::unavailable();
+        }
+
+        if (!$process->isSuccessful()) {
+            return FaceDetectionResult::unavailable();
+        }
+
+        $output = trim($process->getOutput());
+        if ($output === '') {
+            $output = trim($process->getErrorOutput());
+        }
+
+        if ($output === '') {
+            return FaceDetectionResult::fromCount(0);
+        }
+
+        $decoded = json_decode($output, true);
+        if (!is_array($decoded)) {
+            return FaceDetectionResult::unavailable();
+        }
+
+        if (array_key_exists('count', $decoded) && is_numeric($decoded['count'])) {
+            return FaceDetectionResult::fromCount(max(0, (int) $decoded['count']));
+        }
+
+        $faces = $decoded['faces'] ?? $decoded['detections'] ?? null;
+        if (!is_array($faces)) {
+            return FaceDetectionResult::fromCount(0);
+        }
+
+        $count = 0;
+        foreach ($faces as $face) {
+            if (is_array($face)) {
+                ++$count;
+
+                continue;
+            }
+
+            if (is_numeric($face)) {
+                ++$count;
+            }
+        }
+
+        return FaceDetectionResult::fromCount(max(0, $count));
+    }
+}

--- a/src/Service/Metadata/Support/FaceDetectionBackendInterface.php
+++ b/src/Service/Metadata/Support/FaceDetectionBackendInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Abstraction for face-detection backends (CLI, PHP extensions, …).
+ */
+interface FaceDetectionBackendInterface
+{
+    public function detectFaces(string $imagePath, Media $media): FaceDetectionResult;
+}

--- a/src/Service/Metadata/Support/FaceDetectionResult.php
+++ b/src/Service/Metadata/Support/FaceDetectionResult.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use InvalidArgumentException;
+
+/**
+ * Value object describing the outcome of a face-detection run.
+ */
+final class FaceDetectionResult
+{
+    private bool $available;
+
+    private int $facesCount;
+
+    private function __construct(bool $available, int $facesCount)
+    {
+        if ($facesCount < 0) {
+            throw new InvalidArgumentException('facesCount must be greater or equal to zero.');
+        }
+
+        $this->available   = $available;
+        $this->facesCount  = $facesCount;
+    }
+
+    public static function unavailable(): self
+    {
+        return new self(false, 0);
+    }
+
+    public static function fromCount(int $facesCount): self
+    {
+        return new self(true, $facesCount);
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->available;
+    }
+
+    public function hasFaces(): bool
+    {
+        return $this->facesCount > 0;
+    }
+
+    public function getFacesCount(): int
+    {
+        return $this->facesCount;
+    }
+}

--- a/test/Integration/Service/Metadata/FacePresenceDetectorTest.php
+++ b/test/Integration/Service/Metadata/FacePresenceDetectorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Integration\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\FacePresenceDetector;
+use MagicSunday\Memories\Service\Metadata\Support\FaceDetectionBackendInterface;
+use MagicSunday\Memories\Service\Metadata\Support\FaceDetectionResult;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function chmod;
+use function file_put_contents;
+use function is_file;
+use function is_string;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class FacePresenceDetectorTest extends TestCase
+{
+    #[Test]
+    public function detectsFacesOnPosterFrame(): void
+    {
+        $videoBase = tempnam(sys_get_temp_dir(), 'video_');
+        if ($videoBase === false) {
+            self::fail('Unable to create temporary video fixture.');
+        }
+
+        $videoPath = $videoBase . '.mp4';
+        unlink($videoBase);
+        file_put_contents($videoPath, 'video');
+
+        $ffmpeg  = $this->createMockFfmpegBinary();
+        $ffprobe = $this->createMockFfprobeBinary();
+
+        $backend  = new RecordingFaceBackend(FaceDetectionResult::fromCount(1));
+        $detector = new FacePresenceDetector($backend, $ffmpeg, $ffprobe, 1.0);
+
+        try {
+            $media = $this->makeMedia(
+                id: 801,
+                path: $videoPath,
+                configure: static function (Media $media): void {
+                    $media->setMime('video/mp4');
+                    $media->setIsVideo(true);
+                    $media->setWidth(1920);
+                    $media->setHeight(1080);
+                },
+            );
+
+            $detector->extract($videoPath, $media);
+
+            self::assertSame(1, $backend->calls);
+            self::assertTrue($media->hasFaces());
+            self::assertSame(1, $media->getFacesCount());
+
+            $posterPath = $backend->lastPath;
+            self::assertNotNull($posterPath);
+            self::assertTrue(is_string($posterPath));
+            self::assertNotSame($videoPath, $posterPath);
+            self::assertFalse(is_file($posterPath));
+        } finally {
+            if (is_file($videoPath)) {
+                unlink($videoPath);
+            }
+
+            $this->cleanupBinary($ffmpeg);
+            $this->cleanupBinary($ffprobe);
+        }
+    }
+
+    #[Test]
+    public function keepsDefaultsWhenBackendReportsNoFacesForPoster(): void
+    {
+        $videoBase = tempnam(sys_get_temp_dir(), 'video_');
+        if ($videoBase === false) {
+            self::fail('Unable to create temporary video fixture.');
+        }
+
+        $videoPath = $videoBase . '.mp4';
+        unlink($videoBase);
+        file_put_contents($videoPath, 'video');
+
+        $ffmpeg  = $this->createMockFfmpegBinary();
+        $ffprobe = $this->createMockFfprobeBinary();
+
+        $backend  = new RecordingFaceBackend(FaceDetectionResult::fromCount(0));
+        $detector = new FacePresenceDetector($backend, $ffmpeg, $ffprobe, 1.0);
+
+        try {
+            $media = $this->makeMedia(
+                id: 802,
+                path: $videoPath,
+                configure: static function (Media $media): void {
+                    $media->setMime('video/mp4');
+                    $media->setIsVideo(true);
+                    $media->setWidth(1920);
+                    $media->setHeight(1080);
+                },
+            );
+
+            $detector->extract($videoPath, $media);
+
+            self::assertSame(1, $backend->calls);
+            self::assertFalse($media->hasFaces());
+            self::assertSame(0, $media->getFacesCount());
+        } finally {
+            if (is_file($videoPath)) {
+                unlink($videoPath);
+            }
+
+            $this->cleanupBinary($ffmpeg);
+            $this->cleanupBinary($ffprobe);
+        }
+    }
+
+    private function createMockFfmpegBinary(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'ffmpeg_');
+        if ($path === false) {
+            self::fail('Unable to allocate temporary ffmpeg binary.');
+        }
+
+        $script = <<<'PHP'
+#!/usr/bin/env php
+<?php
+$args = $_SERVER['argv'] ?? [];
+$output = $args[count($args) - 1] ?? null;
+if (!is_string($output) || $output === '') {
+    fwrite(STDERR, "missing output path\n");
+    exit(1);
+}
+
+$image = imagecreatetruecolor(8, 8);
+$color = imagecolorallocate($image, 255, 0, 0);
+imagefilledrectangle($image, 0, 0, 7, 7, $color);
+if (imagejpeg($image, $output) !== true) {
+    fwrite(STDERR, "failed to write poster\n");
+    imagedestroy($image);
+    exit(1);
+}
+
+imagedestroy($image);
+exit(0);
+PHP;
+
+        file_put_contents($path, $script);
+        chmod($path, 0o755);
+
+        return $path;
+    }
+
+    private function createMockFfprobeBinary(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'ffprobe_');
+        if ($path === false) {
+            self::fail('Unable to allocate temporary ffprobe binary.');
+        }
+
+        $script = <<<'PHP'
+#!/usr/bin/env php
+<?php
+fwrite(STDOUT, "2.0\n");
+PHP;
+
+        file_put_contents($path, $script);
+        chmod($path, 0o755);
+
+        return $path;
+    }
+
+    private function cleanupBinary(string $path): void
+    {
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+}
+
+final class RecordingFaceBackend implements FaceDetectionBackendInterface
+{
+    public int $calls = 0;
+
+    public ?string $lastPath = null;
+
+    public function __construct(private readonly FaceDetectionResult $result)
+    {
+    }
+
+    public function detectFaces(string $imagePath, Media $media): FaceDetectionResult
+    {
+        ++$this->calls;
+        $this->lastPath = $imagePath;
+
+        return $this->result;
+    }
+}

--- a/test/Unit/Service/Metadata/FacePresenceDetectorTest.php
+++ b/test/Unit/Service/Metadata/FacePresenceDetectorTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\FacePresenceDetector;
+use MagicSunday\Memories\Service\Metadata\Support\FaceDetectionBackendInterface;
+use MagicSunday\Memories\Service\Metadata\Support\FaceDetectionResult;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function file_put_contents;
+use function is_file;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class FacePresenceDetectorTest extends TestCase
+{
+    #[Test]
+    public function detectsFacesOnStillImageWhenMetadataMissing(): void
+    {
+        $imagePath = tempnam(sys_get_temp_dir(), 'face_');
+        if ($imagePath === false) {
+            self::fail('Unable to create temporary image fixture.');
+        }
+
+        file_put_contents($imagePath, 'jpeg');
+
+        $backend  = new RecordingFaceDetectionBackend(FaceDetectionResult::fromCount(2));
+        $detector = new FacePresenceDetector($backend);
+
+        try {
+            $media = $this->makeMedia(
+                id: 701,
+                path: $imagePath,
+                configure: static function (Media $media): void {
+                    $media->setMime('image/jpeg');
+                    $media->setWidth(1024);
+                    $media->setHeight(768);
+                },
+            );
+
+            $detector->extract($imagePath, $media);
+
+            self::assertSame(1, $backend->calls);
+            self::assertSame($imagePath, $backend->lastPath);
+            self::assertTrue($media->hasFaces());
+            self::assertSame(2, $media->getFacesCount());
+        } finally {
+            if (is_file($imagePath)) {
+                unlink($imagePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function marksAbsenceWhenBackendReturnsZero(): void
+    {
+        $imagePath = tempnam(sys_get_temp_dir(), 'face_');
+        if ($imagePath === false) {
+            self::fail('Unable to create temporary image fixture.');
+        }
+
+        file_put_contents($imagePath, 'jpeg');
+
+        $backend  = new RecordingFaceDetectionBackend(FaceDetectionResult::fromCount(0));
+        $detector = new FacePresenceDetector($backend);
+
+        try {
+            $media = $this->makeMedia(
+                id: 702,
+                path: $imagePath,
+                configure: static function (Media $media): void {
+                    $media->setMime('image/jpeg');
+                    $media->setWidth(800);
+                    $media->setHeight(600);
+                },
+            );
+
+            $detector->extract($imagePath, $media);
+
+            self::assertSame(1, $backend->calls);
+            self::assertFalse($media->hasFaces());
+            self::assertSame(0, $media->getFacesCount());
+        } finally {
+            if (is_file($imagePath)) {
+                unlink($imagePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function skipsWhenMediaAlreadyContainsFaceMetadata(): void
+    {
+        $imagePath = tempnam(sys_get_temp_dir(), 'face_');
+        if ($imagePath === false) {
+            self::fail('Unable to create temporary image fixture.');
+        }
+
+        file_put_contents($imagePath, 'jpeg');
+
+        $backend  = new RecordingFaceDetectionBackend(FaceDetectionResult::fromCount(4));
+        $detector = new FacePresenceDetector($backend);
+
+        try {
+            $media = $this->makeMedia(
+                id: 703,
+                path: $imagePath,
+                configure: static function (Media $media): void {
+                    $media->setMime('image/jpeg');
+                    $media->setWidth(640);
+                    $media->setHeight(480);
+                    $media->setHasFaces(true);
+                    $media->setFacesCount(3);
+                },
+            );
+
+            $detector->extract($imagePath, $media);
+
+            self::assertSame(0, $backend->calls);
+            self::assertTrue($media->hasFaces());
+            self::assertSame(3, $media->getFacesCount());
+        } finally {
+            if (is_file($imagePath)) {
+                unlink($imagePath);
+            }
+        }
+    }
+
+    #[Test]
+    public function skipsWhenMediaIsHiddenOrLowQuality(): void
+    {
+        $imagePath = tempnam(sys_get_temp_dir(), 'face_');
+        if ($imagePath === false) {
+            self::fail('Unable to create temporary image fixture.');
+        }
+
+        file_put_contents($imagePath, 'jpeg');
+
+        $backend  = new RecordingFaceDetectionBackend(FaceDetectionResult::fromCount(1));
+        $detector = new FacePresenceDetector($backend);
+
+        try {
+            $media = $this->makeMedia(
+                id: 704,
+                path: $imagePath,
+                configure: static function (Media $media): void {
+                    $media->setMime('image/jpeg');
+                    $media->setWidth(640);
+                    $media->setHeight(480);
+                    $media->setLowQuality(true);
+                },
+            );
+
+            $detector->extract($imagePath, $media);
+            self::assertSame(0, $backend->calls);
+
+            $media->setLowQuality(false);
+            $media->setNoShow(true);
+
+            $detector->extract($imagePath, $media);
+            self::assertSame(0, $backend->calls);
+        } finally {
+            if (is_file($imagePath)) {
+                unlink($imagePath);
+            }
+        }
+    }
+}
+
+final class RecordingFaceDetectionBackend implements FaceDetectionBackendInterface
+{
+    public int $calls = 0;
+
+    public ?string $lastPath = null;
+
+    public function __construct(private readonly FaceDetectionResult $result)
+    {
+    }
+
+    public function detectFaces(string $imagePath, Media $media): FaceDetectionResult
+    {
+        ++$this->calls;
+        $this->lastPath = $imagePath;
+
+        return $this->result;
+    }
+}


### PR DESCRIPTION
## Summary
- add a FacePresenceDetector that skips low-quality/no-show media, reuses video poster frames, and fills hasFaces metadata only when empty
- provide a configurable command-line face detection backend plus supporting value object and interface wiring
- register the detector after quality extractors and add unit/integration coverage for positive and negative scenarios

## Testing
- composer ci:test *(fails: phpstan reports pre-existing strict-rule findings outside the new code)*
- composer ci:test:php:unit *(fails: existing feed and thumbnail unit tests error under current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1497115608323971661d93a655b9b