### PR TITLE
Add timezone confidence scoring for media capture metadata

### DIFF
--- a/migrations/Version20250323103000.php
+++ b/migrations/Version20250323103000.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250323103000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add timezone confidence column to the media table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE media ADD tzConfidence DOUBLE PRECISION DEFAULT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP tzConfidence');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -17,6 +17,8 @@ use Doctrine\ORM\Mapping as ORM;
 use MagicSunday\Memories\Entity\Enum\ContentKind;
 use MagicSunday\Memories\Entity\Enum\TimeSource;
 use function count;
+use function max;
+use function min;
 
 /**
  * Doctrine entity describing an imported photo or video including its metadata.
@@ -115,6 +117,12 @@ class Media
      */
     #[ORM\Column(type: Types::STRING, length: 128, nullable: true)]
     private ?string $tzId = null;
+
+    /**
+     * Confidence score (0..1) describing the accuracy of the timezone metadata.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $tzConfidence = null;
 
     /**
      * Capture timestamp expressed in local wall time.
@@ -767,6 +775,30 @@ class Media
     public function setTzId(?string $tzId): void
     {
         $this->tzId = $tzId;
+    }
+
+    /**
+     * Returns the confidence score assigned to the timezone metadata.
+     */
+    public function getTzConfidence(): ?float
+    {
+        return $this->tzConfidence;
+    }
+
+    /**
+     * Updates the confidence score assigned to the timezone metadata.
+     *
+     * @param float|null $tzConfidence Confidence level between 0.0 and 1.0.
+     */
+    public function setTzConfidence(?float $tzConfidence): void
+    {
+        if ($tzConfidence === null) {
+            $this->tzConfidence = null;
+
+            return;
+        }
+
+        $this->tzConfidence = max(0.0, min(1.0, $tzConfidence));
     }
 
     /**

--- a/src/Service/Metadata/Exif/Processor/DateTimeExifMetadataProcessor.php
+++ b/src/Service/Metadata/Exif/Processor/DateTimeExifMetadataProcessor.php
@@ -18,6 +18,9 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
 use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifValueAccessorInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use function abs;
+use function intdiv;
+use function sprintf;
 
 /**
  * Applies capture date, timezone offset and sub-second precision from EXIF data.
@@ -57,6 +60,7 @@ final class DateTimeExifMetadataProcessor implements ExifMetadataProcessorInterf
 
         if ($offset !== null) {
             $media->setTimezoneOffsetMin($offset);
+            $media->setTzConfidence(1.0);
         }
 
         $subSeconds = $this->accessor->intOrNull($exif['EXIF']['SubSecTimeOriginal'] ?? null);

--- a/src/Service/Metadata/FileStatMetadataExtractor.php
+++ b/src/Service/Metadata/FileStatMetadataExtractor.php
@@ -48,6 +48,7 @@ final class FileStatMetadataExtractor implements SingleMetadataExtractorInterfac
         $media->setCapturedLocal($takenAt);
         $media->setTzId($timezoneName);
         $media->setTimeSource(TimeSource::FILE_MTIME);
+        $media->setTzConfidence(0.2);
 
         return $media;
     }

--- a/src/Service/Metadata/TimeNormalizer.php
+++ b/src/Service/Metadata/TimeNormalizer.php
@@ -71,6 +71,7 @@ final class TimeNormalizer implements SingleMetadataExtractorInterface
                 $media->setCapturedLocal($parsed);
                 $media->setTimeSource(TimeSource::FILENAME);
                 $media->setTzId($parsed->getTimezone()->getName());
+                $this->promoteTzConfidence($media, 0.4);
 
                 return;
             }
@@ -83,6 +84,7 @@ final class TimeNormalizer implements SingleMetadataExtractorInterface
                 $media->setCapturedLocal($fileInstant);
                 $media->setTzId($fileInstant->getTimezone()->getName());
                 $media->setTimeSource(TimeSource::FILE_MTIME);
+                $this->promoteTzConfidence($media, 0.2);
             }
         }
     }
@@ -116,6 +118,7 @@ final class TimeNormalizer implements SingleMetadataExtractorInterface
             if ($media->getTzId() === null) {
                 $media->setTzId($timezone->getName());
             }
+            $this->promoteTzConfidence($media, 0.2);
         }
 
         if ($media->getTimezoneOffsetMin() === null) {
@@ -145,6 +148,15 @@ final class TimeNormalizer implements SingleMetadataExtractorInterface
             return new DateTimeZone($this->defaultTimezone);
         } catch (Exception) {
             return new DateTimeZone('UTC');
+        }
+    }
+
+    private function promoteTzConfidence(Media $media, float $confidence): void
+    {
+        $current = $media->getTzConfidence();
+
+        if ($current === null || $confidence > $current) {
+            $media->setTzConfidence($confidence);
         }
     }
 }

--- a/test/Unit/Service/Metadata/TimeNormalizerTest.php
+++ b/test/Unit/Service/Metadata/TimeNormalizerTest.php
@@ -46,12 +46,14 @@ final class TimeNormalizerTest extends TestCase
             takenAt: '2024-01-01T09:11:12+00:00',
             configure: static function (Media $item): void {
                 $item->setIndexLog('initial');
+                $item->setTzConfidence(1.0);
             },
         );
 
         $result = $normalizer->extract($media->getPath(), $media);
 
         self::assertSame(TimeSource::EXIF, $result->getTimeSource());
+        self::assertSame(1.0, $result->getTzConfidence());
         $expectedSummary = sprintf(
             'time=%s; tz=%s; off=%+d',
             TimeSource::EXIF->value,
@@ -103,6 +105,7 @@ final class TimeNormalizerTest extends TestCase
         self::assertSame(TimeSource::FILENAME, $result->getTimeSource());
         self::assertSame('Europe/Berlin', $result->getTzId());
         self::assertSame(120, $result->getTimezoneOffsetMin());
+        self::assertSame(0.4, $result->getTzConfidence());
         self::assertSame('time=FILENAME; tz=Europe/Berlin; off=+120', $result->getIndexLog());
     }
 
@@ -134,6 +137,7 @@ final class TimeNormalizerTest extends TestCase
         self::assertSame(TimeSource::FILE_MTIME, $result->getTimeSource());
         self::assertSame('Europe/Berlin', $result->getTzId());
         self::assertSame(60, $result->getTimezoneOffsetMin());
+        self::assertSame(0.2, $result->getTzConfidence());
         $expectedSummary = sprintf(
             'time=%s; tz=%s; off=%+d',
             TimeSource::FILE_MTIME->value,
@@ -170,6 +174,7 @@ final class TimeNormalizerTest extends TestCase
         self::assertSame(TimeSource::FILENAME, $result->getTimeSource());
         self::assertSame('Europe/Rome', $result->getTzId());
         self::assertSame(120, $result->getTimezoneOffsetMin());
+        self::assertSame(0.8, $result->getTzConfidence());
         self::assertStringContainsString('tz=Europe/Rome', (string) $result->getIndexLog());
     }
 


### PR DESCRIPTION
## Summary
- add a tzConfidence column to the media entity with Doctrine migration support
- propagate timezone confidence scoring across EXIF, filename, and fallback capture time resolution paths
- extend time normalization unit tests to verify confidence values for each source

## Testing
- composer ci:test *(fails: phpstan reports pre-existing strictness warnings about always-true checks)*

------
https://chatgpt.com/codex/tasks/task_e_68e1984f067c8323a036dd9137a6aa4b