### PR TITLE
Add rotation metadata from ffprobe streams

### DIFF
--- a/migrations/Version20250321120000.php
+++ b/migrations/Version20250321120000.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250321120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add video rotation, stabilisation flag, and stream metadata columns to the media table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE media ADD videoRotationDeg DOUBLE PRECISION DEFAULT NULL, ADD videoHasStabilization TINYINT(1) DEFAULT NULL, ADD videoStreams LONGTEXT DEFAULT NULL COMMENT '(DC2Type:json)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP videoRotationDeg, DROP videoHasStabilization, DROP videoStreams');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -370,6 +370,26 @@ class Media
     private ?bool $isSlowMo = null;
 
     /**
+     * Rotation derived from ffprobe metadata in degrees.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $videoRotationDeg = null;
+
+    /**
+     * Indicates whether stabilisation metadata is present for the video stream.
+     */
+    #[ORM\Column(type: Types::BOOLEAN, nullable: true)]
+    private ?bool $videoHasStabilization = null;
+
+    /**
+     * Normalised ffprobe stream metadata for downstream consumers.
+     *
+     * @var array<int, array<int|string, int|float|string|bool|null|array<int|string, int|float|string|bool|null|array>>>|null
+     */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $videoStreams = null;
+
+    /**
      * Flag indicating whether the media is portrait oriented.
      */
     #[ORM\Column(type: Types::BOOLEAN, nullable: true)]
@@ -1562,6 +1582,62 @@ class Media
     public function setIsSlowMo(?bool $v): void
     {
         $this->isSlowMo = $v;
+    }
+
+    /**
+     * Returns the video rotation in degrees.
+     */
+    public function getVideoRotationDeg(): ?float
+    {
+        return $this->videoRotationDeg;
+    }
+
+    /**
+     * Sets the video rotation in degrees.
+     *
+     * @param float|null $rotationDeg Rotation to apply clockwise.
+     */
+    public function setVideoRotationDeg(?float $rotationDeg): void
+    {
+        $this->videoRotationDeg = $rotationDeg;
+    }
+
+    /**
+     * Indicates whether stabilisation metadata is present for the video stream.
+     */
+    public function getVideoHasStabilization(): ?bool
+    {
+        return $this->videoHasStabilization;
+    }
+
+    /**
+     * Sets whether stabilisation metadata is present for the video stream.
+     *
+     * @param bool|null $hasStabilization True when stabilisation information exists.
+     */
+    public function setVideoHasStabilization(?bool $hasStabilization): void
+    {
+        $this->videoHasStabilization = $hasStabilization;
+    }
+
+    /**
+     * Provides the normalised ffprobe stream metadata.
+     *
+     * @return array<int, array<int|string, int|float|string|bool|null|array<int|string, int|float|string|bool|null|array>>>|null
+     */
+    public function getVideoStreams(): ?array
+    {
+        return $this->videoStreams;
+    }
+
+    /**
+     * Stores the normalised ffprobe stream metadata.
+     *
+     * @param array<int, array<int|string, int|float|string|bool|null|array<int|string, int|float|string|bool|null|array>>>|null $streams
+     */
+    public function setVideoStreams(?array $streams): void
+    {
+        $this->videoStreams = $streams;
     }
 
     /**

--- a/test/Unit/Service/Metadata/FfprobeMetadataExtractorTest.php
+++ b/test/Unit/Service/Metadata/FfprobeMetadataExtractorTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\FfprobeMetadataExtractor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function file_get_contents;
+use function sys_get_temp_dir;
+use function str_repeat;
+use function tempnam;
+use function unlink;
+
+final class FfprobeMetadataExtractorTest extends TestCase
+{
+    #[Test]
+    public function extractsRotationFromTagAndDetectsStabilisation(): void
+    {
+        $fixture = $this->loadFixture('rotate-stabilised.json');
+        $extractor = new FfprobeMetadataExtractor(processRunner: static fn (string $command): string => $fixture);
+
+        $videoPath = tempnam(sys_get_temp_dir(), 'vid');
+        if ($videoPath === false) {
+            self::fail('Unable to create temporary video fixture.');
+        }
+
+        try {
+            $media = new Media($videoPath, str_repeat('a', 64), 2048);
+            $media->setMime('video/mp4');
+
+            $extractor->extract($videoPath, $media);
+
+            self::assertSame('h264', $media->getVideoCodec());
+            self::assertSame(120.0, $media->getVideoFps());
+            self::assertSame(12.345, $media->getVideoDurationS());
+            self::assertTrue($media->isSlowMo());
+            self::assertSame(90.0, $media->getVideoRotationDeg());
+            self::assertTrue($media->getVideoHasStabilization());
+
+            $streams = $media->getVideoStreams();
+            self::assertIsArray($streams);
+            self::assertCount(1, $streams);
+            self::assertSame(
+                [
+                    [
+                        'index' => 0,
+                        'codec_name' => 'h264',
+                        'codec_type' => 'video',
+                        'avg_frame_rate' => '120/1',
+                        'tags' => ['rotate' => '90'],
+                        'side_data_list' => [
+                            [
+                                'side_data_type' => 'Display Matrix',
+                                'rotation' => '90',
+                            ],
+                            [
+                                'side_data_type' => 'Camera Motion',
+                                'stabilization' => 'on',
+                            ],
+                        ],
+                    ],
+                ],
+                $streams
+            );
+        } finally {
+            unlink($videoPath);
+        }
+    }
+
+    #[Test]
+    public function extractsDisplayMatrixRotationWithoutStabilisation(): void
+    {
+        $fixture = $this->loadFixture('displaymatrix-rotation.json');
+        $extractor = new FfprobeMetadataExtractor(processRunner: static fn (string $command): string => $fixture);
+
+        $videoPath = tempnam(sys_get_temp_dir(), 'vid');
+        if ($videoPath === false) {
+            self::fail('Unable to create temporary video fixture.');
+        }
+
+        try {
+            $media = new Media($videoPath, str_repeat('b', 64), 1024);
+            $media->setMime('video/mp4');
+
+            $extractor->extract($videoPath, $media);
+
+            self::assertSame('hevc', $media->getVideoCodec());
+            self::assertSame(30.0, $media->getVideoFps());
+            self::assertSame(5.0, $media->getVideoDurationS());
+            self::assertFalse($media->isSlowMo());
+            self::assertSame(-90.0, $media->getVideoRotationDeg());
+            self::assertNull($media->getVideoHasStabilization());
+
+            $streams = $media->getVideoStreams();
+            self::assertIsArray($streams);
+            self::assertCount(1, $streams);
+            self::assertSame(
+                [
+                    [
+                        'index' => 0,
+                        'codec_name' => 'hevc',
+                        'codec_type' => 'video',
+                        'avg_frame_rate' => '30/1',
+                        'side_data_list' => [
+                            [
+                                'side_data_type' => 'Display Matrix',
+                                'displaymatrix' => [
+                                    'rotation' => '-90',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                $streams
+            );
+        } finally {
+            unlink($videoPath);
+        }
+    }
+
+    private function loadFixture(string $filename): string
+    {
+        $path = __DIR__ . '/fixtures/ffprobe/' . $filename;
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            self::fail('Unable to load ffprobe fixture: ' . $filename);
+        }
+
+        return $contents;
+    }
+}

--- a/test/Unit/Service/Metadata/fixtures/ffprobe/displaymatrix-rotation.json
+++ b/test/Unit/Service/Metadata/fixtures/ffprobe/displaymatrix-rotation.json
@@ -1,0 +1,21 @@
+{
+  "streams": [
+    {
+      "index": 0,
+      "codec_name": "hevc",
+      "codec_type": "video",
+      "avg_frame_rate": "30/1",
+      "side_data_list": [
+        {
+          "side_data_type": "Display Matrix",
+          "displaymatrix": {
+            "rotation": "-90"
+          }
+        }
+      ]
+    }
+  ],
+  "format": {
+    "duration": "5.0"
+  }
+}

--- a/test/Unit/Service/Metadata/fixtures/ffprobe/rotate-stabilised.json
+++ b/test/Unit/Service/Metadata/fixtures/ffprobe/rotate-stabilised.json
@@ -1,0 +1,26 @@
+{
+  "streams": [
+    {
+      "index": 0,
+      "codec_name": "h264",
+      "codec_type": "video",
+      "avg_frame_rate": "120/1",
+      "tags": {
+        "rotate": "90"
+      },
+      "side_data_list": [
+        {
+          "side_data_type": "Display Matrix",
+          "rotation": "90"
+        },
+        {
+          "side_data_type": "Camera Motion",
+          "stabilization": "on"
+        }
+      ]
+    }
+  ],
+  "format": {
+    "duration": "12.345"
+  }
+}


### PR DESCRIPTION
## Summary
- extend the ffprobe extractor to capture stream rotation, stabilisation hints, and retain raw stream metadata
- persist the new video rotation, stabilisation, and stream payload fields on the media entity with a Doctrine migration
- cover the new parsing logic with unit tests that exercise rotation from tags and display matrices

## Testing
- composer ci:test *(fails: phpstan reports pre-existing baseline issues in multiple modules)*
- composer ci:test:php:unit *(fails: PHPUnit reports a warning from ThumbnailServiceTest about mkdir() on an existing directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e19254755c8323ad1c4017372063fa