### PR TITLE
Fix default MEMORIES_HOME_VERSION_HASH fallback

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -25,7 +25,8 @@ parameters:
     memories.hash.phash_prefix_length: 16
 
     # Home configuration
-    memories.home.version_hash: '%env(default:home_config_v1:string:MEMORIES_HOME_VERSION_HASH)%'
+    env(MEMORIES_HOME_VERSION_HASH): 'home_config_v1'
+    memories.home.version_hash: '%env(string:MEMORIES_HOME_VERSION_HASH)%'
 
     # Geocoding Defaults
     memories.geocoding.nominatim.base_url: '%env(string:NOMINATIM_BASE_URL)%'


### PR DESCRIPTION
## Summary
- set the default MEMORIES_HOME_VERSION_HASH value directly in parameters.yaml so the DI container can resolve the env fallback
- continue to expose the same home version hash parameter for overriding via the environment

## Testing
- composer ci:test *(fails: `bin/php` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16133f370832393cecdec3f3f62cd