### PR TITLE
Enhance cluster metadata persistence and indexing

### DIFF
--- a/migrations/Version20240209000100.php
+++ b/migrations/Version20240209000100.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+use MagicSunday\Memories\Utility\GeoCell;
+
+use function array_is_list;
+use function array_map;
+use function is_array;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function ksort;
+use function sha1;
+
+final class Version20240209000100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add rich metadata columns to cluster table and backfill values';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $indexes  = $this->connection->createSchemaManager()->listTableIndexes('cluster');
+
+        foreach ($indexes as $index) {
+            if ($index->isUnique() && $index->getColumns() === ['fingerprint']) {
+                $this->addSql($platform->getDropIndexSQL($index, 'cluster'));
+            }
+        }
+
+        $this->addSql('ALTER TABLE cluster ADD startAt DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD endAt DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD membersCount INT NOT NULL DEFAULT 0');
+        $this->addSql('ALTER TABLE cluster ADD photoCount INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD videoCount INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD cover_id BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD location_id BIGINT DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD algorithmVersion VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD configHash VARCHAR(64) DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD centroidLat DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD centroidLon DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('ALTER TABLE cluster ADD centroidCell7 VARCHAR(32) DEFAULT NULL');
+
+        $this->addSql('CREATE INDEX idx_cluster_start_at ON cluster (startAt)');
+        $this->addSql('CREATE INDEX idx_cluster_end_at ON cluster (endAt)');
+        $this->addSql('CREATE INDEX idx_cluster_members_count ON cluster (membersCount)');
+        $this->addSql('CREATE INDEX idx_cluster_cover_id ON cluster (cover_id)');
+        $this->addSql('CREATE INDEX idx_cluster_location_id ON cluster (location_id)');
+        $this->addSql('CREATE INDEX idx_cluster_centroid_cell7 ON cluster (centroidCell7)');
+        $this->addSql('CREATE INDEX idx_cluster_config_hash ON cluster (configHash)');
+        $this->addSql('ALTER TABLE cluster ADD CONSTRAINT FK_cluster_cover_media FOREIGN KEY (cover_id) REFERENCES media (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE cluster ADD CONSTRAINT FK_cluster_location_location FOREIGN KEY (location_id) REFERENCES location (id) ON DELETE SET NULL');
+
+        $this->backfillClusterMetadata();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE cluster DROP FOREIGN KEY FK_cluster_cover_media');
+        $this->addSql('ALTER TABLE cluster DROP FOREIGN KEY FK_cluster_location_location');
+        $this->addSql('DROP INDEX idx_cluster_start_at ON cluster');
+        $this->addSql('DROP INDEX idx_cluster_end_at ON cluster');
+        $this->addSql('DROP INDEX idx_cluster_members_count ON cluster');
+        $this->addSql('DROP INDEX idx_cluster_cover_id ON cluster');
+        $this->addSql('DROP INDEX idx_cluster_location_id ON cluster');
+        $this->addSql('DROP INDEX idx_cluster_centroid_cell7 ON cluster');
+        $this->addSql('DROP INDEX idx_cluster_config_hash ON cluster');
+        $this->addSql('ALTER TABLE cluster DROP startAt, DROP endAt, DROP membersCount, DROP photoCount, DROP videoCount, DROP cover_id, DROP location_id, DROP algorithmVersion, DROP configHash, DROP centroidLat, DROP centroidLon, DROP centroidCell7');
+        $this->addSql('CREATE UNIQUE INDEX uniq_cluster_fingerprint ON cluster (fingerprint)');
+    }
+
+    private function backfillClusterMetadata(): void
+    {
+        $clusters = $this->connection->fetchAllAssociative('SELECT id, members, centroid, params FROM cluster');
+
+        foreach ($clusters as $cluster) {
+            $id = (int) $cluster['id'];
+            $memberIds = $this->decodeMembers($cluster['members'] ?? '[]');
+            $membersCount = count($memberIds);
+
+            $photoCount = null;
+            $videoCount = null;
+            $startAt    = null;
+            $endAt      = null;
+
+            if ($memberIds !== []) {
+                $rows = $this->connection->executeQuery(
+                    'SELECT id, takenAt, isVideo FROM media WHERE id IN (?)',
+                    [$memberIds],
+                    [ArrayParameterType::INTEGER]
+                )->fetchAllAssociative();
+
+                if ($rows !== []) {
+                    $photoCount = 0;
+                    $videoCount = 0;
+
+                    foreach ($rows as $row) {
+                        $isVideo = (int) ($row['isVideo'] ?? 0) === 1;
+                        if ($isVideo) {
+                            ++$videoCount;
+                        } else {
+                            ++$photoCount;
+                        }
+
+                        $takenAtRaw = $row['takenAt'] ?? null;
+                        if ($takenAtRaw === null) {
+                            continue;
+                        }
+
+                        $dt = new DateTimeImmutable((string) $takenAtRaw);
+                        if ($startAt === null || $dt < $startAt) {
+                            $startAt = $dt;
+                        }
+
+                        if ($endAt === null || $dt > $endAt) {
+                            $endAt = $dt;
+                        }
+                    }
+                }
+            }
+
+            $centroidLat = null;
+            $centroidLon = null;
+            $centroidCell = null;
+            $centroidData = json_decode((string) ($cluster['centroid'] ?? 'null'), true);
+            if (is_array($centroidData)) {
+                $centroidLat = $this->numericOrNull($centroidData['lat'] ?? null);
+                $centroidLon = $this->numericOrNull($centroidData['lon'] ?? null);
+                if ($centroidLat !== null && $centroidLon !== null) {
+                    $centroidCell = GeoCell::fromPoint($centroidLat, $centroidLon, 7);
+                }
+            }
+
+            $params = json_decode((string) ($cluster['params'] ?? 'null'), true);
+            $params = is_array($params) ? $params : [];
+            $algorithmVersion = $this->resolveAlgorithmVersion($params);
+            $configHash       = $this->computeConfigHash($params);
+
+            $this->connection->update(
+                'cluster',
+                [
+                    'membersCount'      => $membersCount,
+                    'photoCount'        => $photoCount,
+                    'videoCount'        => $videoCount,
+                    'startAt'           => $startAt?->format('Y-m-d H:i:s'),
+                    'endAt'             => $endAt?->format('Y-m-d H:i:s'),
+                    'centroidLat'       => $centroidLat,
+                    'centroidLon'       => $centroidLon,
+                    'centroidCell7'     => $centroidCell,
+                    'algorithmVersion'  => $algorithmVersion,
+                    'configHash'        => $configHash,
+                ],
+                ['id' => $id],
+                [
+                    'membersCount'     => ParameterType::INTEGER,
+                    'photoCount'       => ParameterType::INTEGER,
+                    'videoCount'       => ParameterType::INTEGER,
+                    'startAt'          => Types::DATETIME_MUTABLE,
+                    'endAt'            => Types::DATETIME_MUTABLE,
+                    'centroidLat'      => ParameterType::FLOAT,
+                    'centroidLon'      => ParameterType::FLOAT,
+                    'centroidCell7'    => ParameterType::STRING,
+                    'algorithmVersion' => ParameterType::STRING,
+                    'configHash'       => ParameterType::STRING,
+                ]
+            );
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function resolveAlgorithmVersion(array $params): ?string
+    {
+        $candidates = [
+            $params['algorithm_version'] ?? null,
+            $params['algorithmVersion'] ?? null,
+            $params['version'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) && $candidate !== '') {
+                return $candidate;
+            }
+
+            if (is_int($candidate)) {
+                return (string) $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function computeConfigHash(array $params): ?string
+    {
+        if ($params === []) {
+            return null;
+        }
+
+        $normalized = $this->normaliseParams($params);
+        $encoded    = json_encode($normalized);
+
+        if ($encoded === false) {
+            return null;
+        }
+
+        return sha1($encoded);
+    }
+
+    /**
+     * @param array<string|int, mixed> $value
+     *
+     * @return array<string|int, mixed>
+     */
+    private function normaliseParams(array $value): array
+    {
+        if (array_is_list($value)) {
+            return array_map(function ($entry): mixed {
+                if (is_array($entry)) {
+                    return $this->normaliseParams($entry);
+                }
+
+                return $entry;
+            }, $value);
+        }
+
+        ksort($value);
+
+        foreach ($value as $key => $entry) {
+            if (is_array($entry)) {
+                $value[$key] = $this->normaliseParams($entry);
+            }
+        }
+
+        return $value;
+    }
+
+    private function decodeMembers(?string $json): array
+    {
+        $decoded = json_decode((string) $json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($decoded as $value) {
+            if (is_int($value)) {
+                $ids[] = $value;
+                continue;
+            }
+
+            if (is_numeric($value)) {
+                $ids[] = (int) $value;
+            }
+        }
+
+        return $ids;
+    }
+
+    private function numericOrNull(mixed $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_int($value) || is_float($value) || is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Clusterer/ClusterDraft.php
+++ b/src/Clusterer/ClusterDraft.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer;
 
+use DateTimeImmutable;
+use MagicSunday\Memories\Entity\Location;
+
 /**
  * Minimal DTO used across strategies and persistence.
  */
@@ -27,7 +30,34 @@ final class ClusterDraft
         private readonly array $centroid,
         private readonly array $members,
     ) {
+        $this->membersCount = count($members);
+        $this->centroidLat  = $centroid['lat'] ?? null;
+        $this->centroidLon  = $centroid['lon'] ?? null;
     }
+
+    private ?DateTimeImmutable $startAt = null;
+
+    private ?DateTimeImmutable $endAt = null;
+
+    private int $membersCount = 0;
+
+    private ?int $photoCount = null;
+
+    private ?int $videoCount = null;
+
+    private ?int $coverMediaId = null;
+
+    private ?Location $location = null;
+
+    private ?string $algorithmVersion = null;
+
+    private ?string $configHash = null;
+
+    private ?float $centroidLat = null;
+
+    private ?float $centroidLon = null;
+
+    private ?string $centroidCell7 = null;
 
     public function getAlgorithm(): string
     {
@@ -64,5 +94,125 @@ final class ClusterDraft
     public function getMembers(): array
     {
         return $this->members;
+    }
+
+    public function getStartAt(): ?DateTimeImmutable
+    {
+        return $this->startAt;
+    }
+
+    public function setStartAt(?DateTimeImmutable $startAt): void
+    {
+        $this->startAt = $startAt;
+    }
+
+    public function getEndAt(): ?DateTimeImmutable
+    {
+        return $this->endAt;
+    }
+
+    public function setEndAt(?DateTimeImmutable $endAt): void
+    {
+        $this->endAt = $endAt;
+    }
+
+    public function getMembersCount(): int
+    {
+        return $this->membersCount;
+    }
+
+    public function setMembersCount(int $count): void
+    {
+        $this->membersCount = $count;
+    }
+
+    public function getPhotoCount(): ?int
+    {
+        return $this->photoCount;
+    }
+
+    public function setPhotoCount(?int $count): void
+    {
+        $this->photoCount = $count;
+    }
+
+    public function getVideoCount(): ?int
+    {
+        return $this->videoCount;
+    }
+
+    public function setVideoCount(?int $count): void
+    {
+        $this->videoCount = $count;
+    }
+
+    public function getCoverMediaId(): ?int
+    {
+        return $this->coverMediaId;
+    }
+
+    public function setCoverMediaId(?int $mediaId): void
+    {
+        $this->coverMediaId = $mediaId;
+    }
+
+    public function getLocation(): ?Location
+    {
+        return $this->location;
+    }
+
+    public function setLocation(?Location $location): void
+    {
+        $this->location = $location;
+    }
+
+    public function getAlgorithmVersion(): ?string
+    {
+        return $this->algorithmVersion;
+    }
+
+    public function setAlgorithmVersion(?string $version): void
+    {
+        $this->algorithmVersion = $version;
+    }
+
+    public function getConfigHash(): ?string
+    {
+        return $this->configHash;
+    }
+
+    public function setConfigHash(?string $hash): void
+    {
+        $this->configHash = $hash;
+    }
+
+    public function getCentroidLat(): ?float
+    {
+        return $this->centroidLat;
+    }
+
+    public function setCentroidLat(?float $lat): void
+    {
+        $this->centroidLat = $lat;
+    }
+
+    public function getCentroidLon(): ?float
+    {
+        return $this->centroidLon;
+    }
+
+    public function setCentroidLon(?float $lon): void
+    {
+        $this->centroidLon = $lon;
+    }
+
+    public function getCentroidCell7(): ?string
+    {
+        return $this->centroidCell7;
+    }
+
+    public function setCentroidCell7(?string $cell): void
+    {
+        $this->centroidCell7 = $cell;
     }
 }

--- a/src/Entity/Cluster.php
+++ b/src/Entity/Cluster.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Entity;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use MagicSunday\Memories\Utility\GeoCell;
 
 use function count;
 use function implode;
@@ -26,9 +27,20 @@ use const SORT_NUMERIC;
  * Cluster of related media grouped by a specific clustering algorithm.
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'cluster')]
+#[ORM\Table(
+    name: 'cluster',
+    indexes: [
+        new ORM\Index(name: 'idx_cluster_fingerprint', columns: ['fingerprint']),
+        new ORM\Index(name: 'idx_cluster_start_at', columns: ['startAt']),
+        new ORM\Index(name: 'idx_cluster_end_at', columns: ['endAt']),
+        new ORM\Index(name: 'idx_cluster_members_count', columns: ['membersCount']),
+        new ORM\Index(name: 'idx_cluster_cover_id', columns: ['cover_id']),
+        new ORM\Index(name: 'idx_cluster_location_id', columns: ['location_id']),
+        new ORM\Index(name: 'idx_cluster_centroid_cell7', columns: ['centroidCell7']),
+        new ORM\Index(name: 'idx_cluster_config_hash', columns: ['configHash']),
+    ]
+)]
 #[ORM\UniqueConstraint(name: 'uniq_cluster_algo_fp', columns: ['algorithm', 'fingerprint'])]
-#[ORM\Index(name: 'idx_cluster_fingerprint', columns: ['fingerprint'])]
 class Cluster
 {
     /**
@@ -78,8 +90,82 @@ class Cluster
     /**
      * Order-insensitive hash derived from all member identifiers.
      */
-    #[ORM\Column(type: Types::STRING, length: 64, unique: true)]
+    #[ORM\Column(type: Types::STRING, length: 64)]
     private string $fingerprint;
+
+    /**
+     * Timestamp that marks the beginning of the cluster timeline.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $startAt = null;
+
+    /**
+     * Timestamp that marks the end of the cluster timeline.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $endAt = null;
+
+    /**
+     * Number of members contained in the cluster.
+     */
+    #[ORM\Column(type: Types::INTEGER, options: ['unsigned' => true])]
+    private int $membersCount = 0;
+
+    /**
+     * Number of photo members contained in the cluster.
+     */
+    #[ORM\Column(type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+    private ?int $photoCount = null;
+
+    /**
+     * Number of video members contained in the cluster.
+     */
+    #[ORM\Column(type: Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+    private ?int $videoCount = null;
+
+    /**
+     * Cover media chosen to represent the cluster.
+     */
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'cover_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Media $cover = null;
+
+    /**
+     * Dominant location representing the cluster.
+     */
+    #[ORM\ManyToOne(targetEntity: Location::class)]
+    #[ORM\JoinColumn(name: 'location_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Location $location = null;
+
+    /**
+     * Semantic version of the clustering algorithm.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $algorithmVersion = null;
+
+    /**
+     * Hash of the clustering configuration used to build the cluster.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
+    private ?string $configHash = null;
+
+    /**
+     * Latitude component of the centroid stored redundantly for querying.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $centroidLat = null;
+
+    /**
+     * Longitude component of the centroid stored redundantly for querying.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $centroidLon = null;
+
+    /**
+     * Approximate spatial cell identifier for the centroid.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $centroidCell7 = null;
 
     /**
      * @param string              $algorithm Algorithm used for clustering.
@@ -101,6 +187,20 @@ class Cluster
 
         // Pre-compute the fingerprint to ensure deterministic cluster identity.
         $this->fingerprint = self::computeFingerprint($this->members);
+        $this->membersCount = count($members);
+        $this->synchroniseCentroid($centroid);
+    }
+
+    /**
+     * Updates derived centroid metadata.
+     *
+     * @param array{lat: float, lon: float} $centroid
+     */
+    private function synchroniseCentroid(array $centroid): void
+    {
+        $this->centroidLat = $centroid['lat'] ?? null;
+        $this->centroidLon = $centroid['lon'] ?? null;
+        $this->updateCentroidCell();
     }
 
     /**
@@ -161,6 +261,17 @@ class Cluster
     }
 
     /**
+     * Stores the centroid and synchronises scalar projections.
+     *
+     * @param array{lat: float, lon: float} $value
+     */
+    public function setCentroid(array $value): void
+    {
+        $this->centroid = $value;
+        $this->synchroniseCentroid($value);
+    }
+
+    /**
      * Returns the list of media identifiers associated with the cluster.
      *
      * @return list<int> Media identifiers belonging to the cluster.
@@ -188,5 +299,209 @@ class Cluster
     public function getFingerprint(): string
     {
         return $this->fingerprint;
+    }
+
+    /**
+     * Returns the start timestamp of the cluster timeline.
+     */
+    public function getStartAt(): ?DateTimeImmutable
+    {
+        return $this->startAt;
+    }
+
+    /**
+     * Updates the start timestamp of the cluster timeline.
+     */
+    public function setStartAt(?DateTimeImmutable $startAt): void
+    {
+        $this->startAt = $startAt;
+    }
+
+    /**
+     * Returns the end timestamp of the cluster timeline.
+     */
+    public function getEndAt(): ?DateTimeImmutable
+    {
+        return $this->endAt;
+    }
+
+    /**
+     * Updates the end timestamp of the cluster timeline.
+     */
+    public function setEndAt(?DateTimeImmutable $endAt): void
+    {
+        $this->endAt = $endAt;
+    }
+
+    /**
+     * Returns the number of members within the cluster.
+     */
+    public function getMembersCount(): int
+    {
+        return $this->membersCount;
+    }
+
+    /**
+     * Sets the number of members contained in the cluster.
+     */
+    public function setMembersCount(int $count): void
+    {
+        $this->membersCount = $count;
+    }
+
+    /**
+     * Returns the number of photo members if known.
+     */
+    public function getPhotoCount(): ?int
+    {
+        return $this->photoCount;
+    }
+
+    /**
+     * Stores the number of photo members.
+     */
+    public function setPhotoCount(?int $photoCount): void
+    {
+        $this->photoCount = $photoCount;
+    }
+
+    /**
+     * Returns the number of video members if known.
+     */
+    public function getVideoCount(): ?int
+    {
+        return $this->videoCount;
+    }
+
+    /**
+     * Stores the number of video members.
+     */
+    public function setVideoCount(?int $videoCount): void
+    {
+        $this->videoCount = $videoCount;
+    }
+
+    /**
+     * Returns the selected cover media entity.
+     */
+    public function getCover(): ?Media
+    {
+        return $this->cover;
+    }
+
+    /**
+     * Updates the selected cover media entity.
+     */
+    public function setCover(?Media $cover): void
+    {
+        $this->cover = $cover;
+    }
+
+    /**
+     * Returns the dominant location entity.
+     */
+    public function getLocation(): ?Location
+    {
+        return $this->location;
+    }
+
+    /**
+     * Updates the dominant location entity.
+     */
+    public function setLocation(?Location $location): void
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * Returns the semantic version of the algorithm used.
+     */
+    public function getAlgorithmVersion(): ?string
+    {
+        return $this->algorithmVersion;
+    }
+
+    /**
+     * Stores the semantic version of the algorithm used.
+     */
+    public function setAlgorithmVersion(?string $version): void
+    {
+        $this->algorithmVersion = $version;
+    }
+
+    /**
+     * Returns the configuration hash used to generate the cluster.
+     */
+    public function getConfigHash(): ?string
+    {
+        return $this->configHash;
+    }
+
+    /**
+     * Stores the configuration hash used to generate the cluster.
+     */
+    public function setConfigHash(?string $hash): void
+    {
+        $this->configHash = $hash;
+    }
+
+    /**
+     * Returns the centroid latitude if available.
+     */
+    public function getCentroidLat(): ?float
+    {
+        return $this->centroidLat;
+    }
+
+    /**
+     * Stores the centroid latitude and updates the derived cell key.
+     */
+    public function setCentroidLat(?float $lat): void
+    {
+        $this->centroidLat = $lat;
+        $this->updateCentroidCell();
+    }
+
+    /**
+     * Returns the centroid longitude if available.
+     */
+    public function getCentroidLon(): ?float
+    {
+        return $this->centroidLon;
+    }
+
+    /**
+     * Stores the centroid longitude and updates the derived cell key.
+     */
+    public function setCentroidLon(?float $lon): void
+    {
+        $this->centroidLon = $lon;
+        $this->updateCentroidCell();
+    }
+
+    /**
+     * Returns the centroid cell identifier.
+     */
+    public function getCentroidCell7(): ?string
+    {
+        return $this->centroidCell7;
+    }
+
+    /**
+     * Explicitly sets the centroid cell identifier.
+     */
+    public function setCentroidCell7(?string $cell): void
+    {
+        $this->centroidCell7 = $cell;
+    }
+
+    private function updateCentroidCell(): void
+    {
+        if ($this->centroidLat === null || $this->centroidLon === null) {
+            $this->centroidCell7 = null;
+            return;
+        }
+
+        $this->centroidCell7 = GeoCell::fromPoint($this->centroidLat, $this->centroidLon, 7);
     }
 }

--- a/src/Repository/ClusterRepository.php
+++ b/src/Repository/ClusterRepository.php
@@ -35,7 +35,8 @@ readonly class ClusterRepository
         $qb = $this->em->createQueryBuilder()
             ->select('c')
             ->from(Cluster::class, 'c')
-            ->orderBy('c.createdAt', 'DESC')
+            ->orderBy('c.startAt', 'DESC')
+            ->addOrderBy('c.createdAt', 'DESC')
             ->setMaxResults($limit);
 
         $query = $qb->getQuery();

--- a/src/Support/ClusterEntityToDraftMapper.php
+++ b/src/Support/ClusterEntityToDraftMapper.php
@@ -63,12 +63,27 @@ final class ClusterEntityToDraftMapper
             $centroid  = $e->getCentroid();
             $members   = $this->normalizeMembers($e->getMembers());
 
-            $out[] = new ClusterDraft(
+            $draft = new ClusterDraft(
                 algorithm: $algorithm,
                 params: $params,
                 centroid: $centroid,
                 members: $members
             );
+
+            $draft->setStartAt($e->getStartAt());
+            $draft->setEndAt($e->getEndAt());
+            $draft->setMembersCount($e->getMembersCount());
+            $draft->setPhotoCount($e->getPhotoCount());
+            $draft->setVideoCount($e->getVideoCount());
+            $draft->setCoverMediaId($e->getCover()?->getId());
+            $draft->setLocation($e->getLocation());
+            $draft->setAlgorithmVersion($e->getAlgorithmVersion());
+            $draft->setConfigHash($e->getConfigHash());
+            $draft->setCentroidLat($e->getCentroidLat());
+            $draft->setCentroidLon($e->getCentroidLon());
+            $draft->setCentroidCell7($e->getCentroidCell7());
+
+            $out[] = $draft;
         }
 
         return $out;

--- a/src/Utility/GeoCell.php
+++ b/src/Utility/GeoCell.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility;
+
+use function is_finite;
+use function max;
+use function min;
+use function round;
+use function sprintf;
+
+/**
+ * Generates coarse geo cell identifiers without relying on external libraries.
+ */
+final class GeoCell
+{
+    private const int DEFAULT_PRECISION = 4;
+
+    private function __construct()
+    {
+    }
+
+    public static function fromPoint(float $lat, float $lon, int $precision = self::DEFAULT_PRECISION): string
+    {
+        if (!is_finite($lat) || !is_finite($lon)) {
+            return '0.0000,0.0000';
+        }
+
+        $precision = max(1, min(7, $precision));
+
+        $lat = self::clampLatitude($lat);
+        $lon = self::normalizeLongitude($lon);
+
+        $format = sprintf('%%0.%df,%%0.%df', $precision, $precision);
+
+        return sprintf($format, round($lat, $precision), round($lon, $precision));
+    }
+
+    private static function clampLatitude(float $lat): float
+    {
+        if ($lat > 90.0) {
+            return 90.0;
+        }
+
+        if ($lat < -90.0) {
+            return -90.0;
+        }
+
+        return $lat;
+    }
+
+    private static function normalizeLongitude(float $lon): float
+    {
+        if ($lon >= -180.0 && $lon <= 180.0) {
+            return $lon;
+        }
+
+        $period = 360.0;
+        $normalized = $lon;
+        while ($normalized > 180.0) {
+            $normalized -= $period;
+        }
+
+        while ($normalized < -180.0) {
+            $normalized += $period;
+        }
+
+        return $normalized;
+    }
+}

--- a/test/Unit/Repository/ClusterRepositoryTest.php
+++ b/test/Unit/Repository/ClusterRepositoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use MagicSunday\Memories\Repository\ClusterRepository;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class ClusterRepositoryTest extends TestCase
+{
+    #[Test]
+    public function findLatestOrdersByStartAt(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $query = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getResult'])
+            ->getMock();
+        $query->method('getResult')->willReturn([]);
+
+        $qb = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['select', 'from', 'orderBy', 'addOrderBy', 'setMaxResults', 'getQuery'])
+            ->getMock();
+
+        /** @var list<array{string,string}> $orderBys */
+        $orderBys = [];
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('orderBy')->willReturnCallback(static function (string $field, string $direction) use (&$orderBys, &$qb): QueryBuilder {
+            $orderBys[] = [$field, $direction];
+
+            return $qb;
+        });
+        $qb->method('addOrderBy')->willReturnCallback(static function (string $field, string $direction) use (&$orderBys, &$qb): QueryBuilder {
+            $orderBys[] = [$field, $direction];
+
+            return $qb;
+        });
+        $qb->method('setMaxResults')->willReturnSelf();
+        $qb->method('getQuery')->willReturn($query);
+
+        $em->method('createQueryBuilder')->willReturn($qb);
+
+        $repository = new ClusterRepository($em);
+        $repository->findLatest(5);
+
+        self::assertSame([
+            ['c.startAt', 'DESC'],
+            ['c.createdAt', 'DESC'],
+        ], $orderBys);
+    }
+}

--- a/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
+++ b/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Clusterer;
+
+use DateInterval;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Entity\Cluster;
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Clusterer\ClusterPersistenceService;
+use MagicSunday\Memories\Service\Clusterer\Pipeline\MemberMediaLookupInterface;
+use MagicSunday\Memories\Service\Feed\CoverPickerInterface;
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\GeoCell;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+
+final class ClusterPersistenceServiceTest extends TestCase
+{
+    #[Test]
+    public function persistBatchedComputesMetadata(): void
+    {
+        $media = $this->buildMediaSet();
+        $lookup = new class($media) implements MemberMediaLookupInterface {
+            /** @param array<int, Media> $media */
+            public function __construct(private array $media) {}
+
+            public function findByIds(array $ids, bool $onlyVideos = false): array
+            {
+                $result = [];
+                foreach ($ids as $id) {
+                    if (isset($this->media[$id])) {
+                        $result[] = $this->media[$id];
+                    }
+                }
+
+                return $result;
+            }
+        };
+
+        $coverPicker = $this->createMock(CoverPickerInterface::class);
+        $coverPicker->method('pickCover')->willReturn($media[2]);
+
+        $persisted = null;
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $query = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getResult'])
+            ->getMock();
+        $query->method('getResult')->willReturn([]);
+
+        $qb = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['select', 'from', 'where', 'andWhere', 'setParameter', 'getQuery'])
+            ->getMock();
+        $qb->method('select')->willReturnSelf();
+        $qb->method('from')->willReturnSelf();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+        $qb->method('getQuery')->willReturn($query);
+
+        $em->method('createQueryBuilder')->willReturn($qb);
+        $em->method('persist')->willReturnCallback(static function (object $entity) use (&$persisted): void {
+            $persisted = $entity;
+        });
+        $em->method('flush');
+        $em->method('clear');
+
+        $service = new ClusterPersistenceService(
+            $em,
+            $lookup,
+            $coverPicker,
+            defaultBatchSize: 10,
+            maxMembers: 20
+        );
+
+        $draft = new ClusterDraft(
+            algorithm: 'demo',
+            params: [
+                'version' => '2024.1',
+                'member_quality' => ['ordered' => [2, 1, 3]],
+            ],
+            centroid: ['lat' => 48.123456, 'lon' => 11.654321],
+            members: [1, 2, 3],
+        );
+
+        $persistedCount = $service->persistBatched([$draft], 5, null);
+
+        self::assertSame(1, $persistedCount);
+        self::assertNotNull($persisted);
+        self::assertInstanceOf(Cluster::class, $persisted);
+
+        self::assertEquals($draft->getStartAt(), $persisted->getStartAt());
+        self::assertEquals($draft->getEndAt(), $persisted->getEndAt());
+        self::assertSame(3, $persisted->getMembersCount());
+        self::assertSame(2, $persisted->getPhotoCount());
+        self::assertSame(1, $persisted->getVideoCount());
+        self::assertSame(2, $persisted->getCover()?->getId());
+        self::assertSame($media[1]->getLocation(), $persisted->getLocation());
+        self::assertSame('2024.1', $persisted->getAlgorithmVersion());
+        self::assertSame($draft->getConfigHash(), $persisted->getConfigHash());
+        self::assertSame($draft->getCentroidLat(), $persisted->getCentroidLat());
+        self::assertSame($draft->getCentroidLon(), $persisted->getCentroidLon());
+        self::assertSame($draft->getCentroidCell7(), $persisted->getCentroidCell7());
+        self::assertSame(2, $draft->getCoverMediaId());
+        self::assertSame(3, $draft->getMembersCount());
+        self::assertSame(2, $draft->getPhotoCount());
+        self::assertSame(1, $draft->getVideoCount());
+        self::assertNotNull($draft->getConfigHash());
+        self::assertSame(GeoCell::fromPoint(48.123456, 11.654321, 7), $draft->getCentroidCell7());
+    }
+
+    /**
+     * @return array<int, Media>
+     */
+    private function buildMediaSet(): array
+    {
+        $home = new Location('osm', '1', 'Home', 48.1234, 11.5678, 'cell');
+        $this->setId($home, 42);
+
+        $base = new DateTimeImmutable('2024-05-20 10:00:00');
+
+        $media1 = $this->buildMedia(1, $base);
+        $media1->setIsVideo(false);
+        $media1->setLocation($home);
+
+        $media2 = $this->buildMedia(2, $base->add(new DateInterval('PT2H')));
+        $media2->setIsVideo(false);
+        $media2->setLocation($home);
+
+        $media3 = $this->buildMedia(3, $base->add(new DateInterval('PT4H')));
+        $media3->setIsVideo(true);
+
+        return [
+            1 => $media1,
+            2 => $media2,
+            3 => $media3,
+        ];
+    }
+
+    private function buildMedia(int $id, DateTimeImmutable $takenAt): Media
+    {
+        $media = new Media('path-' . $id . '.jpg', 'checksum-' . $id, 4096);
+        $this->setId($media, $id);
+        $media->setTakenAt($takenAt);
+        $media->setWidth(4000);
+        $media->setHeight(3000);
+        $media->setThumbnails(['small' => 'thumb-' . $id . '.jpg']);
+
+        return $media;
+    }
+
+    private function setId(object $entity, int $id): void
+    {
+        $ref = new ReflectionProperty($entity, 'id');
+        $ref->setAccessible(true);
+        $ref->setValue($entity, $id);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the `Cluster` entity with timeline, count, cover/location, version/hash, and centroid scalar metadata plus Doctrine indexes
- update cluster drafts, persistence, feed builders, and helpers to compute and consume the new metadata and add a GeoCell utility
- add a migration that backfills the new columns and expand unit coverage for persistence and repository ordering

## Testing
- composer ci:test *(fails: `bin/php` wrapper is unavailable in the container)*
- vendor/bin/phpunit -c .build/phpunit.xml *(fails: existing FeedController, MediaRepository, ThumbnailService, and TimeNormalizer tests require upstream fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68e153d888e88323b981740ffda1b42a