### PR TITLE
Refine media quality scoring defaults

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -187,6 +187,13 @@ parameters:
 
     # Scoring Defaults
     memories.score.quality_baseline_megapixels: 12.0
+    memories.score.quality.min_resolution_megapixels: 2.0
+    memories.score.quality.low_score_threshold: 0.35
+    memories.score.quality.low_sharpness_threshold: 0.20
+    memories.score.quality.low_exposure_threshold: 0.25
+    memories.score.quality.low_noise_quality_threshold: 0.25
+    memories.score.quality.clipping_threshold: 0.15
+    memories.score.quality.clipping_penalty_weight: 0.5
     memories.score.min_valid_year: 1995
     memories.score.time_range.min_samples: 3
     memories.score.time_range.min_coverage: 0.6

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -191,6 +191,16 @@ services:
     MagicSunday\Memories\Service\Metadata\Support\FaceDetectionBackendInterface:
         alias: MagicSunday\Memories\Service\Metadata\Support\CommandLineFaceDetectionBackend
 
+    MagicSunday\Memories\Service\Metadata\Quality\MediaQualityAggregator:
+        arguments:
+            $minResolutionMegapixels: '%memories.score.quality.min_resolution_megapixels%'
+            $lowScoreThreshold: '%memories.score.quality.low_score_threshold%'
+            $lowSharpnessThreshold: '%memories.score.quality.low_sharpness_threshold%'
+            $lowExposureThreshold: '%memories.score.quality.low_exposure_threshold%'
+            $lowNoiseQualityThreshold: '%memories.score.quality.low_noise_quality_threshold%'
+            $clippingLowQualityThreshold: '%memories.score.quality.clipping_threshold%'
+            $clippingPenaltyWeight: '%memories.score.quality.clipping_penalty_weight%'
+
     MagicSunday\Memories\Service\Metadata\VisionSignatureExtractor:
         arguments:
             $sampleSize: 320

--- a/test/Unit/Service/Metadata/Quality/MediaQualityAggregatorTest.php
+++ b/test/Unit/Service/Metadata/Quality/MediaQualityAggregatorTest.php
@@ -36,7 +36,7 @@ final class MediaQualityAggregatorTest extends TestCase
         $aggregator->aggregate($media);
 
         self::assertNotNull($media->getQualityScore());
-        self::assertEqualsWithDelta(0.9364, $media->getQualityScore(), 0.0005);
+        self::assertEqualsWithDelta(0.8794, $media->getQualityScore(), 0.0005);
         self::assertEqualsWithDelta(0.86, $media->getQualityExposure(), 0.0005);
         self::assertEqualsWithDelta(0.8571, $media->getQualityNoise(), 0.0005);
         self::assertFalse($media->isLowQuality());
@@ -57,9 +57,27 @@ final class MediaQualityAggregatorTest extends TestCase
         $aggregator->aggregate($media);
 
         self::assertTrue($media->isLowQuality());
-        self::assertEqualsWithDelta(0.1166, $media->getQualityScore(), 0.0005);
+        self::assertEqualsWithDelta(0.1526, $media->getQualityScore(), 0.0005);
         self::assertEqualsWithDelta(0.08, $media->getQualityExposure(), 0.0005);
         self::assertEqualsWithDelta(0.1429, $media->getQualityNoise(), 0.0005);
+    }
+
+    #[Test]
+    public function marksHighQualitySignalsAsLowWhenResolutionTooSmall(): void
+    {
+        $media = $this->createMedia(4);
+        $media->setWidth(1200);
+        $media->setHeight(1600);
+        $media->setSharpness(0.9);
+        $media->setIso(100);
+        $media->setBrightness(0.55);
+        $media->setContrast(0.65);
+
+        $aggregator = new MediaQualityAggregator();
+        $aggregator->aggregate($media);
+
+        self::assertNotNull($media->getQualityScore());
+        self::assertTrue($media->isLowQuality());
     }
 
     #[Test]
@@ -79,8 +97,8 @@ final class MediaQualityAggregatorTest extends TestCase
         $aggregator->aggregate($media);
 
         $expectedNoise = 1.0 - (log(200.0 / 50.0) / log(6400.0 / 50.0));
-        $baseScore     = (1.0 * 0.45) + (0.6 * 0.35) + ($expectedNoise * 0.20);
-        $expectedScore = ($baseScore / (0.45 + 0.35 + 0.20)) * (1.0 - (0.5 * 0.2));
+        $baseScore     = (0.6 * 0.50) + (0.8 * 0.30) + ($expectedNoise * 0.20);
+        $expectedScore = $baseScore * (1.0 - (0.5 * 0.2));
 
         self::assertEqualsWithDelta($expectedScore, $media->getQualityScore() ?? 0.0, 0.0005);
         self::assertTrue($media->isLowQuality());


### PR DESCRIPTION
## Summary
- adjust the media quality aggregation to focus on sharpness, exposure, and ISO-derived noise while enforcing a 2 MP minimum resolution gate
- surface the scoring thresholds as configurable parameters and wire them into the service container
- refresh the unit suite to validate the revised quality scores and new low-resolution handling

## Testing
- composer ci:test *(fails: phpstan baseline reports pre-existing issues)*
- composer ci:test:php:unit *(fails: known warning about mkdir in ThumbnailService test)*

------
https://chatgpt.com/codex/tasks/task_e_68e218646f0483239ee10ca955209a43