### PR TITLE
Refine metadata extraction stage orchestration

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -110,17 +110,39 @@ services:
     MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor:
         arguments:
             $readExifForVideos: false
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 190 }
 
     MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface:
         alias: MagicSunday\Memories\Service\Metadata\Exif\DefaultExifValueAccessor
 
-    MagicSunday\Memories\Service\Metadata\XmpIptcExtractor: ~
+    MagicSunday\Memories\Service\Metadata\XmpIptcExtractor:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 180 }
 
-    MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor: ~
+    MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 160 }
 
-    MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor: ~
+    MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 150 }
 
-    MagicSunday\Memories\Service\Metadata\BurstIndexExtractor: ~
+    MagicSunday\Memories\Service\Metadata\BurstIndexExtractor:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 120 }
+
+    MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 170 }
+
+    MagicSunday\Memories\Service\Metadata\BurstDetector:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 140 }
+
+    MagicSunday\Memories\Service\Metadata\LivePairLinker:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 130 }
 
     MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher:
         arguments:
@@ -129,20 +151,30 @@ services:
             $homeRadiusKm: '%env(default::float:MEMORIES_HOME_RADIUS_KM)%'
             $homeVersionHash: '%memories.home.version_hash%'
             $cellDegrees: 0.01
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 110 }
 
     MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser: ~
 
     MagicSunday\Memories\Service\Metadata\TimeNormalizer:
         arguments:
             $defaultTimezone: '%memories.timezone.default%'
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 100 }
 
-    MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher: ~
+    MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 90 }
 
-    MagicSunday\Memories\Service\Metadata\DaypartEnricher: ~
+    MagicSunday\Memories\Service\Metadata\DaypartEnricher:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 80 }
 
     MagicSunday\Memories\Service\Metadata\SolarEnricher:
         arguments:
             $goldenMinutes: 60
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 70 }
 
     MagicSunday\Memories\Service\Metadata\Support\CommandLineFaceDetectionBackend:
         arguments:
@@ -162,12 +194,16 @@ services:
             $ffmpegBinary: '%memories.video.ffmpeg_path%'
             $ffprobeBinary: '%memories.video.ffprobe_path%'
             $posterFrameSecond: '%memories.video.poster_frame_second%'
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 60 }
 
     MagicSunday\Memories\Service\Metadata\FacePresenceDetector:
         arguments:
             $ffmpegBinary: '%memories.video.ffmpeg_path%'
             $ffprobeBinary: '%memories.video.ffprobe_path%'
             $posterFrameSecond: '%memories.video.poster_frame_second%'
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 50 }
 
     MagicSunday\Memories\Service\Metadata\VisionSceneTagModelInterface:
         alias: MagicSunday\Memories\Service\Metadata\HeuristicClipSceneTagModel
@@ -176,13 +212,19 @@ services:
         arguments:
             $maxTags: 5
             $minScore: 0.2
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 40 }
 
-    MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor: ~
+    MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor:
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 30 }
 
     MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor:
         arguments:
             $ffprobePath: '%env(string:FFPROBE_PATH)%'
             $slowMoFpsThreshold: 100.0
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 20 }
 
     MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor:
         arguments:
@@ -192,29 +234,12 @@ services:
             $ffmpegBinary: '%memories.video.ffmpeg_path%'
             $ffprobeBinary: '%memories.video.ffprobe_path%'
             $posterFrameSecond: '%memories.video.poster_frame_second%'
+        tags:
+            - { name: 'memories.metadata_extractor', priority: 10 }
 
     MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor:
         arguments:
-            $extractors:
-                - '@MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\XmpIptcExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\BurstDetector'
-                - '@MagicSunday\Memories\Service\Metadata\LivePairLinker'
-                - '@MagicSunday\Memories\Service\Metadata\BurstIndexExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher'
-                - '@MagicSunday\Memories\Service\Metadata\TimeNormalizer'
-                - '@MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher'
-                - '@MagicSunday\Memories\Service\Metadata\DaypartEnricher'
-                - '@MagicSunday\Memories\Service\Metadata\SolarEnricher'
-                - '@MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\FacePresenceDetector'
-                - '@MagicSunday\Memories\Service\Metadata\ClipSceneTagExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor'
-                - '@MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor'
+            $extractors: !tagged_iterator 'memories.metadata_extractor'
 
     MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface:
         alias: MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor
@@ -238,7 +263,9 @@ services:
 
     MagicSunday\Memories\Service\Indexing\Stage\DuplicateHandlingStage: ~
 
-    MagicSunday\Memories\Service\Indexing\Stage\MetadataExtractionStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\MetadataExtractionStage:
+        arguments:
+            $extractors: !tagged_iterator 'memories.metadata_extractor'
 
     MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage: ~
 

--- a/src/Service/Indexing/Stage/AbstractExtractorStage.php
+++ b/src/Service/Indexing/Stage/AbstractExtractorStage.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use DateTimeImmutable;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+use MagicSunday\Memories\Service\Metadata\MetadataFeatureVersion;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Throwable;
+
+use function sprintf;
+
+abstract class AbstractExtractorStage implements MediaIngestionStageInterface
+{
+    protected function shouldSkipExtraction(MediaIngestionContext $context): bool
+    {
+        if ($context->isSkipped()) {
+            return true;
+        }
+
+        $media = $context->getMedia();
+        if ($media === null) {
+            return true;
+        }
+
+        if ($context->isForce() === false
+            && $media->getFeatureVersion() === MetadataFeatureVersion::PIPELINE_VERSION
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param iterable<SingleMetadataExtractorInterface> $extractors
+     */
+    protected function runExtractors(MediaIngestionContext $context, iterable $extractors): MediaIngestionContext
+    {
+        $media = $context->getMedia();
+        if ($media === null) {
+            return $context;
+        }
+
+        $media->setIndexLog(null);
+
+        foreach ($extractors as $extractor) {
+            if ($extractor->supports($context->getFilePath(), $media) === false) {
+                continue;
+            }
+
+            try {
+                $media = $extractor->extract($context->getFilePath(), $media);
+            } catch (Throwable $exception) {
+                $media->setFeatureVersion(MetadataFeatureVersion::PIPELINE_VERSION);
+                $media->setIndexedAt(new DateTimeImmutable());
+
+                $message = sprintf('%s: %s', $exception::class, $exception->getMessage());
+                if ($message === '') {
+                    $media->setIndexLog(null);
+                } else {
+                    $media->setIndexLog($message);
+                }
+
+                $context->getOutput()->writeln(
+                    sprintf('<error>Metadata extraction failed for %s: %s</error>', $context->getFilePath(), $exception->getMessage())
+                );
+
+                return $context->withMedia($media);
+            }
+        }
+
+        $media->setFeatureVersion(MetadataFeatureVersion::PIPELINE_VERSION);
+        $media->setIndexedAt(new DateTimeImmutable());
+
+        $log = $media->getIndexLog();
+        if ($log === null || $log === '') {
+            $media->setIndexLog(null);
+        }
+
+        return $context->withMedia($media);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an AbstractExtractorStage with shared skip guards and extractor execution
- refactor MetadataExtractionStage to consume individual extractors and reuse the helper logic
- tag metadata extractors for DI, wire them into the stage, and update the related unit tests

## Testing
- composer ci:test *(fails: `bin/php` not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15aa7fa348323b4fd280f77b539bc