### PR TITLE
Add near duplicate ingestion stage

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -303,6 +303,11 @@ services:
     MagicSunday\Memories\Service\Indexing\Stage\HashStage:
         arguments:
             $hash: '@MagicSunday\Memories\Service\Metadata\PerceptualHashExtractor'
+    MagicSunday\Memories\Service\Indexing\Stage\NearDuplicateStage:
+        arguments:
+            $mediaRepository: '@MagicSunday\Memories\Repository\MediaRepository'
+            $duplicateRepository: '@MagicSunday\Memories\Repository\MediaDuplicateRepository'
+            $maxHammingDistance: 6
 
     MagicSunday\Memories\Service\Indexing\Stage\ThumbnailGenerationStage: ~
 
@@ -321,6 +326,7 @@ services:
                 - '@MagicSunday\Memories\Service\Indexing\Stage\QualityStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\ContentKindStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\HashStage'
+                - '@MagicSunday\Memories\Service\Indexing\Stage\NearDuplicateStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\BurstLiveStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\FacesStage'
                 - '@MagicSunday\Memories\Service\Indexing\Stage\SceneStage'

--- a/migrations/Version20250324150000.php
+++ b/migrations/Version20250324150000.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250324150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create media_duplicate table storing perceptual duplicate distances.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE TABLE media_duplicate (
+                id BIGINT AUTO_INCREMENT NOT NULL,
+                media_left_id BIGINT NOT NULL,
+                media_right_id BIGINT NOT NULL,
+                distance SMALLINT NOT NULL,
+                createdAt DATETIME NOT NULL,
+                updatedAt DATETIME DEFAULT NULL,
+                INDEX idx_media_duplicate_left (media_left_id),
+                INDEX idx_media_duplicate_right (media_right_id),
+                UNIQUE INDEX uniq_media_duplicate_pair (media_left_id, media_right_id),
+                CONSTRAINT FK_media_duplicate_left FOREIGN KEY (media_left_id) REFERENCES media (id) ON DELETE CASCADE,
+                CONSTRAINT FK_media_duplicate_right FOREIGN KEY (media_right_id) REFERENCES media (id) ON DELETE CASCADE
+            ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE media_duplicate');
+    }
+}

--- a/src/Entity/MediaDuplicate.php
+++ b/src/Entity/MediaDuplicate.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Entity;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
+
+/**
+ * Stores perceptual near-duplicate relationships between media assets.
+ */
+#[ORM\Entity]
+#[ORM\Table(
+    name: 'media_duplicate',
+    uniqueConstraints: [
+        new ORM\UniqueConstraint(name: 'uniq_media_duplicate_pair', columns: ['media_left_id', 'media_right_id'])
+    ],
+    indexes: [
+        new ORM\Index(name: 'idx_media_duplicate_left', columns: ['media_left_id']),
+        new ORM\Index(name: 'idx_media_duplicate_right', columns: ['media_right_id'])
+    ]
+)]
+final class MediaDuplicate
+{
+    /**
+     * Internal primary key managed by the database sequence.
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::BIGINT)]
+    #[ORM\GeneratedValue]
+    private int $id;
+
+    /**
+     * Canonical left-side media reference of the duplicate pair.
+     */
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'media_left_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Media $leftMedia;
+
+    /**
+     * Canonical right-side media reference of the duplicate pair.
+     */
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'media_right_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Media $rightMedia;
+
+    /**
+     * Hamming distance between the perceptual hashes of both assets.
+     */
+    #[ORM\Column(type: Types::SMALLINT)]
+    private int $distance;
+
+    /**
+     * Timestamp when the duplicate pair was first detected.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * Timestamp when the distance value was last updated.
+     */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $updatedAt = null;
+
+    /**
+     * @throws InvalidArgumentException When the distance is negative or the media references are identical.
+     */
+    public function __construct(Media $leftMedia, Media $rightMedia, int $distance)
+    {
+        if ($distance < 0) {
+            throw new InvalidArgumentException('Distance must be zero or greater.');
+        }
+
+        if ($leftMedia === $rightMedia) {
+            throw new InvalidArgumentException('Duplicate pair requires distinct media instances.');
+        }
+
+        $this->leftMedia  = $leftMedia;
+        $this->rightMedia = $rightMedia;
+        $this->distance   = $distance;
+        $this->createdAt  = new DateTimeImmutable();
+    }
+
+    /**
+     * Returns the unique identifier assigned by Doctrine.
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Returns the canonical left media entity.
+     */
+    public function getLeftMedia(): Media
+    {
+        return $this->leftMedia;
+    }
+
+    /**
+     * Returns the canonical right media entity.
+     */
+    public function getRightMedia(): Media
+    {
+        return $this->rightMedia;
+    }
+
+    /**
+     * Returns the recorded Hamming distance.
+     */
+    public function getDistance(): int
+    {
+        return $this->distance;
+    }
+
+    /**
+     * Updates the stored Hamming distance.
+     *
+     * @throws InvalidArgumentException When the provided distance is negative.
+     */
+    public function setDistance(int $distance): void
+    {
+        if ($distance < 0) {
+            throw new InvalidArgumentException('Distance must be zero or greater.');
+        }
+
+        if ($this->distance === $distance) {
+            return;
+        }
+
+        $this->distance  = $distance;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    /**
+     * Returns the timestamp when the duplicate pair was first recorded.
+     */
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Returns the timestamp of the last update, if available.
+     */
+    public function getUpdatedAt(): ?DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/src/Repository/MediaDuplicateRepository.php
+++ b/src/Repository/MediaDuplicateRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use InvalidArgumentException;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Entity\MediaDuplicate;
+
+use function strcmp;
+
+/**
+ * Repository helper responsible for persisting perceptual duplicate pairs.
+ */
+readonly class MediaDuplicateRepository
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    /**
+     * Records or updates the perceptual distance between two media entities.
+     *
+     * @throws InvalidArgumentException When the provided media references are identical or the distance is invalid.
+     */
+    public function recordDistance(Media $first, Media $second, int $distance): MediaDuplicate
+    {
+        if ($distance < 0) {
+            throw new InvalidArgumentException('Distance must be zero or greater.');
+        }
+
+        if ($first === $second) {
+            throw new InvalidArgumentException('Duplicate detection requires distinct media instances.');
+        }
+
+        [$left, $right] = $this->normalisePair($first, $second);
+
+        /** @var ObjectRepository<MediaDuplicate> $repository */
+        $repository = $this->entityManager->getRepository(MediaDuplicate::class);
+
+        $existing = $repository->findOneBy([
+            'leftMedia'  => $left,
+            'rightMedia' => $right,
+        ]);
+
+        if ($existing instanceof MediaDuplicate) {
+            $existing->setDistance($distance);
+
+            return $existing;
+        }
+
+        $duplicate = new MediaDuplicate($left, $right, $distance);
+        $this->entityManager->persist($duplicate);
+
+        return $duplicate;
+    }
+
+    /**
+     * Ensures deterministic ordering of duplicate pairs based on media paths.
+     *
+     * @return array{0: Media, 1: Media}
+     */
+    private function normalisePair(Media $first, Media $second): array
+    {
+        if (strcmp($first->getPath(), $second->getPath()) <= 0) {
+            return [$first, $second];
+        }
+
+        return [$second, $first];
+    }
+}

--- a/src/Service/Indexing/Stage/NearDuplicateStage.php
+++ b/src/Service/Indexing/Stage/NearDuplicateStage.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Indexing\Stage;
+
+use InvalidArgumentException;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Repository\MediaDuplicateRepository;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionStageInterface;
+
+use function is_int;
+
+/**
+ * Detects perceptually similar media and records their Hamming distance.
+ */
+final class NearDuplicateStage implements MediaIngestionStageInterface
+{
+    public function __construct(
+        private readonly MediaRepository $mediaRepository,
+        private readonly MediaDuplicateRepository $duplicateRepository,
+        private readonly int $maxHammingDistance = 6,
+    ) {
+        if ($this->maxHammingDistance < 0) {
+            throw new InvalidArgumentException('Maximum Hamming distance must be zero or greater.');
+        }
+    }
+
+    public function process(MediaIngestionContext $context): MediaIngestionContext
+    {
+        if ($context->isSkipped()) {
+            return $context;
+        }
+
+        $media = $context->getMedia();
+        if (!$media instanceof Media) {
+            return $context;
+        }
+
+        $phash = $media->getPhash();
+        if ($phash === null || $phash === '') {
+            return $context;
+        }
+
+        $candidates = $this->mediaRepository->findNearestByPhash($phash, $this->maxHammingDistance);
+        if ($candidates === []) {
+            return $context;
+        }
+
+        foreach ($candidates as $candidate) {
+            $other    = $candidate['media'] ?? null;
+            $distance = $candidate['distance'] ?? null;
+
+            if (!$other instanceof Media) {
+                continue;
+            }
+
+            if ($other === $media) {
+                continue;
+            }
+
+            if (!is_int($distance)) {
+                continue;
+            }
+
+            if ($distance > $this->maxHammingDistance) {
+                continue;
+            }
+
+            if ($context->isDryRun()) {
+                continue;
+            }
+
+            $this->duplicateRepository->recordDistance($media, $other, $distance);
+        }
+
+        return $context;
+    }
+}

--- a/test/Unit/Repository/MediaDuplicateRepositoryTest.php
+++ b/test/Unit/Repository/MediaDuplicateRepositoryTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use MagicSunday\Memories\Entity\MediaDuplicate;
+use MagicSunday\Memories\Repository\MediaDuplicateRepository;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MediaDuplicateRepositoryTest extends TestCase
+{
+    #[Test]
+    public function recordDistancePersistsNewPairs(): void
+    {
+        $mediaA = $this->makeMedia(1, '/library/a.jpg');
+        $mediaB = $this->makeMedia(2, '/library/b.jpg');
+
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $entityRepository->expects(self::once())
+            ->method('findOneBy')
+            ->with([
+                'leftMedia'  => $mediaA,
+                'rightMedia' => $mediaB,
+            ])
+            ->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(MediaDuplicate::class)
+            ->willReturn($entityRepository);
+        $entityManager->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (MediaDuplicate $duplicate) use ($mediaA, $mediaB): bool {
+                return $duplicate->getLeftMedia() === $mediaA
+                    && $duplicate->getRightMedia() === $mediaB
+                    && $duplicate->getDistance() === 5;
+            }));
+
+        $repository = new MediaDuplicateRepository($entityManager);
+        $result     = $repository->recordDistance($mediaA, $mediaB, 5);
+
+        self::assertSame($mediaA, $result->getLeftMedia());
+        self::assertSame($mediaB, $result->getRightMedia());
+        self::assertSame(5, $result->getDistance());
+    }
+
+    #[Test]
+    public function recordDistanceNormalisesPairOrdering(): void
+    {
+        $mediaA = $this->makeMedia(10, '/library/z.jpg');
+        $mediaB = $this->makeMedia(11, '/library/a.jpg');
+
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $entityRepository->expects(self::once())
+            ->method('findOneBy')
+            ->with([
+                'leftMedia'  => $mediaB,
+                'rightMedia' => $mediaA,
+            ])
+            ->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(MediaDuplicate::class)
+            ->willReturn($entityRepository);
+        $entityManager->expects(self::once())->method('persist');
+
+        $repository = new MediaDuplicateRepository($entityManager);
+        $repository->recordDistance($mediaA, $mediaB, 3);
+    }
+
+    #[Test]
+    public function recordDistanceUpdatesExistingDistance(): void
+    {
+        $mediaA = $this->makeMedia(21, '/library/a.jpg');
+        $mediaB = $this->makeMedia(22, '/library/b.jpg');
+
+        $existing = new MediaDuplicate($mediaA, $mediaB, 8);
+
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $entityRepository->expects(self::once())
+            ->method('findOneBy')
+            ->with([
+                'leftMedia'  => $mediaA,
+                'rightMedia' => $mediaB,
+            ])
+            ->willReturn($existing);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(MediaDuplicate::class)
+            ->willReturn($entityRepository);
+        $entityManager->expects(self::never())->method('persist');
+
+        $repository = new MediaDuplicateRepository($entityManager);
+        $result     = $repository->recordDistance($mediaB, $mediaA, 2);
+
+        self::assertSame($existing, $result);
+        self::assertSame(2, $existing->getDistance());
+        self::assertNotNull($existing->getUpdatedAt());
+    }
+}

--- a/test/Unit/Service/Indexing/Stage/NearDuplicateStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/NearDuplicateStageTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Indexing\Stage;
+
+use MagicSunday\Memories\Entity\MediaDuplicate;
+use MagicSunday\Memories\Repository\MediaDuplicateRepository;
+use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Indexing\Contract\MediaIngestionContext;
+use MagicSunday\Memories\Service\Indexing\Stage\NearDuplicateStage;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class NearDuplicateStageTest extends TestCase
+{
+    #[Test]
+    public function processPersistsDuplicateDistances(): void
+    {
+        $primary = $this->makeMedia(10, '/library/a.jpg');
+        $primary->setPhash('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+        $secondary = $this->makeMedia(11, '/library/b.jpg');
+
+        $mediaRepository = $this->createMock(MediaRepository::class);
+        $mediaRepository->expects(self::once())
+            ->method('findNearestByPhash')
+            ->with('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 6)
+            ->willReturn([
+                ['media' => $primary, 'distance' => 0],
+                ['media' => $secondary, 'distance' => 4],
+            ]);
+
+        $duplicateRepository = $this->createMock(MediaDuplicateRepository::class);
+        $duplicateRepository->expects(self::once())
+            ->method('recordDistance')
+            ->with($primary, $secondary, 4)
+            ->willReturn(new MediaDuplicate($primary, $secondary, 4));
+
+        $stage = new NearDuplicateStage($mediaRepository, $duplicateRepository);
+
+        $context = MediaIngestionContext::create(
+            $primary->getPath(),
+            false,
+            false,
+            false,
+            false,
+            new BufferedOutput()
+        )->withMedia($primary);
+
+        $result = $stage->process($context);
+
+        self::assertSame($primary, $result->getMedia());
+    }
+
+    #[Test]
+    public function processSkipsPersistenceDuringDryRun(): void
+    {
+        $primary = $this->makeMedia(20, '/library/dry-run.jpg');
+        $primary->setPhash('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+        $secondary = $this->makeMedia(21, '/library/dry-run-2.jpg');
+
+        $mediaRepository = $this->createMock(MediaRepository::class);
+        $mediaRepository->expects(self::once())
+            ->method('findNearestByPhash')
+            ->with('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 6)
+            ->willReturn([
+                ['media' => $secondary, 'distance' => 2],
+            ]);
+
+        $duplicateRepository = $this->createMock(MediaDuplicateRepository::class);
+        $duplicateRepository->expects(self::never())->method('recordDistance');
+
+        $stage = new NearDuplicateStage($mediaRepository, $duplicateRepository);
+
+        $context = MediaIngestionContext::create(
+            $primary->getPath(),
+            false,
+            true,
+            false,
+            false,
+            new BufferedOutput()
+        )->withMedia($primary);
+
+        $result = $stage->process($context);
+
+        self::assertSame($primary, $result->getMedia());
+    }
+
+    #[Test]
+    public function processDoesNotQueryRepositoryWhenPhashMissing(): void
+    {
+        $primary = $this->makeMedia(30, '/library/no-hash.jpg');
+
+        $mediaRepository = $this->createMock(MediaRepository::class);
+        $mediaRepository->expects(self::never())->method('findNearestByPhash');
+
+        $duplicateRepository = $this->createMock(MediaDuplicateRepository::class);
+        $duplicateRepository->expects(self::never())->method('recordDistance');
+
+        $stage = new NearDuplicateStage($mediaRepository, $duplicateRepository);
+
+        $context = MediaIngestionContext::create(
+            $primary->getPath(),
+            false,
+            false,
+            false,
+            false,
+            new BufferedOutput()
+        )->withMedia($primary);
+
+        $result = $stage->process($context);
+
+        self::assertSame($primary, $result->getMedia());
+    }
+}


### PR DESCRIPTION
## Summary
- add a near-duplicate ingestion stage that queries perceptual hash matches and honours dry-run execution
- persist pairwise distances in the new `media_duplicate` entity/table with a repository helper and Doctrine migration
- cover the stage and repository with unit tests and extend the pipeline wiring to include the new stage

## Testing
- composer ci:test *(fails: phpstan currently reports existing baseline issues in unrelated services)*
- composer ci:test:php:unit *(fails: exits with warning from ThumbnailService mkdir in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e21674b0f083238106e9d827381e45