### PR TITLE
BUGFIX: provide defaults for face detection paths

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -14,8 +14,10 @@ parameters:
     memories.video.ffprobe_binary_default: 'ffprobe'
     memories.video.ffprobe_path: "%env(default:memories.video.ffprobe_binary_default:FFPROBE_PATH)%"
 
-    memories.face_detection.binary: '%env(default::string:MEMORIES_FACE_DETECTOR_BIN)%'
-    memories.face_detection.cascade: '%env(default::string:MEMORIES_FACE_DETECTOR_CASCADE)%'
+    memories.face_detection.binary_default: ''
+    memories.face_detection.binary: "%env(default:memories.face_detection.binary_default:MEMORIES_FACE_DETECTOR_BIN)%"
+    memories.face_detection.cascade_default: ''
+    memories.face_detection.cascade: "%env(default:memories.face_detection.cascade_default:MEMORIES_FACE_DETECTOR_CASCADE)%"
     memories.face_detection.scale_factor: 1.1
     memories.face_detection.min_neighbors: 4
     memories.face_detection.min_size: 72


### PR DESCRIPTION
## Summary
- add explicit default values for the face detection binary and cascade parameters so they resolve to empty strings when no env vars are set

## Testing
- `composer ci:test` *(fails: bin/php missing in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1633113a0832382c364ac2690ccfb