### PR TITLE
Refactor metadata extraction into dedicated stages

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -263,9 +263,15 @@ services:
 
     MagicSunday\Memories\Service\Indexing\Stage\DuplicateHandlingStage: ~
 
-    MagicSunday\Memories\Service\Indexing\Stage\MetadataExtractionStage:
-        arguments:
-            $extractors: !tagged_iterator 'memories.metadata_extractor'
+    MagicSunday\Memories\Service\Indexing\Stage\MetadataStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\BurstLiveStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\TimeStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\GeoStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\QualityStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\FacesStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\SceneStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\ContentKindStage: ~
+    MagicSunday\Memories\Service\Indexing\Stage\HashStage: ~
 
     MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage: ~
 
@@ -278,7 +284,15 @@ services:
             $stages:
                 - '@MagicSunday\Memories\Service\Indexing\Stage\MimeDetectionStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\DuplicateHandlingStage'
-                - '@MagicSunday\Memories\Service\Indexing\Stage\MetadataExtractionStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\MetadataStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\BurstLiveStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\TimeStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\GeoStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\QualityStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\FacesStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\SceneStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\ContentKindStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\HashStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\PersistenceBatchStage'
 

--- a/src/Service/Indexing/Stage/BurstLiveStage.php
+++ b/src/Service/Indexing/Stage/BurstLiveStage.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\BurstDetector;
+use MagicSunday\Memories\Service\Metadata\BurstIndexExtractor;
+use MagicSunday\Memories\Service\Metadata\LivePairLinker;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+
+final class BurstLiveStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(
+        BurstDetector $burstDetector,
+        LivePairLinker $livePairLinker,
+        BurstIndexExtractor $burstIndexExtractor,
+    ) {
+        $this->extractors = [
+            $burstDetector,
+            $livePairLinker,
+            $burstIndexExtractor,
+        ];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/ContentKindStage.php
+++ b/src/Service/Indexing/Stage/ContentKindStage.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+
+final class ContentKindStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(ContentClassifierExtractor $contentClassifier)
+    {
+        $this->extractors = [$contentClassifier];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/FacesStage.php
+++ b/src/Service/Indexing/Stage/FacesStage.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\FacePresenceDetector;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+
+final class FacesStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(FacePresenceDetector $facePresenceDetector)
+    {
+        $this->extractors = [$facePresenceDetector];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/GeoStage.php
+++ b/src/Service/Indexing/Stage/GeoStage.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+
+final class GeoStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(GeoFeatureEnricher $geo)
+    {
+        $this->extractors = [$geo];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/HashStage.php
+++ b/src/Service/Indexing/Stage/HashStage.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+
+final class HashStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(PerceptualHashExtractor $hash)
+    {
+        $this->extractors = [$hash];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/MetadataStage.php
+++ b/src/Service/Indexing/Stage/MetadataStage.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor;
+use MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor;
+use MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor;
+use MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor;
+use MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use MagicSunday\Memories\Service\Metadata\XmpIptcExtractor;
+
+final class MetadataStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(
+        ExifMetadataExtractor $exif,
+        XmpIptcExtractor $xmp,
+        FileStatMetadataExtractor $fileStat,
+        FilenameKeywordExtractor $filenameKeyword,
+        AppleHeuristicsExtractor $appleHeuristics,
+        FfprobeMetadataExtractor $ffprobe,
+    ) {
+        $this->extractors = [
+            $exif,
+            $xmp,
+            $fileStat,
+            $filenameKeyword,
+            $appleHeuristics,
+            $ffprobe,
+        ];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/QualityStage.php
+++ b/src/Service/Indexing/Stage/QualityStage.php
@@ -13,19 +13,26 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor;
 
-final class MetadataExtractionStage extends AbstractExtractorStage
+final class QualityStage extends AbstractExtractorStage
 {
     /**
-     * @param iterable<SingleMetadataExtractorInterface> $extractors
+     * @var iterable<SingleMetadataExtractorInterface>
      */
-    public function __construct(
-        private readonly iterable $extractors,
-    ) {
+    private readonly iterable $extractors;
+
+    public function __construct(VisionSignatureExtractor $visionSignature)
+    {
+        $this->extractors = [$visionSignature];
     }
 
     public function process(MediaIngestionContext $context): MediaIngestionContext
     {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
         if ($this->shouldSkipExtraction($context)) {
             return $context;
         }

--- a/src/Service/Indexing/Stage/SceneStage.php
+++ b/src/Service/Indexing/Stage/SceneStage.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\ClipSceneTagExtractor;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+
+final class SceneStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(ClipSceneTagExtractor $sceneTagExtractor)
+    {
+        $this->extractors = [$sceneTagExtractor];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}

--- a/src/Service/Indexing/Stage/TimeStage.php
+++ b/src/Service/Indexing/Stage/TimeStage.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher;
+use MagicSunday\Memories\Service\Metadata\DaypartEnricher;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use MagicSunday\Memories\Service\Metadata\SolarEnricher;
+use MagicSunday\Memories\Service\Metadata\TimeNormalizer;
+
+final class TimeStage extends AbstractExtractorStage
+{
+    /**
+     * @var iterable<SingleMetadataExtractorInterface>
+     */
+    private readonly iterable $extractors;
+
+    public function __construct(
+        TimeNormalizer $normalizer,
+        CalendarFeatureEnricher $calendar,
+        DaypartEnricher $daypart,
+        SolarEnricher $solar,
+    ) {
+        $this->extractors = [
+            $normalizer,
+            $calendar,
+            $daypart,
+            $solar,
+        ];
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        if ($this->shouldSkipExtraction($context)) {
+            return $context;
+        }
+
+        return $this->runExtractors($context, $this->extractors);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the monolithic metadata extraction stage with dedicated metadata, time, geo, quality, content kind, hash, burst/live, faces, and scene stages
- update the service container pipeline wiring to use the new stage classes
- adjust unit tests to exercise extractor behaviour via local test stages

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e15c9c8af48323a13685abe9b34f4d