### PR TITLE
Ensure MEMORIES_HOME_VERSION_HASH has a default fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Der neue HTTP-Einstiegspunkt unter `public/index.php` liefert zwei Dinge:
 
 Unter `public/app/` liegt eine schlanke SPA (Vanilla JS + Vite), die den Feed lädt, Filter per UI anbietet und Cover-Galerien animiert darstellt. Die Anwendung läuft sowohl gegen den lokalen PHP-Server als auch gegen den Vite-Entwicklungsserver.
 
+> **Hinweis:** Die SPA respektiert die Umgebungsvariable `MEMORIES_HOME_VERSION_HASH`, um clientseitige Caches zu steuern. Wird sie nicht gesetzt, greift automatisch der Fallback-Wert `home_config_v1` aus `config/parameters.yaml`.
+
 ### Rückblick-Videos
 
 Jeder Rückblick erhält optional ein automatisch generiertes Video, das die Vorschaubilder in einer Sequenz mit Überblendungen zeigt. Die Generierung erfolgt asynchron über den neuen Konsolenbefehl `slideshow:generate`, der intern durch den HTTP-Controller angestoßen wird. Bereits erzeugte Videos landen standardmäßig im Verzeichnis `public/videos/` (konfigurierbar über die Umgebungsvariable `MEMORIES_SLIDESHOW_DIR`) und werden beim nächsten Abruf wiederverwendet, sodass keine unnötige Rechenzeit entsteht.

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -25,7 +25,7 @@ parameters:
     memories.hash.phash_prefix_length: 16
 
     # Home configuration
-    memories.home.version_hash: '%env(default::string:MEMORIES_HOME_VERSION_HASH)%'
+    memories.home.version_hash: '%env(default:home_config_v1:string:MEMORIES_HOME_VERSION_HASH)%'
 
     # Geocoding Defaults
     memories.geocoding.nominatim.base_url: '%env(string:NOMINATIM_BASE_URL)%'


### PR DESCRIPTION
## Summary
- ensure the `memories.home.version_hash` parameter uses a concrete default fallback when `MEMORIES_HOME_VERSION_HASH` is unset
- document that the SPA falls back to `home_config_v1` when the environment variable is not provided

## Testing
- composer ci:test *(fails: bin/php not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e159f0045483238d561a6e3a9fb845