### PR TITLE
Fix default ffmpeg binaries for metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,5 @@ Die Vision-Pipeline speichert jetzt voraggregierte Qualitätsmetriken direkt am 
 * Rausch-Score `< 0.25`
 
 Alle Score-Werte bewegen sich zwischen `0` und `1`, wobei `1` den bestmöglichen Zustand beschreibt. Die Cluster-Heuristiken greifen bevorzugt auf diese aggregierten Zahlen zu; fehlen sie, bleiben die Rohmetriken (Auflösung, Schärfe, ISO, Helligkeit usw.) als Fallback erhalten.
+
+Für die Berechnung der Qualitätsmetriken und Posterframes greift der Indexer standardmäßig auf die Binaries `ffmpeg` und `ffprobe` aus dem `PATH` zu. Solltest du abweichende Installationspfade verwenden, setzt du die Umgebungsvariablen `FFMPEG_PATH` bzw. `FFPROBE_PATH` oder überschreibst die zugehörigen Symfony-Parameter `memories.video.ffmpeg_path` und `memories.video.ffprobe_path` in deiner Konfiguration. Beide Parameter bringen nun ohne weitere Anpassungen lauffähige Standardwerte mit.

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -9,8 +9,8 @@ parameters:
     memories.index.batch_size: '%env(int:MEMORIES_INDEX_BATCH_SIZE)%'
 
     memories.video.poster_frame_second: 1.5
-    memories.video.ffmpeg_path: '%env(default::string:FFMPEG_PATH)%'
-    memories.video.ffprobe_path: '%env(default::string:FFPROBE_PATH)%'
+    memories.video.ffmpeg_path: '%env(default:ffmpeg:FFMPEG_PATH)%'
+    memories.video.ffprobe_path: '%env(default:ffprobe:FFPROBE_PATH)%'
 
     memories.face_detection.binary: '%env(default::string:MEMORIES_FACE_DETECTOR_BIN)%'
     memories.face_detection.cascade: '%env(default::string:MEMORIES_FACE_DETECTOR_CASCADE)%'


### PR DESCRIPTION
## Summary
- ensure the ffmpeg and ffprobe Symfony parameters default to the standard binaries when no environment override is present
- document the metadata pipeline's ffmpeg/ffprobe requirements and configuration options in the README

## Testing
- composer ci:test *(fails: phpstan reports 530 pre-existing analysis errors in the current tree)*

------
https://chatgpt.com/codex/tasks/task_e_68e161e1d5c48323b1ab82e61309e6c9