### PR TITLE
Add scene tag index log summary and helper

### DIFF
--- a/src/Service/Metadata/ClipSceneTagExtractor.php
+++ b/src/Service/Metadata/ClipSceneTagExtractor.php
@@ -13,12 +13,15 @@ namespace MagicSunday\Memories\Service\Metadata;
 
 use InvalidArgumentException;
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Support\IndexLogHelper;
 
 use function array_slice;
 use function arsort;
+use function implode;
 use function is_float;
 use function is_int;
 use function is_string;
+use function sprintf;
 use function str_starts_with;
 
 /**
@@ -62,6 +65,7 @@ final readonly class ClipSceneTagExtractor implements SingleMetadataExtractorInt
         }
 
         $media->setSceneTags($tags);
+        IndexLogHelper::append($media, $this->formatSceneSummary($tags));
 
         return $media;
     }
@@ -119,6 +123,20 @@ final readonly class ClipSceneTagExtractor implements SingleMetadataExtractorInt
         }
 
         return $result;
+    }
+
+    /**
+     * @param list<array{label: string, score: float}> $tags
+     */
+    private function formatSceneSummary(array $tags): string
+    {
+        $parts = [];
+
+        foreach ($tags as $tag) {
+            $parts[] = sprintf('%s(%.2f)', $tag['label'], $tag['score']);
+        }
+
+        return sprintf('scene=%s', implode(',', $parts));
     }
 }
 

--- a/src/Service/Metadata/Quality/MediaQualityAggregator.php
+++ b/src/Service/Metadata/Quality/MediaQualityAggregator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Metadata\Quality;
 
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Support\IndexLogHelper;
 
 use function abs;
 use function log;
@@ -185,15 +186,7 @@ final class MediaQualityAggregator
             $parts[] = sprintf('clip=%.2f', $clippingShare);
         }
 
-        $line     = implode('; ', $parts);
-        $existing = $media->getIndexLog();
-
-        if ($existing === null || $existing === '') {
-            $media->setIndexLog($line);
-
-            return;
-        }
-
-        $media->setIndexLog($existing . "\n" . $line);
+        $line = implode('; ', $parts);
+        IndexLogHelper::append($media, $line);
     }
 }

--- a/src/Service/Metadata/TimeNormalizer.php
+++ b/src/Service/Metadata/TimeNormalizer.php
@@ -18,6 +18,7 @@ use MagicSunday\Memories\Entity\Enum\TimeSource;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
 use MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser;
+use MagicSunday\Memories\Support\IndexLogHelper;
 
 use function filemtime;
 use function intdiv;
@@ -135,14 +136,7 @@ final class TimeNormalizer implements SingleMetadataExtractorInterface
             $offset !== null ? sprintf('%+d', $offset) : 'n/a',
         );
 
-        $existing = $media->getIndexLog();
-        if ($existing === null || $existing === '') {
-            $media->setIndexLog($summary);
-
-            return;
-        }
-
-        $media->setIndexLog($existing . "\n" . $summary);
+        IndexLogHelper::append($media, $summary);
     }
 
     private function defaultTimezone(): DateTimeZone

--- a/src/Support/IndexLogHelper.php
+++ b/src/Support/IndexLogHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Support;
+
+use MagicSunday\Memories\Entity\Media;
+
+/**
+ * Utility helpers for working with the media index log.
+ */
+final class IndexLogHelper
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Appends a line to the media index log, inserting a newline when required.
+     */
+    public static function append(Media $media, string $line): void
+    {
+        if ($line === '') {
+            return;
+        }
+
+        $existing = $media->getIndexLog();
+        if ($existing === null || $existing === '') {
+            $media->setIndexLog($line);
+
+            return;
+        }
+
+        $media->setIndexLog($existing . "\n" . $line);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable IndexLogHelper to append entries to media index logs
- log a formatted scene tag summary when ClipSceneTagExtractor stores new tags
- route existing metadata appenders through the helper and extend unit coverage for logging

## Testing
- composer ci:test *(fails: bin/php missing in container)*
- ./vendor/bin/phpunit test/Unit/Service/Metadata/ClipSceneTagExtractorTest.php


------
https://chatgpt.com/codex/tasks/task_e_68e14c34f5808323ab83ea460436854e