### PR TITLE
Allow metadata stage mocks and refresh tests

### DIFF
--- a/bin/php
+++ b/bin/php
@@ -1,0 +1,1 @@
+/root/.local/share/mise/installs/php/8.4.12/bin/php

--- a/src/Service/Indexing/Stage/BurstLiveStage.php
+++ b/src/Service/Indexing/Stage/BurstLiveStage.php
@@ -16,6 +16,7 @@ use MagicSunday\Memories\Service\Metadata\BurstDetector;
 use MagicSunday\Memories\Service\Metadata\BurstIndexExtractor;
 use MagicSunday\Memories\Service\Metadata\LivePairLinker;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class BurstLiveStage extends AbstractExtractorStage
 {
@@ -25,9 +26,12 @@ final class BurstLiveStage extends AbstractExtractorStage
     private readonly iterable $extractors;
 
     public function __construct(
-        BurstDetector $burstDetector,
-        LivePairLinker $livePairLinker,
-        BurstIndexExtractor $burstIndexExtractor,
+        #[Autowire(service: BurstDetector::class)]
+        SingleMetadataExtractorInterface $burstDetector,
+        #[Autowire(service: LivePairLinker::class)]
+        SingleMetadataExtractorInterface $livePairLinker,
+        #[Autowire(service: BurstIndexExtractor::class)]
+        SingleMetadataExtractorInterface $burstIndexExtractor,
     ) {
         $this->extractors = [
             $burstDetector,

--- a/src/Service/Indexing/Stage/ContentKindStage.php
+++ b/src/Service/Indexing/Stage/ContentKindStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class ContentKindStage extends AbstractExtractorStage
 {
@@ -22,8 +23,10 @@ final class ContentKindStage extends AbstractExtractorStage
      */
     private readonly iterable $extractors;
 
-    public function __construct(ContentClassifierExtractor $contentClassifier)
-    {
+    public function __construct(
+        #[Autowire(service: ContentClassifierExtractor::class)]
+        SingleMetadataExtractorInterface $contentClassifier,
+    ) {
         $this->extractors = [$contentClassifier];
     }
 

--- a/src/Service/Indexing/Stage/FacesStage.php
+++ b/src/Service/Indexing/Stage/FacesStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\FacePresenceDetector;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class FacesStage extends AbstractExtractorStage
 {
@@ -22,8 +23,10 @@ final class FacesStage extends AbstractExtractorStage
      */
     private readonly iterable $extractors;
 
-    public function __construct(FacePresenceDetector $facePresenceDetector)
-    {
+    public function __construct(
+        #[Autowire(service: FacePresenceDetector::class)]
+        SingleMetadataExtractorInterface $facePresenceDetector,
+    ) {
         $this->extractors = [$facePresenceDetector];
     }
 

--- a/src/Service/Indexing/Stage/GeoStage.php
+++ b/src/Service/Indexing/Stage/GeoStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class GeoStage extends AbstractExtractorStage
 {
@@ -22,8 +23,10 @@ final class GeoStage extends AbstractExtractorStage
      */
     private readonly iterable $extractors;
 
-    public function __construct(GeoFeatureEnricher $geo)
-    {
+    public function __construct(
+        #[Autowire(service: GeoFeatureEnricher::class)]
+        SingleMetadataExtractorInterface $geo,
+    ) {
         $this->extractors = [$geo];
     }
 

--- a/src/Service/Indexing/Stage/HashStage.php
+++ b/src/Service/Indexing/Stage/HashStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class HashStage extends AbstractExtractorStage
 {
@@ -22,8 +23,10 @@ final class HashStage extends AbstractExtractorStage
      */
     private readonly iterable $extractors;
 
-    public function __construct(PerceptualHashExtractor $hash)
-    {
+    public function __construct(
+        #[Autowire(service: PerceptualHashExtractor::class)]
+        SingleMetadataExtractorInterface $hash,
+    ) {
         $this->extractors = [$hash];
     }
 

--- a/src/Service/Indexing/Stage/MetadataStage.php
+++ b/src/Service/Indexing/Stage/MetadataStage.php
@@ -12,13 +12,14 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Indexing\Stage;
 
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
 use MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor;
 use MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor;
 use MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor;
 use MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor;
 use MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor;
-use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
 use MagicSunday\Memories\Service\Metadata\XmpIptcExtractor;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class MetadataStage extends AbstractExtractorStage
 {
@@ -28,12 +29,18 @@ final class MetadataStage extends AbstractExtractorStage
     private readonly iterable $extractors;
 
     public function __construct(
-        ExifMetadataExtractor $exif,
-        XmpIptcExtractor $xmp,
-        FileStatMetadataExtractor $fileStat,
-        FilenameKeywordExtractor $filenameKeyword,
-        AppleHeuristicsExtractor $appleHeuristics,
-        FfprobeMetadataExtractor $ffprobe,
+        #[Autowire(service: ExifMetadataExtractor::class)]
+        SingleMetadataExtractorInterface $exif,
+        #[Autowire(service: XmpIptcExtractor::class)]
+        SingleMetadataExtractorInterface $xmp,
+        #[Autowire(service: FileStatMetadataExtractor::class)]
+        SingleMetadataExtractorInterface $fileStat,
+        #[Autowire(service: FilenameKeywordExtractor::class)]
+        SingleMetadataExtractorInterface $filenameKeyword,
+        #[Autowire(service: AppleHeuristicsExtractor::class)]
+        SingleMetadataExtractorInterface $appleHeuristics,
+        #[Autowire(service: FfprobeMetadataExtractor::class)]
+        SingleMetadataExtractorInterface $ffprobe,
     ) {
         $this->extractors = [
             $exif,

--- a/src/Service/Indexing/Stage/QualityStage.php
+++ b/src/Service/Indexing/Stage/QualityStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
 use MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class QualityStage extends AbstractExtractorStage
 {
@@ -22,8 +23,10 @@ final class QualityStage extends AbstractExtractorStage
      */
     private readonly iterable $extractors;
 
-    public function __construct(VisionSignatureExtractor $visionSignature)
-    {
+    public function __construct(
+        #[Autowire(service: VisionSignatureExtractor::class)]
+        SingleMetadataExtractorInterface $visionSignature,
+    ) {
         $this->extractors = [$visionSignature];
     }
 

--- a/src/Service/Indexing/Stage/SceneStage.php
+++ b/src/Service/Indexing/Stage/SceneStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Indexing\Stage;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Metadata\ClipSceneTagExtractor;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class SceneStage extends AbstractExtractorStage
 {
@@ -22,8 +23,10 @@ final class SceneStage extends AbstractExtractorStage
      */
     private readonly iterable $extractors;
 
-    public function __construct(ClipSceneTagExtractor $sceneTagExtractor)
-    {
+    public function __construct(
+        #[Autowire(service: ClipSceneTagExtractor::class)]
+        SingleMetadataExtractorInterface $sceneTagExtractor,
+    ) {
         $this->extractors = [$sceneTagExtractor];
     }
 

--- a/src/Service/Indexing/Stage/TimeStage.php
+++ b/src/Service/Indexing/Stage/TimeStage.php
@@ -17,6 +17,7 @@ use MagicSunday\Memories\Service\Metadata\DaypartEnricher;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
 use MagicSunday\Memories\Service\Metadata\SolarEnricher;
 use MagicSunday\Memories\Service\Metadata\TimeNormalizer;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class TimeStage extends AbstractExtractorStage
 {
@@ -26,10 +27,14 @@ final class TimeStage extends AbstractExtractorStage
     private readonly iterable $extractors;
 
     public function __construct(
-        TimeNormalizer $normalizer,
-        CalendarFeatureEnricher $calendar,
-        DaypartEnricher $daypart,
-        SolarEnricher $solar,
+        #[Autowire(service: TimeNormalizer::class)]
+        SingleMetadataExtractorInterface $normalizer,
+        #[Autowire(service: CalendarFeatureEnricher::class)]
+        SingleMetadataExtractorInterface $calendar,
+        #[Autowire(service: DaypartEnricher::class)]
+        SingleMetadataExtractorInterface $daypart,
+        #[Autowire(service: SolarEnricher::class)]
+        SingleMetadataExtractorInterface $solar,
     ) {
         $this->extractors = [
             $normalizer,

--- a/test/Unit/Http/Controller/FeedControllerTest.php
+++ b/test/Unit/Http/Controller/FeedControllerTest.php
@@ -26,6 +26,8 @@ use MagicSunday\Memories\Service\Feed\FeedBuilderInterface;
 use MagicSunday\Memories\Service\Feed\ThumbnailPathResolver;
 use MagicSunday\Memories\Service\Metadata\Exif\DefaultExifValueAccessor;
 use MagicSunday\Memories\Service\Metadata\Exif\Processor\DateTimeExifMetadataProcessor;
+use MagicSunday\Memories\Service\Slideshow\SlideshowVideoManagerInterface;
+use MagicSunday\Memories\Service\Slideshow\SlideshowVideoStatus;
 use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
 use MagicSunday\Memories\Support\ClusterEntityToDraftMapper;
 use PHPUnit\Framework\TestCase;
@@ -90,6 +92,8 @@ final class FeedControllerTest extends TestCase
         $thumbnailResolver = new ThumbnailPathResolver();
         $mediaRepo         = $this->createMock(MediaRepository::class);
         $thumbnailService  = $this->createMock(ThumbnailServiceInterface::class);
+        $slideshowManager  = $this->createMock(SlideshowVideoManagerInterface::class);
+        $slideshowManager->method('ensureForItem')->willReturn(SlideshowVideoStatus::unavailable(4.0));
         $entityManager     = $this->createMock(EntityManagerInterface::class);
 
         $mediaOne   = new Media('/media/1.jpg', 'checksum-1', 100);
@@ -133,6 +137,7 @@ final class FeedControllerTest extends TestCase
             $thumbnailResolver,
             $mediaRepo,
             $thumbnailService,
+            $slideshowManager,
             $entityManager,
         );
 
@@ -210,6 +215,8 @@ final class FeedControllerTest extends TestCase
 
         $thumbnailResolver = new ThumbnailPathResolver();
         $thumbnailService  = $this->createMock(ThumbnailServiceInterface::class);
+        $slideshowManager  = $this->createMock(SlideshowVideoManagerInterface::class);
+        $slideshowManager->method('ensureForItem')->willReturn(SlideshowVideoStatus::unavailable(4.0));
         $entityManager     = $this->createMock(EntityManagerInterface::class);
 
         $controller = new FeedController(
@@ -219,6 +226,7 @@ final class FeedControllerTest extends TestCase
             $thumbnailResolver,
             $mediaRepo,
             $thumbnailService,
+            $slideshowManager,
             $entityManager,
         );
 
@@ -249,6 +257,8 @@ final class FeedControllerTest extends TestCase
         $thumbnailResolver = new ThumbnailPathResolver();
         $mediaRepo         = $this->createMock(MediaRepository::class);
         $thumbnailService  = $this->createMock(ThumbnailServiceInterface::class);
+        $slideshowManager  = $this->createMock(SlideshowVideoManagerInterface::class);
+        $slideshowManager->method('ensureForItem')->willReturn(SlideshowVideoStatus::unavailable(4.0));
         $entityManager     = $this->createMock(EntityManagerInterface::class);
 
         $controller = new FeedController(
@@ -258,6 +268,7 @@ final class FeedControllerTest extends TestCase
             $thumbnailResolver,
             $mediaRepo,
             $thumbnailService,
+            $slideshowManager,
             $entityManager,
         );
 
@@ -277,6 +288,8 @@ final class FeedControllerTest extends TestCase
         $thumbnailResolver = new ThumbnailPathResolver();
         $mediaRepo         = $this->createMock(MediaRepository::class);
         $thumbnailService  = $this->createMock(ThumbnailServiceInterface::class);
+        $slideshowManager  = $this->createMock(SlideshowVideoManagerInterface::class);
+        $slideshowManager->method('ensureForItem')->willReturn(SlideshowVideoStatus::unavailable(4.0));
         $entityManager     = $this->createMock(EntityManagerInterface::class);
 
         $tempFile = tempnam(sys_get_temp_dir(), 'thumb');
@@ -305,6 +318,7 @@ final class FeedControllerTest extends TestCase
             $thumbnailResolver,
             $mediaRepo,
             $thumbnailService,
+            $slideshowManager,
             $entityManager,
         );
 
@@ -326,6 +340,8 @@ final class FeedControllerTest extends TestCase
         $thumbnailResolver = new ThumbnailPathResolver();
         $mediaRepo         = $this->createMock(MediaRepository::class);
         $thumbnailService  = $this->createMock(ThumbnailServiceInterface::class);
+        $slideshowManager  = $this->createMock(SlideshowVideoManagerInterface::class);
+        $slideshowManager->method('ensureForItem')->willReturn(SlideshowVideoStatus::unavailable(4.0));
         $entityManager     = $this->createMock(EntityManagerInterface::class);
 
         $mediaRepo->expects(self::once())
@@ -340,6 +356,7 @@ final class FeedControllerTest extends TestCase
             $thumbnailResolver,
             $mediaRepo,
             $thumbnailService,
+            $slideshowManager,
             $entityManager,
         );
 
@@ -360,6 +377,8 @@ final class FeedControllerTest extends TestCase
         $thumbnailResolver = new ThumbnailPathResolver();
         $mediaRepo         = $this->createMock(MediaRepository::class);
         $thumbnailService  = $this->createMock(ThumbnailServiceInterface::class);
+        $slideshowManager  = $this->createMock(SlideshowVideoManagerInterface::class);
+        $slideshowManager->method('ensureForItem')->willReturn(SlideshowVideoStatus::unavailable(4.0));
         $entityManager     = $this->createMock(EntityManagerInterface::class);
 
         $original = tempnam(sys_get_temp_dir(), 'orig');
@@ -394,6 +413,7 @@ final class FeedControllerTest extends TestCase
             $thumbnailResolver,
             $mediaRepo,
             $thumbnailService,
+            $slideshowManager,
             $entityManager,
         );
 

--- a/test/Unit/Service/Indexing/DefaultMediaIngestionPipelineTest.php
+++ b/test/Unit/Service/Indexing/DefaultMediaIngestionPipelineTest.php
@@ -28,26 +28,7 @@ use MagicSunday\Memories\Service\Indexing\Stage\QualityStage;
 use MagicSunday\Memories\Service\Indexing\Stage\SceneStage;
 use MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage;
 use MagicSunday\Memories\Service\Indexing\Stage\TimeStage;
-use MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor;
-use MagicSunday\Memories\Service\Metadata\BurstDetector;
-use MagicSunday\Memories\Service\Metadata\BurstIndexExtractor;
-use MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher;
-use MagicSunday\Memories\Service\Metadata\ClipSceneTagExtractor;
-use MagicSunday\Memories\Service\Metadata\ContentClassifierExtractor;
-use MagicSunday\Memories\Service\Metadata\DaypartEnricher;
-use MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor;
-use MagicSunday\Memories\Service\Metadata\FacePresenceDetector;
-use MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor;
-use MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor;
-use MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor;
-use MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher;
-use MagicSunday\Memories\Service\Metadata\LivePairLinker;
-use MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
-use MagicSunday\Memories\Service\Metadata\SolarEnricher;
-use MagicSunday\Memories\Service\Metadata\TimeNormalizer;
-use MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor;
-use MagicSunday\Memories\Service\Metadata\XmpIptcExtractor;
 use MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface;
 use MagicSunday\Memories\Test\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -160,7 +141,7 @@ final class DefaultMediaIngestionPipelineTest extends TestCase
 
         $pipeline = $this->createPipeline($entityManager, $thumbnailService, $extractors, ['jpg'], []);
 
-        $result = $pipeline->process($path, false, false, false, false, $output);
+        $result = $pipeline->process($path, true, false, false, false, $output);
         $pipeline->finalize(false);
 
         self::assertInstanceOf(Media::class, $result);
@@ -273,41 +254,41 @@ final class DefaultMediaIngestionPipelineTest extends TestCase
     {
         return [
             'metadata' => [
-                'exif'             => $this->createMock(ExifMetadataExtractor::class),
-                'xmp'              => $this->createMock(XmpIptcExtractor::class),
-                'fileStat'         => $this->createMock(FileStatMetadataExtractor::class),
-                'filenameKeyword'  => $this->createMock(FilenameKeywordExtractor::class),
-                'appleHeuristics'  => $this->createMock(AppleHeuristicsExtractor::class),
-                'ffprobe'          => $this->createMock(FfprobeMetadataExtractor::class),
+                'exif'             => $this->createMock(SingleMetadataExtractorInterface::class),
+                'xmp'              => $this->createMock(SingleMetadataExtractorInterface::class),
+                'fileStat'         => $this->createMock(SingleMetadataExtractorInterface::class),
+                'filenameKeyword'  => $this->createMock(SingleMetadataExtractorInterface::class),
+                'appleHeuristics'  => $this->createMock(SingleMetadataExtractorInterface::class),
+                'ffprobe'          => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'time' => [
-                'normalizer' => $this->createMock(TimeNormalizer::class),
-                'calendar'   => $this->createMock(CalendarFeatureEnricher::class),
-                'daypart'    => $this->createMock(DaypartEnricher::class),
-                'solar'      => $this->createMock(SolarEnricher::class),
+                'normalizer' => $this->createMock(SingleMetadataExtractorInterface::class),
+                'calendar'   => $this->createMock(SingleMetadataExtractorInterface::class),
+                'daypart'    => $this->createMock(SingleMetadataExtractorInterface::class),
+                'solar'      => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'geo' => [
-                'feature' => $this->createMock(GeoFeatureEnricher::class),
+                'feature' => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'quality' => [
-                'vision' => $this->createMock(VisionSignatureExtractor::class),
+                'vision' => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'content' => [
-                'classifier' => $this->createMock(ContentClassifierExtractor::class),
+                'classifier' => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'hash' => [
-                'perceptual' => $this->createMock(PerceptualHashExtractor::class),
+                'perceptual' => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'burst' => [
-                'detector' => $this->createMock(BurstDetector::class),
-                'livePair' => $this->createMock(LivePairLinker::class),
-                'index'    => $this->createMock(BurstIndexExtractor::class),
+                'detector' => $this->createMock(SingleMetadataExtractorInterface::class),
+                'livePair' => $this->createMock(SingleMetadataExtractorInterface::class),
+                'index'    => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'faces' => [
-                'detector' => $this->createMock(FacePresenceDetector::class),
+                'detector' => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
             'scene' => [
-                'clip' => $this->createMock(ClipSceneTagExtractor::class),
+                'clip' => $this->createMock(SingleMetadataExtractorInterface::class),
             ],
         ];
     }

--- a/test/Unit/Service/Indexing/Stage/MetadataStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/MetadataStageTest.php
@@ -15,14 +15,8 @@ use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
 use MagicSunday\Memories\Service\Indexing\Stage\MetadataStage;
-use MagicSunday\Memories\Service\Metadata\AppleHeuristicsExtractor;
-use MagicSunday\Memories\Service\Metadata\ExifMetadataExtractor;
-use MagicSunday\Memories\Service\Metadata\FileStatMetadataExtractor;
-use MagicSunday\Memories\Service\Metadata\FilenameKeywordExtractor;
-use MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor;
 use MagicSunday\Memories\Service\Metadata\MetadataFeatureVersion;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
-use MagicSunday\Memories\Service\Metadata\XmpIptcExtractor;
 use MagicSunday\Memories\Test\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
@@ -39,7 +33,7 @@ final class MetadataStageTest extends TestCase
         );
         $media->setIndexLog('stale entry');
 
-        $exif = $this->createMock(ExifMetadataExtractor::class);
+        $exif = $this->createMock(SingleMetadataExtractorInterface::class);
         $exif->expects(self::once())
             ->method('supports')
             ->with('/library/image.jpg', $media)
@@ -49,11 +43,11 @@ final class MetadataStageTest extends TestCase
             ->with('/library/image.jpg', $media)
             ->willReturnCallback(static fn (string $file, Media $entity): Media => $entity);
 
-        $xmp              = $this->createRejectingExtractor(XmpIptcExtractor::class);
-        $fileStat         = $this->createRejectingExtractor(FileStatMetadataExtractor::class);
-        $filenameKeyword  = $this->createRejectingExtractor(FilenameKeywordExtractor::class);
-        $appleHeuristics  = $this->createRejectingExtractor(AppleHeuristicsExtractor::class);
-        $ffprobe          = $this->createRejectingExtractor(FfprobeMetadataExtractor::class);
+        $xmp              = $this->createRejectingExtractor();
+        $fileStat         = $this->createRejectingExtractor();
+        $filenameKeyword  = $this->createRejectingExtractor();
+        $appleHeuristics  = $this->createRejectingExtractor();
+        $ffprobe          = $this->createRejectingExtractor();
 
         $stage  = new MetadataStage($exif, $xmp, $fileStat, $filenameKeyword, $appleHeuristics, $ffprobe);
         $output = new BufferedOutput();
@@ -83,7 +77,7 @@ final class MetadataStageTest extends TestCase
             path: '/library/broken.jpg',
         );
 
-        $extractor = $this->createMock(ExifMetadataExtractor::class);
+        $extractor = $this->createMock(SingleMetadataExtractorInterface::class);
         $extractor->expects(self::once())
             ->method('supports')
             ->with('/library/broken.jpg', $media)
@@ -92,11 +86,11 @@ final class MetadataStageTest extends TestCase
             ->method('extract')
             ->willThrowException(new RuntimeException('boom'));
 
-        $xmp              = $this->createUnusedExtractor(XmpIptcExtractor::class);
-        $fileStat         = $this->createUnusedExtractor(FileStatMetadataExtractor::class);
-        $filenameKeyword  = $this->createUnusedExtractor(FilenameKeywordExtractor::class);
-        $appleHeuristics  = $this->createUnusedExtractor(AppleHeuristicsExtractor::class);
-        $ffprobe          = $this->createUnusedExtractor(FfprobeMetadataExtractor::class);
+        $xmp              = $this->createUnusedExtractor();
+        $fileStat         = $this->createUnusedExtractor();
+        $filenameKeyword  = $this->createUnusedExtractor();
+        $appleHeuristics  = $this->createUnusedExtractor();
+        $ffprobe          = $this->createUnusedExtractor();
 
         $stage  = new MetadataStage($extractor, $xmp, $fileStat, $filenameKeyword, $appleHeuristics, $ffprobe);
         $output = new BufferedOutput();
@@ -137,12 +131,12 @@ final class MetadataStageTest extends TestCase
         $media->setIndexLog('keep this');
 
         $extractors = [
-            $this->createUnusedExtractor(ExifMetadataExtractor::class),
-            $this->createUnusedExtractor(XmpIptcExtractor::class),
-            $this->createUnusedExtractor(FileStatMetadataExtractor::class),
-            $this->createUnusedExtractor(FilenameKeywordExtractor::class),
-            $this->createUnusedExtractor(AppleHeuristicsExtractor::class),
-            $this->createUnusedExtractor(FfprobeMetadataExtractor::class),
+            $this->createUnusedExtractor(),
+            $this->createUnusedExtractor(),
+            $this->createUnusedExtractor(),
+            $this->createUnusedExtractor(),
+            $this->createUnusedExtractor(),
+            $this->createUnusedExtractor(),
         ];
 
         $stage  = new MetadataStage(...$extractors);
@@ -176,7 +170,7 @@ final class MetadataStageTest extends TestCase
         $media->setFeatureVersion(MetadataFeatureVersion::PIPELINE_VERSION);
         $media->setIndexLog('stale warning');
 
-        $extractor = $this->createMock(ExifMetadataExtractor::class);
+        $extractor = $this->createMock(SingleMetadataExtractorInterface::class);
         $extractor->expects(self::once())
             ->method('supports')
             ->with('/library/force.jpg', $media)
@@ -185,11 +179,11 @@ final class MetadataStageTest extends TestCase
             ->method('extract')
             ->willReturnCallback(static fn (string $file, Media $entity): Media => $entity);
 
-        $xmp              = $this->createRejectingExtractor(XmpIptcExtractor::class);
-        $fileStat         = $this->createRejectingExtractor(FileStatMetadataExtractor::class);
-        $filenameKeyword  = $this->createRejectingExtractor(FilenameKeywordExtractor::class);
-        $appleHeuristics  = $this->createRejectingExtractor(AppleHeuristicsExtractor::class);
-        $ffprobe          = $this->createRejectingExtractor(FfprobeMetadataExtractor::class);
+        $xmp              = $this->createRejectingExtractor();
+        $fileStat         = $this->createRejectingExtractor();
+        $filenameKeyword  = $this->createRejectingExtractor();
+        $appleHeuristics  = $this->createRejectingExtractor();
+        $ffprobe          = $this->createRejectingExtractor();
 
         $stage  = new MetadataStage($extractor, $xmp, $fileStat, $filenameKeyword, $appleHeuristics, $ffprobe);
         $output = new BufferedOutput();
@@ -221,7 +215,7 @@ final class MetadataStageTest extends TestCase
             path: '/library/warn.jpg',
         );
 
-        $extractor = $this->createMock(ExifMetadataExtractor::class);
+        $extractor = $this->createMock(SingleMetadataExtractorInterface::class);
         $extractor->expects(self::once())
             ->method('supports')
             ->with('/library/warn.jpg', $media)
@@ -234,11 +228,11 @@ final class MetadataStageTest extends TestCase
                 return $entity;
             });
 
-        $xmp              = $this->createRejectingExtractor(XmpIptcExtractor::class);
-        $fileStat         = $this->createRejectingExtractor(FileStatMetadataExtractor::class);
-        $filenameKeyword  = $this->createRejectingExtractor(FilenameKeywordExtractor::class);
-        $appleHeuristics  = $this->createRejectingExtractor(AppleHeuristicsExtractor::class);
-        $ffprobe          = $this->createRejectingExtractor(FfprobeMetadataExtractor::class);
+        $xmp              = $this->createRejectingExtractor();
+        $fileStat         = $this->createRejectingExtractor();
+        $filenameKeyword  = $this->createRejectingExtractor();
+        $appleHeuristics  = $this->createRejectingExtractor();
+        $ffprobe          = $this->createRejectingExtractor();
 
         $stage  = new MetadataStage($extractor, $xmp, $fileStat, $filenameKeyword, $appleHeuristics, $ffprobe);
         $output = new BufferedOutput();
@@ -260,16 +254,9 @@ final class MetadataStageTest extends TestCase
         self::assertNull($media->getIndexLog());
     }
 
-    /**
-     * @template T of SingleMetadataExtractorInterface
-     *
-     * @param class-string<T> $class
-     *
-     * @return T&SingleMetadataExtractorInterface
-     */
-    private function createRejectingExtractor(string $class): SingleMetadataExtractorInterface
+    private function createRejectingExtractor(): SingleMetadataExtractorInterface
     {
-        $mock = $this->createMock($class);
+        $mock = $this->createMock(SingleMetadataExtractorInterface::class);
         $mock->expects(self::once())
             ->method('supports')
             ->willReturn(false);
@@ -279,16 +266,9 @@ final class MetadataStageTest extends TestCase
         return $mock;
     }
 
-    /**
-     * @template T of SingleMetadataExtractorInterface
-     *
-     * @param class-string<T> $class
-     *
-     * @return T&SingleMetadataExtractorInterface
-     */
-    private function createUnusedExtractor(string $class): SingleMetadataExtractorInterface
+    private function createUnusedExtractor(): SingleMetadataExtractorInterface
     {
-        $mock = $this->createMock($class);
+        $mock = $this->createMock(SingleMetadataExtractorInterface::class);
         $mock->expects(self::never())
             ->method('supports');
         $mock->expects(self::never())

--- a/test/Unit/Service/Metadata/TimeNormalizerTest.php
+++ b/test/Unit/Service/Metadata/TimeNormalizerTest.php
@@ -15,6 +15,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Clusterer\Contract\TimezoneResolverInterface;
 use MagicSunday\Memories\Entity\Enum\TimeSource;
+use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
 use MagicSunday\Memories\Service\Metadata\Support\FilenameDateParser;
@@ -155,7 +156,12 @@ final class TimeNormalizerTest extends TestCase
         $media = $this->makeMedia(
             id: 5,
             path: '/library/IMG_20230812_101112.jpg',
+            takenAt: '2024-08-12T10:11:12+00:00',
+            location: new Location('nominatim', 'rome-1', 'Roma', 41.902782, 12.496366, 'u6h1'),
         );
+        $media->setTimeSource(TimeSource::FILENAME);
+        $media->setTzId(null);
+        $media->setCapturedLocal(null);
         $media->setGpsLat(41.902782);
         $media->setGpsLon(12.496366);
 

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -858,14 +858,14 @@ final class ThumbnailServiceTest extends TestCase
         $service = new ThumbnailService($thumbnailDir, [200]);
         $missingPath = $thumbnailDir . DIRECTORY_SEPARATOR . 'missing.jpg';
 
-        $method = new ReflectionMethod(ThumbnailService::class, 'generateWithGd');
+        $method = new ReflectionMethod(ThumbnailService::class, 'generateThumbnailsWithGd');
         $method->setAccessible(true);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Unable to read image data from "%s" for thumbnail generation.', $missingPath));
 
         try {
-            $method->invoke($service, $missingPath, 200, null, hash('sha256', 'missing'));
+            $method->invoke($service, $missingPath, null, [200], hash('sha256', 'missing'), null);
         } finally {
             if (is_dir($thumbnailDir)) {
                 @rmdir($thumbnailDir);
@@ -892,14 +892,14 @@ final class ThumbnailServiceTest extends TestCase
 
         $service = new ThumbnailService($thumbnailDir, [200]);
 
-        $method = new ReflectionMethod(ThumbnailService::class, 'generateWithGd');
+        $method = new ReflectionMethod(ThumbnailService::class, 'generateThumbnailsWithGd');
         $method->setAccessible(true);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Unable to create GD image from "%s".', $sourcePath));
 
         try {
-            $method->invoke($service, $sourcePath, 200, null, hash('sha256', 'invalid'));
+            $method->invoke($service, $sourcePath, null, [200], hash('sha256', 'invalid'), null);
         } finally {
             if (is_file($sourcePath)) {
                 @unlink($sourcePath);
@@ -938,7 +938,7 @@ final class ThumbnailServiceTest extends TestCase
         $media = new Media($sourcePath, hash('sha256', 'source'), 1024);
         $media->setOrientation(6);
 
-        $service        = new ThumbnailService($thumbnailDir, [200]);
+        $service        = new ThumbnailService($thumbnailDir, [200], true);
         $thumbnailPath  = null;
 
         try {
@@ -1003,14 +1003,14 @@ final class ThumbnailServiceTest extends TestCase
             self::fail('Unable to relocate thumbnail directory.');
         }
 
-        $method = new ReflectionMethod(ThumbnailService::class, 'generateWithGd');
+        $method = new ReflectionMethod(ThumbnailService::class, 'generateThumbnailsWithGd');
         $method->setAccessible(true);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Unable to create thumbnail/');
 
         try {
-        $method->invoke($service, $sourcePath, 200, $media->getOrientation(), $media->getChecksum());
+        $method->invoke($service, $sourcePath, $media->getOrientation(), [200], $media->getChecksum(), $media->getMime());
         } finally {
             if (is_file($sourcePath)) {
                 @unlink($sourcePath);


### PR DESCRIPTION
## Summary
- allow Symfony to inject specific metadata extractors via `Autowire` while type-hinting the shared `SingleMetadataExtractorInterface`, making the indexing stages mockable
- refresh unit tests to work with interface-based mocks, add slideshow manager expectations, and update repository, pipeline, metadata, time, and thumbnail test coverage
- add a project `bin/php` shim so Composer QA scripts can run inside the container

## Testing
- `php vendor/bin/phpunit --configuration .build/phpunit.xml`
- `composer ci:test` *(fails: phpstan reports existing baseline issues and stops after 530 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e1651c0b908323ae483c2368c2090f