### PR TITLE
Log thumbnail generation failures in index log

### DIFF
--- a/src/Service/Indexing/Stage/ThumbnailGenerationStage.php
+++ b/src/Service/Indexing/Stage/ThumbnailGenerationStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
 use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
+use MagicSunday\Memories\Support\IndexLogHelper;
 use Throwable;
 
 use function sprintf;
@@ -35,9 +36,10 @@ final class ThumbnailGenerationStage implements MediaIngestionStageInterface
             $thumbnails = $this->thumbnailService->generateAll($context->getFilePath(), $context->getMedia());
             $context->getMedia()->setThumbnails($thumbnails);
         } catch (Throwable $exception) {
-            $context->getOutput()->writeln(
-                sprintf('<error>Thumbnail generation failed for %s: %s</error>', $context->getFilePath(), $exception->getMessage())
-            );
+            $message = sprintf('Thumbnail generation failed for %s: %s', $context->getFilePath(), $exception->getMessage());
+
+            $context->getOutput()->writeln(sprintf('<error>%s</error>', $message));
+            IndexLogHelper::append($context->getMedia(), $message);
         }
 
         return $context;

--- a/test/Unit/Service/Indexing/Stage/ThumbnailGenerationStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/ThumbnailGenerationStageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage;
+use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class ThumbnailGenerationStageTest extends TestCase
+{
+    #[Test]
+    public function processAppendsIndexLogWhenGenerationFails(): void
+    {
+        $media  = new Media('/tmp/file.jpg', 'checksum', 1);
+        $output = new BufferedOutput();
+
+        $context = MediaIngestionContext::create('/tmp/file.jpg', false, false, true, false, $output)
+            ->withMedia($media);
+
+        $thumbnailService = $this->createMock(ThumbnailServiceInterface::class);
+        $thumbnailService->expects(self::once())
+            ->method('generateAll')
+            ->willThrowException(new RuntimeException('Generation failed'));
+
+        $stage = new ThumbnailGenerationStage($thumbnailService);
+
+        $stage->process($context);
+
+        self::assertSame('Thumbnail generation failed for /tmp/file.jpg: Generation failed', $media->getIndexLog());
+    }
+}
+


### PR DESCRIPTION
## Summary
- append thumbnail generation failure messages to the media index log via IndexLogHelper
- add a unit test proving the log is updated when thumbnail generation throws an exception

## Testing
- composer ci:test *(fails: bin/php not found in container)*
- ./vendor/bin/phpunit --configuration .build/phpunit.xml --filter ThumbnailGenerationStageTest


------
https://chatgpt.com/codex/tasks/task_e_68e15297d1348323bde58974c9e7674f