### PR TITLE
Add geohash persistence for media coordinates

### DIFF
--- a/migrations/Version20250323120000.php
+++ b/migrations/Version20250323120000.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250323120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add GeoHash precision columns and indexes for media coordinates.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE media ADD geohash7 VARCHAR(12) DEFAULT NULL");
+        $this->addSql("ALTER TABLE media ADD geohash5 VARCHAR(12) DEFAULT NULL");
+        $this->addSql('CREATE INDEX idx_media_geohash7 ON media (geohash7)');
+        $this->addSql('CREATE INDEX idx_media_geohash5 ON media (geohash5)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_media_geohash7 ON media');
+        $this->addSql('DROP INDEX idx_media_geohash5 ON media');
+        $this->addSql('ALTER TABLE media DROP geohash7');
+        $this->addSql('ALTER TABLE media DROP geohash5');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -34,6 +34,8 @@ use function min;
         new ORM\Index(name: 'idx_live_pair_checksum', columns: ['livePairChecksum']),
         new ORM\Index(name: 'idx_media_live_pair_id', columns: ['livePairMediaId']),
         new ORM\Index(name: 'idx_media_geocell8', columns: ['geoCell8']),
+        new ORM\Index(name: 'idx_media_geohash7', columns: ['geohash7']),
+        new ORM\Index(name: 'idx_media_geohash5', columns: ['geohash5']),
         new ORM\Index(name: 'idx_media_phash_prefix', columns: ['phashPrefix']),
         new ORM\Index(name: 'idx_media_burst_taken', columns: ['burstUuid', 'takenAt']),
         new ORM\Index(name: 'idx_media_video_taken', columns: ['isVideo', 'takenAt']),
@@ -303,6 +305,18 @@ class Media
      */
     #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
     private ?string $geoCell8 = null;
+
+    /**
+     * GeoHash at precision seven characters.
+     */
+    #[ORM\Column(type: Types::STRING, length: 12, nullable: true)]
+    private ?string $geohash7 = null;
+
+    /**
+     * GeoHash at precision five characters.
+     */
+    #[ORM\Column(type: Types::STRING, length: 12, nullable: true)]
+    private ?string $geohash5 = null;
 
     /**
      * Distance from configured home location in kilometres.
@@ -1418,6 +1432,42 @@ class Media
     public function setGeoCell8(?string $v): void
     {
         $this->geoCell8 = $v;
+    }
+
+    /**
+     * Returns the GeoHash with seven characters.
+     */
+    public function getGeohash7(): ?string
+    {
+        return $this->geohash7;
+    }
+
+    /**
+     * Sets the GeoHash with seven characters.
+     *
+     * @param string|null $v GeoHash string with seven characters.
+     */
+    public function setGeohash7(?string $v): void
+    {
+        $this->geohash7 = $v;
+    }
+
+    /**
+     * Returns the GeoHash with five characters.
+     */
+    public function getGeohash5(): ?string
+    {
+        return $this->geohash5;
+    }
+
+    /**
+     * Sets the GeoHash with five characters.
+     *
+     * @param string|null $v GeoHash string with five characters.
+     */
+    public function setGeohash5(?string $v): void
+    {
+        $this->geohash5 = $v;
     }
 
     /**

--- a/src/Service/Metadata/GeoFeatureEnricher.php
+++ b/src/Service/Metadata/GeoFeatureEnricher.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Metadata;
 
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\GeoHash;
 use MagicSunday\Memories\Utility\MediaMath;
 
 use function floor;
@@ -46,10 +47,10 @@ final readonly class GeoFeatureEnricher implements SingleMetadataExtractorInterf
             || $media->getGeoCell8() === null
             || $media->getDistanceKmFromHome() === null;
 
-        if ($shouldUpdateHomeMetrics) {
-            $lat = (float) $media->getGpsLat();
-            $lon = (float) $media->getGpsLon();
+        $lat = (float) $media->getGpsLat();
+        $lon = (float) $media->getGpsLon();
 
+        if ($shouldUpdateHomeMetrics) {
             $cell = $this->cellKey($lat, $lon, $this->cellDegrees);
             $media->setGeoCell8($cell);
 
@@ -58,6 +59,9 @@ final readonly class GeoFeatureEnricher implements SingleMetadataExtractorInterf
 
             $media->setHomeConfigHash($desiredHash);
         }
+
+        $media->setGeohash7(GeoHash::encode($lat, $lon, 7));
+        $media->setGeohash5(GeoHash::encode($lat, $lon, 5));
 
         $media->setNeedsGeocode($media->getLocation() === null);
 

--- a/src/Utility/GeoHash.php
+++ b/src/Utility/GeoHash.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Utility;
+
+use InvalidArgumentException;
+
+/**
+ * Helper for encoding latitude/longitude into GeoHash strings.
+ */
+final class GeoHash
+{
+    private const string BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+
+    /**
+     * Encodes the provided latitude and longitude into a GeoHash.
+     *
+     * @param float $latitude  Latitude in decimal degrees.
+     * @param float $longitude Longitude in decimal degrees.
+     * @param int   $precision Desired GeoHash length.
+     */
+    public static function encode(float $latitude, float $longitude, int $precision): string
+    {
+        if ($precision <= 0) {
+            throw new InvalidArgumentException('GeoHash precision must be a positive integer.');
+        }
+
+        if ($latitude < -90.0 || $latitude > 90.0) {
+            throw new InvalidArgumentException('Latitude must be within the range -90 to 90 degrees.');
+        }
+
+        if ($longitude < -180.0 || $longitude > 180.0) {
+            throw new InvalidArgumentException('Longitude must be within the range -180 to 180 degrees.');
+        }
+
+        $geohash = '';
+        $latInterval = [-90.0, 90.0];
+        $lonInterval = [-180.0, 180.0];
+        $isEven = true;
+        $bit = 0;
+        $ch = 0;
+
+        while (strlen($geohash) < $precision) {
+            if ($isEven) {
+                $mid = ($lonInterval[0] + $lonInterval[1]) / 2.0;
+                if ($longitude >= $mid) {
+                    $ch |= 1 << (4 - $bit);
+                    $lonInterval[0] = $mid;
+                } else {
+                    $lonInterval[1] = $mid;
+                }
+            } else {
+                $mid = ($latInterval[0] + $latInterval[1]) / 2.0;
+                if ($latitude >= $mid) {
+                    $ch |= 1 << (4 - $bit);
+                    $latInterval[0] = $mid;
+                } else {
+                    $latInterval[1] = $mid;
+                }
+            }
+
+            $isEven = !$isEven;
+
+            if ($bit < 4) {
+                $bit++;
+                continue;
+            }
+
+            $geohash .= self::BASE32[$ch];
+            $bit = 0;
+            $ch = 0;
+        }
+
+        return $geohash;
+    }
+}

--- a/test/Unit/Service/Metadata/GeoFeatureEnricherTest.php
+++ b/test/Unit/Service/Metadata/GeoFeatureEnricherTest.php
@@ -54,10 +54,14 @@ final class GeoFeatureEnricherTest extends TestCase
         $expectedHash = $this->computeHomeConfigHash();
         $expectedCell = $this->expectedCell(48.137154, 11.576124);
         $expectedDistance = $this->expectedDistanceKm(48.137154, 11.576124);
+        $expectedGeohash7 = 'u281z7j';
+        $expectedGeohash5 = 'u281z';
 
         self::assertSame($expectedHash, $result->getHomeConfigHash());
         self::assertSame($expectedCell, $result->getGeoCell8());
         self::assertSame($expectedDistance, $result->getDistanceKmFromHome());
+        self::assertSame($expectedGeohash7, $result->getGeohash7());
+        self::assertSame($expectedGeohash5, $result->getGeohash5());
         self::assertTrue($result->needsGeocode());
     }
 
@@ -75,15 +79,22 @@ final class GeoFeatureEnricherTest extends TestCase
                 $media->setGeoCell8('custom-cell');
                 $media->setDistanceKmFromHome(12.5);
                 $media->setHomeConfigHash($expectedHash);
+                $media->setGeohash7('legacy7');
+                $media->setGeohash5('legacy5');
             },
         );
 
         $enricher = $this->createEnricher();
         $result   = $enricher->extract($media->getPath(), $media);
 
+        $expectedGeohash7 = 'u284pyx';
+        $expectedGeohash5 = 'u284p';
+
         self::assertSame($expectedHash, $result->getHomeConfigHash());
         self::assertSame('custom-cell', $result->getGeoCell8());
         self::assertSame(12.5, $result->getDistanceKmFromHome());
+        self::assertSame($expectedGeohash7, $result->getGeohash7());
+        self::assertSame($expectedGeohash5, $result->getGeohash5());
         self::assertTrue($result->needsGeocode());
     }
 
@@ -111,10 +122,14 @@ final class GeoFeatureEnricherTest extends TestCase
 
         $expectedCell     = $this->expectedCell($lat, $lon);
         $expectedDistance = $this->expectedDistanceKm($lat, $lon);
+        $expectedGeohash7 = 'u2860h8';
+        $expectedGeohash5 = 'u2860';
 
         self::assertSame($expectedHash, $result->getHomeConfigHash());
         self::assertSame($expectedCell, $result->getGeoCell8());
         self::assertSame($expectedDistance, $result->getDistanceKmFromHome());
+        self::assertSame($expectedGeohash7, $result->getGeohash7());
+        self::assertSame($expectedGeohash5, $result->getGeohash5());
         self::assertTrue($result->needsGeocode());
     }
 


### PR DESCRIPTION
## Summary
- add geohash5 and geohash7 columns and Doctrine indexes to the media entity with a migration
- compute and persist geohash hashes in the geo feature enricher via a reusable helper
- extend the enricher unit tests to cover the new geohash values

## Testing
- composer ci:test *(fails: existing phpstan baseline violations)*
- vendor/bin/phpunit -c .build/phpunit.xml --filter GeoFeatureEnricherTest


------
https://chatgpt.com/codex/tasks/task_e_68e213b531988323873d67cabd79b609