### PR TITLE
Add guard for excluded media in clip scene extractor

### DIFF
--- a/src/Service/Metadata/ClipSceneTagExtractor.php
+++ b/src/Service/Metadata/ClipSceneTagExtractor.php
@@ -45,6 +45,10 @@ final readonly class ClipSceneTagExtractor implements SingleMetadataExtractorInt
 
     public function supports(string $filepath, Media $media): bool
     {
+        if ($media->isNoShow() || $media->isLowQuality()) {
+            return false;
+        }
+
         $mime = $media->getMime();
         if ($mime === null) {
             return true;

--- a/test/Unit/Service/Metadata/ClipSceneTagExtractorTest.php
+++ b/test/Unit/Service/Metadata/ClipSceneTagExtractorTest.php
@@ -80,6 +80,18 @@ final class ClipSceneTagExtractorTest extends TestCase
     }
 
     #[Test]
+    public function supportsSkipsNoShowMedia(): void
+    {
+        $extractor = new ClipSceneTagExtractor(new HeuristicClipSceneTagModel());
+
+        $media = new Media('hidden.jpg', 'hidden', 128);
+        $media->setMime('image/jpeg');
+        $media->setNoShow(true);
+
+        self::assertFalse($extractor->supports('hidden.jpg', $media));
+    }
+
+    #[Test]
     public function extractClearsTagsWhenScoresAreTooLow(): void
     {
         $model = new class implements VisionSceneTagModelInterface {


### PR DESCRIPTION
## Summary
- skip clip scene tag extraction for media marked as no-show or low-quality
- add a unit test to ensure the extractor ignores no-show media

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1528c0d4083239c6af4830efca567