### PR TITLE
Enhance geocoding metadata persistence and coverage

### DIFF
--- a/migrations/Version20250315093000.php
+++ b/migrations/Version20250315093000.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250315093000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add geocoding metadata columns and indexes to the location table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE location ADD attribution VARCHAR(255) DEFAULT NULL, ADD licence VARCHAR(255) DEFAULT NULL, ADD refreshedAt DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', ADD stale TINYINT(1) DEFAULT 0 NOT NULL, ADD confidence DOUBLE PRECISION DEFAULT NULL, ADD accuracyRadiusMeters DOUBLE PRECISION DEFAULT NULL, ADD timezone VARCHAR(64) DEFAULT NULL, ADD osmType VARCHAR(16) DEFAULT NULL, ADD osmId VARCHAR(32) DEFAULT NULL, ADD wikidataId VARCHAR(32) DEFAULT NULL, ADD wikipedia VARCHAR(128) DEFAULT NULL, ADD altNames JSON DEFAULT NULL, ADD extraTags JSON DEFAULT NULL");
+        $this->addSql('CREATE INDEX idx_loc_country_city ON location (countryCode, city)');
+        $this->addSql('UPDATE location SET refreshedAt = NOW() WHERE refreshedAt IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_loc_country_city ON location');
+        $this->addSql('ALTER TABLE location DROP attribution, DROP licence, DROP refreshedAt, DROP stale, DROP confidence, DROP accuracyRadiusMeters, DROP timezone, DROP osmType, DROP osmId, DROP wikidataId, DROP wikipedia, DROP altNames, DROP extraTags');
+    }
+}

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Entity;
 
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -21,6 +22,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Table(name: 'location')]
 #[ORM\UniqueConstraint(name: 'uniq_loc_provider', columns: ['provider', 'providerPlaceId'])]
 #[ORM\Index(name: 'idx_loc_cell', columns: ['cell'])]
+#[ORM\Index(name: 'idx_loc_country_city', columns: ['countryCode', 'city'])]
 class Location
 {
     /**
@@ -148,6 +150,88 @@ class Location
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $pois = null;
+
+    /**
+     * Attribution string required by the provider.
+     */
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $attribution = null;
+
+    /**
+     * Licence string provided by the geocoding service.
+     */
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $licence = null;
+
+    /**
+     * Timestamp when the location metadata was last refreshed.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $refreshedAt = null;
+
+    /**
+     * Indicates that the metadata should be refreshed from the provider.
+     */
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $stale = false;
+
+    /**
+     * Provider supplied confidence/importance score.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $confidence = null;
+
+    /**
+     * Estimated accuracy radius in meters.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $accuracyRadiusMeters = null;
+
+    /**
+     * Timezone identifier for the resolved location.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
+    private ?string $timezone = null;
+
+    /**
+     * OpenStreetMap element type.
+     */
+    #[ORM\Column(type: Types::STRING, length: 16, nullable: true)]
+    private ?string $osmType = null;
+
+    /**
+     * OpenStreetMap element identifier.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $osmId = null;
+
+    /**
+     * Wikidata identifier reference.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $wikidataId = null;
+
+    /**
+     * Wikipedia article reference.
+     */
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
+    private ?string $wikipedia = null;
+
+    /**
+     * Alternative names keyed by qualifier or locale.
+     *
+     * @var array<string, string>|null
+     */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $altNames = null;
+
+    /**
+     * Additional provider specific tags.
+     *
+     * @var array<string, string>|null
+     */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $extraTags = null;
 
     /**
      * @param string $provider        Geocoding provider name.
@@ -565,6 +649,248 @@ class Location
     public function setPois(?array $pois): Location
     {
         $this->pois = $pois;
+
+        return $this;
+    }
+
+    /**
+     * Returns the attribution string for the location.
+     */
+    public function getAttribution(): ?string
+    {
+        return $this->attribution;
+    }
+
+    /**
+     * Sets the attribution string for the location.
+     */
+    public function setAttribution(?string $attribution): Location
+    {
+        $this->attribution = $attribution;
+
+        return $this;
+    }
+
+    /**
+     * Returns the licence string supplied by the provider.
+     */
+    public function getLicence(): ?string
+    {
+        return $this->licence;
+    }
+
+    /**
+     * Sets the licence string supplied by the provider.
+     */
+    public function setLicence(?string $licence): Location
+    {
+        $this->licence = $licence;
+
+        return $this;
+    }
+
+    /**
+     * Returns the timestamp when the metadata was last refreshed.
+     */
+    public function getRefreshedAt(): ?DateTimeImmutable
+    {
+        return $this->refreshedAt;
+    }
+
+    /**
+     * Sets the timestamp when the metadata was last refreshed.
+     */
+    public function setRefreshedAt(?DateTimeImmutable $refreshedAt): Location
+    {
+        $this->refreshedAt = $refreshedAt;
+
+        return $this;
+    }
+
+    /**
+     * Indicates whether the metadata should be refreshed.
+     */
+    public function isStale(): bool
+    {
+        return $this->stale;
+    }
+
+    /**
+     * Marks the metadata as stale or up to date.
+     */
+    public function setStale(bool $stale): Location
+    {
+        $this->stale = $stale;
+
+        return $this;
+    }
+
+    /**
+     * Returns the provider supplied confidence value.
+     */
+    public function getConfidence(): ?float
+    {
+        return $this->confidence;
+    }
+
+    /**
+     * Sets the provider supplied confidence value.
+     */
+    public function setConfidence(?float $confidence): Location
+    {
+        $this->confidence = $confidence;
+
+        return $this;
+    }
+
+    /**
+     * Returns the estimated accuracy radius in meters.
+     */
+    public function getAccuracyRadiusMeters(): ?float
+    {
+        return $this->accuracyRadiusMeters;
+    }
+
+    /**
+     * Sets the estimated accuracy radius in meters.
+     */
+    public function setAccuracyRadiusMeters(?float $accuracyRadiusMeters): Location
+    {
+        $this->accuracyRadiusMeters = $accuracyRadiusMeters;
+
+        return $this;
+    }
+
+    /**
+     * Returns the timezone identifier.
+     */
+    public function getTimezone(): ?string
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * Sets the timezone identifier.
+     */
+    public function setTimezone(?string $timezone): Location
+    {
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    /**
+     * Returns the OSM element type.
+     */
+    public function getOsmType(): ?string
+    {
+        return $this->osmType;
+    }
+
+    /**
+     * Sets the OSM element type.
+     */
+    public function setOsmType(?string $osmType): Location
+    {
+        $this->osmType = $osmType;
+
+        return $this;
+    }
+
+    /**
+     * Returns the OSM element identifier.
+     */
+    public function getOsmId(): ?string
+    {
+        return $this->osmId;
+    }
+
+    /**
+     * Sets the OSM element identifier.
+     */
+    public function setOsmId(?string $osmId): Location
+    {
+        $this->osmId = $osmId;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Wikidata identifier.
+     */
+    public function getWikidataId(): ?string
+    {
+        return $this->wikidataId;
+    }
+
+    /**
+     * Sets the Wikidata identifier.
+     */
+    public function setWikidataId(?string $wikidataId): Location
+    {
+        $this->wikidataId = $wikidataId;
+
+        return $this;
+    }
+
+    /**
+     * Returns the Wikipedia reference string.
+     */
+    public function getWikipedia(): ?string
+    {
+        return $this->wikipedia;
+    }
+
+    /**
+     * Sets the Wikipedia reference string.
+     */
+    public function setWikipedia(?string $wikipedia): Location
+    {
+        $this->wikipedia = $wikipedia;
+
+        return $this;
+    }
+
+    /**
+     * Returns alternative names keyed by qualifier or locale.
+     *
+     * @return array<string, string>|null
+     */
+    public function getAltNames(): ?array
+    {
+        return $this->altNames;
+    }
+
+    /**
+     * Stores alternative names keyed by qualifier or locale.
+     *
+     * @param array<string, string>|null $altNames
+     */
+    public function setAltNames(?array $altNames): Location
+    {
+        $this->altNames = $altNames;
+
+        return $this;
+    }
+
+    /**
+     * Returns provider specific extra tags.
+     *
+     * @return array<string, string>|null
+     */
+    public function getExtraTags(): ?array
+    {
+        return $this->extraTags;
+    }
+
+    /**
+     * Stores provider specific extra tags.
+     *
+     * @param array<string, string>|null $extraTags
+     */
+    public function setExtraTags(?array $extraTags): Location
+    {
+        $this->extraTags = $extraTags;
 
         return $this;
     }

--- a/src/Service/Geocoding/GeocodeResult.php
+++ b/src/Service/Geocoding/GeocodeResult.php
@@ -11,14 +11,50 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Geocoding;
 
+use DateTimeImmutable;
+
 /**
  * Immutable reverse-geocoding result mapped to our domain.
  */
 final readonly class GeocodeResult
 {
+    /**
+     * @param string                     $provider            Provider identifier (for example, "nominatim").
+     * @param string                     $providerPlaceId     Provider specific place identifier.
+     * @param float                      $lat                 Latitude in decimal degrees.
+     * @param float                      $lon                 Longitude in decimal degrees.
+     * @param string                     $displayName         Human readable label.
+     * @param string|null                $countryCode         ISO country code when available.
+     * @param string|null                $country             Country name.
+     * @param string|null                $state               State or region name.
+     * @param string|null                $county              County or administrative district.
+     * @param string|null                $city                City name.
+     * @param string|null                $town                Town name as provided by the geocoder.
+     * @param string|null                $village             Village or hamlet name.
+     * @param string|null                $suburb              Suburb designation.
+     * @param string|null                $neighbourhood       Neighbourhood designation.
+     * @param string|null                $postcode            Postal code.
+     * @param string|null                $road                Street or road name.
+     * @param string|null                $houseNumber         House number.
+     * @param list<float>|null           $boundingBox         Bounding box [south, north, west, east].
+     * @param string|null                $category            Provider category.
+     * @param string|null                $type                Provider type (for example, "city").
+     * @param string|null                $attribution         Attribution required by the provider.
+     * @param string|null                $licence             Licence string supplied by the provider.
+     * @param DateTimeImmutable|null     $refreshedAt         Timestamp when the result was retrieved.
+     * @param float|null                 $confidence          Provider supplied confidence/importance score.
+     * @param float|null                 $accuracyRadiusMeters Accuracy radius estimate in meters.
+     * @param string|null                $timezone            Timezone identifier when known.
+     * @param string|null                $osmType             OSM element type (node/way/relation).
+     * @param string|null                $osmId               OSM element identifier.
+     * @param string|null                $wikidataId          Wikidata reference identifier.
+     * @param string|null                $wikipedia           Wikipedia reference string.
+     * @param array<string,string>|null  $altNames            Alternative names keyed by language or qualifier.
+     * @param array<string,string>|null  $extraTags           Additional provider tags.
+     */
     public function __construct(
-        public string $provider,            // e.g. "nominatim"
-        public string $providerPlaceId,     // e.g. Nominatim place_id (stringified)
+        public string $provider,
+        public string $providerPlaceId,
         public float $lat,
         public float $lon,
         public string $displayName,
@@ -34,10 +70,21 @@ final readonly class GeocodeResult
         public ?string $postcode,
         public ?string $road,
         public ?string $houseNumber,
-        /** @var list<float>|null [south, north, west, east] */
         public ?array $boundingBox,
-        public ?string $category,           // poi category/type if available
-        public ?string $type,                // e.g. "residential", "house", "city"
+        public ?string $category,
+        public ?string $type,
+        public ?string $attribution,
+        public ?string $licence,
+        public ?DateTimeImmutable $refreshedAt,
+        public ?float $confidence,
+        public ?float $accuracyRadiusMeters,
+        public ?string $timezone,
+        public ?string $osmType,
+        public ?string $osmId,
+        public ?string $wikidataId,
+        public ?string $wikipedia,
+        public ?array $altNames,
+        public ?array $extraTags,
     ) {
     }
 }

--- a/test/Unit/Entity/LocationMetadataTest.php
+++ b/test/Unit/Entity/LocationMetadataTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Entity;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Location;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LocationMetadataTest extends TestCase
+{
+    #[Test]
+    public function storesMetadataFields(): void
+    {
+        $location = new Location('nominatim', 'place-1', 'Berlin', 52.5, 13.4, 'cell');
+
+        $refreshedAt = new DateTimeImmutable('2025-03-15T09:30:00+00:00');
+        $altNames    = ['name:en' => 'Berlin', 'short' => 'BER'];
+        $extraTags   = ['wikidata' => 'Q64', 'wikipedia' => 'de:Berlin'];
+
+        $location
+            ->setAttribution('© OpenStreetMap')
+            ->setLicence('ODbL')
+            ->setRefreshedAt($refreshedAt)
+            ->setStale(true)
+            ->setConfidence(0.85)
+            ->setAccuracyRadiusMeters(125.5)
+            ->setTimezone('Europe/Berlin')
+            ->setOsmType('node')
+            ->setOsmId('12345')
+            ->setWikidataId('Q64')
+            ->setWikipedia('de:Berlin')
+            ->setAltNames($altNames)
+            ->setExtraTags($extraTags);
+
+        self::assertSame('© OpenStreetMap', $location->getAttribution());
+        self::assertSame('ODbL', $location->getLicence());
+        self::assertSame($refreshedAt, $location->getRefreshedAt());
+        self::assertTrue($location->isStale());
+        self::assertSame(0.85, $location->getConfidence());
+        self::assertSame(125.5, $location->getAccuracyRadiusMeters());
+        self::assertSame('Europe/Berlin', $location->getTimezone());
+        self::assertSame('node', $location->getOsmType());
+        self::assertSame('12345', $location->getOsmId());
+        self::assertSame('Q64', $location->getWikidataId());
+        self::assertSame('de:Berlin', $location->getWikipedia());
+        self::assertSame($altNames, $location->getAltNames());
+        self::assertSame($extraTags, $location->getExtraTags());
+    }
+}

--- a/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
+++ b/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
@@ -316,6 +316,18 @@ final class LocationPoiEnricherTest extends TestCase
             boundingBox: null,
             category: null,
             type: null,
+            attribution: null,
+            licence: null,
+            refreshedAt: null,
+            confidence: null,
+            accuracyRadiusMeters: null,
+            timezone: null,
+            osmType: null,
+            osmId: null,
+            wikidataId: null,
+            wikipedia: null,
+            altNames: null,
+            extraTags: null,
         );
     }
 

--- a/test/Unit/Service/Geocoding/LocationResolverMetadataTest.php
+++ b/test/Unit/Service/Geocoding/LocationResolverMetadataTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Service\Geocoding\GeocodeResult;
+use MagicSunday\Memories\Service\Geocoding\LocationResolver;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LocationResolverMetadataTest extends TestCase
+{
+    #[Test]
+    public function appliesGeocodeMetadataWhenCreatingLocation(): void
+    {
+        $repository = $this->createMock(EntityRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+        $repository->method('findBy')->willReturn([]);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->with(Location::class)->willReturn($repository);
+        $entityManager->method('contains')->willReturn(false);
+        $entityManager->expects(self::once())->method('persist')->with(self::isInstanceOf(Location::class));
+
+        $resolver = new LocationResolver($entityManager);
+
+        $refreshedAt = new DateTimeImmutable('2025-03-15T09:45:00+00:00');
+        $geocode     = new GeocodeResult(
+            provider: 'nominatim',
+            providerPlaceId: 'place-100',
+            lat: 52.520008,
+            lon: 13.404954,
+            displayName: 'Berlin, Deutschland',
+            countryCode: 'DE',
+            country: 'Deutschland',
+            state: 'Berlin',
+            county: 'Berlin',
+            city: 'Berlin',
+            town: null,
+            village: null,
+            suburb: 'Mitte',
+            neighbourhood: 'Nikolaiviertel',
+            postcode: '10178',
+            road: 'Karl-Liebknecht-Straße',
+            houseNumber: '8',
+            boundingBox: [52.515, 52.525, 13.4, 13.41],
+            category: 'tourism',
+            type: 'viewpoint',
+            attribution: '© OpenStreetMap',
+            licence: 'ODbL',
+            refreshedAt: $refreshedAt,
+            confidence: 0.92,
+            accuracyRadiusMeters: 135.0,
+            timezone: 'Europe/Berlin',
+            osmType: 'node',
+            osmId: '123456',
+            wikidataId: 'Q64',
+            wikipedia: 'de:Berlin',
+            altNames: ['name:en' => 'Berlin', 'short' => 'BER'],
+            extraTags: ['wikidata' => 'Q64', 'wikimedia_commons' => 'Category:Berlin'],
+        );
+
+        $location = $resolver->findOrCreate($geocode);
+
+        self::assertSame('Berlin, Deutschland', $location->getDisplayName());
+        self::assertSame('DE', $location->getCountryCode());
+        self::assertSame('Deutschland', $location->getCountry());
+        self::assertSame('Berlin', $location->getState());
+        self::assertSame('Berlin', $location->getCounty());
+        self::assertSame('Berlin', $location->getCity());
+        self::assertSame('Mitte', $location->getSuburb());
+        self::assertSame('10178', $location->getPostcode());
+        self::assertSame('Karl-Liebknecht-Straße', $location->getRoad());
+        self::assertSame('8', $location->getHouseNumber());
+        self::assertSame('tourism', $location->getCategory());
+        self::assertSame('viewpoint', $location->getType());
+        self::assertSame([52.515, 52.525, 13.4, 13.41], $location->getBoundingBox());
+        self::assertSame('© OpenStreetMap', $location->getAttribution());
+        self::assertSame('ODbL', $location->getLicence());
+        self::assertSame(0.92, $location->getConfidence());
+        self::assertSame(135.0, $location->getAccuracyRadiusMeters());
+        self::assertSame('Europe/Berlin', $location->getTimezone());
+        self::assertSame('node', $location->getOsmType());
+        self::assertSame('123456', $location->getOsmId());
+        self::assertSame('Q64', $location->getWikidataId());
+        self::assertSame('de:Berlin', $location->getWikipedia());
+        self::assertSame(['name:en' => 'Berlin', 'short' => 'BER'], $location->getAltNames());
+        self::assertSame(['wikidata' => 'Q64', 'wikimedia_commons' => 'Category:Berlin'], $location->getExtraTags());
+        self::assertSame($refreshedAt, $location->getRefreshedAt());
+        self::assertFalse($location->isStale());
+    }
+}

--- a/test/Unit/Service/Geocoding/NominatimReverseGeocoderTest.php
+++ b/test/Unit/Service/Geocoding/NominatimReverseGeocoderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\NominatimReverseGeocoder;
+use MagicSunday\Memories\Utility\MediaMath;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class NominatimReverseGeocoderTest extends TestCase
+{
+    #[Test]
+    public function parsesExtendedMetadata(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $response   = $this->createMock(ResponseInterface::class);
+
+        $httpClient
+            ->expects(self::once())
+            ->method('request')
+            ->with(
+                'GET',
+                'https://nominatim.openstreetmap.org/reverse',
+                self::callback(static function (array $options): bool {
+                    self::assertSame('application/json', $options['headers']['Accept']);
+                    self::assertSame('jsonv2', $options['query']['format']);
+                    self::assertSame('1', $options['query']['addressdetails']);
+                    self::assertSame('1', $options['query']['namedetails']);
+                    self::assertSame('1', $options['query']['extratags']);
+
+                    return true;
+                })
+            )
+            ->willReturn($response);
+
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('toArray')->with(false)->willReturn([
+            'place_id'     => 123456,
+            'display_name' => 'Berlin, Deutschland',
+            'lat'          => '52.520008',
+            'lon'          => '13.404954',
+            'address'      => [
+                'country_code' => 'de',
+                'country'      => 'Deutschland',
+                'state'        => 'Berlin',
+                'county'       => 'Berlin',
+                'city'         => 'Berlin',
+                'suburb'       => 'Mitte',
+                'neighbourhood'=> 'Nikolaiviertel',
+                'postcode'     => '10178',
+                'road'         => 'Karl-Liebknecht-Straße',
+                'house_number' => '8',
+            ],
+            'boundingbox' => ['52.515', '52.525', '13.4', '13.41'],
+            'category'    => 'tourism',
+            'type'        => 'viewpoint',
+            'attribution' => 'Data © OpenStreetMap contributors',
+            'licence'     => 'ODbL',
+            'importance'  => 0.92,
+            'osm_type'    => 'node',
+            'osm_id'      => 123456,
+            'extratags'   => [
+                'wikidata' => 'Q64',
+                'wikipedia' => 'de:Berlin',
+                'timezone' => 'Europe/Berlin',
+            ],
+            'namedetails' => [
+                'name'    => 'Berlin',
+                'name:en' => 'Berlin',
+                'short_name' => 'BER',
+            ],
+        ]);
+
+        $geocoder = new NominatimReverseGeocoder($httpClient);
+        $result   = $geocoder->reverse(52.520008, 13.404954, 'de');
+
+        self::assertNotNull($result);
+        self::assertSame('nominatim', $result->provider);
+        self::assertSame('123456', $result->providerPlaceId);
+        self::assertSame('Data © OpenStreetMap contributors', $result->attribution);
+        self::assertSame('ODbL', $result->licence);
+        self::assertSame('Europe/Berlin', $result->timezone);
+        self::assertSame('node', $result->osmType);
+        self::assertSame('123456', $result->osmId);
+        self::assertSame('Q64', $result->wikidataId);
+        self::assertSame('de:Berlin', $result->wikipedia);
+        self::assertSame(['wikidata' => 'Q64', 'wikipedia' => 'de:Berlin', 'timezone' => 'Europe/Berlin'], $result->extraTags);
+        self::assertSame(['name' => 'Berlin', 'name:en' => 'Berlin', 'short_name' => 'BER'], $result->altNames);
+        self::assertSame(0.92, $result->confidence);
+
+        self::assertNotNull($result->accuracyRadiusMeters);
+        $expectedRadius = max(
+            MediaMath::haversineDistanceInMeters(52.520008, 13.404954, 52.525, 13.404954),
+            MediaMath::haversineDistanceInMeters(52.520008, 13.404954, 52.515, 13.404954),
+            MediaMath::haversineDistanceInMeters(52.520008, 13.404954, 52.520008, 13.41),
+            MediaMath::haversineDistanceInMeters(52.520008, 13.404954, 52.520008, 13.4),
+        );
+        self::assertEqualsWithDelta($expectedRadius, $result->accuracyRadiusMeters, 0.01);
+
+        self::assertNotNull($result->refreshedAt);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the geocoding result DTO and Nominatim parsing to expose attribution, licensing, confidence, timezone and provider references
- persist the enriched metadata on Location entities, update the resolver workflow, and add a migration with a (countryCode, city) index
- add focused unit tests for the new metadata handling and provider parsing

## Testing
- composer ci:test *(fails: bin/php not found in the execution environment)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter LocationResolverMetadataTest
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter LocationMetadataTest
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter NominatimReverseGeocoderTest

------
https://chatgpt.com/codex/tasks/task_e_68e153e6f934832385a0999cc0549351