### PR TITLE
Improve metadata extraction rerun handling

### DIFF
--- a/src/Service/Metadata/MetadataFeatureVersion.php
+++ b/src/Service/Metadata/MetadataFeatureVersion.php
@@ -16,7 +16,19 @@ namespace MagicSunday\Memories\Service\Metadata;
  */
 final class MetadataFeatureVersion
 {
-    public const CURRENT = 1;
+    public const PIPELINE_VERSION = 1;
+
+    /**
+     * @var array<string, int>
+     */
+    public const MODULE_VERSIONS = [
+        'core' => 1,
+        'exif' => 1,
+        'xmp' => 1,
+        'vision' => 1,
+    ];
+
+    public const CURRENT = self::PIPELINE_VERSION;
 
     private function __construct()
     {


### PR DESCRIPTION
## Summary
- add a dedicated pipeline version constant (and module version map) to MetadataFeatureVersion
- skip metadata extraction when media already matches the pipeline version unless force is requested
- refresh metadata timestamps while preserving warning logs on reruns and cover the behaviour with new tests

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml test/Unit/Service/Indexing/Stage/MetadataExtractionStageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e14d34ea3483239aa94bbd3adb077b