### PR TITLE
Adjust ClipSceneTagExtractor minimum score threshold

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -224,7 +224,7 @@ services:
     MagicSunday\Memories\Service\Metadata\ClipSceneTagExtractor:
         arguments:
             $maxTags: 5
-            $minScore: 0.2
+            $minScore: 0.3
         tags:
             - { name: 'memories.metadata_extractor', priority: 40 }
 

--- a/src/Service/Metadata/ClipSceneTagExtractor.php
+++ b/src/Service/Metadata/ClipSceneTagExtractor.php
@@ -29,10 +29,14 @@ use function str_starts_with;
  */
 final readonly class ClipSceneTagExtractor implements SingleMetadataExtractorInterface
 {
+    /**
+     * @param int   $maxTags  Maximum number of scene tags to persist.
+     * @param float $minScore Minimum confidence required to accept a tag.
+     */
     public function __construct(
         private VisionSceneTagModelInterface $model,
         private int $maxTags = 6,
-        private float $minScore = 0.05,
+        private float $minScore = 0.3,
     ) {
         if ($this->maxTags < 1) {
             throw new InvalidArgumentException('maxTags must be >= 1');

--- a/test/Unit/Service/Metadata/ClipSceneTagExtractorTest.php
+++ b/test/Unit/Service/Metadata/ClipSceneTagExtractorTest.php
@@ -40,7 +40,7 @@ final class ClipSceneTagExtractorTest extends TestCase
         $media->setHeight(2000);
         $media->setKeywords(['beach', 'family']);
 
-        $extractor = new ClipSceneTagExtractor(new HeuristicClipSceneTagModel(), maxTags: 3, minScore: 0.2);
+        $extractor = new ClipSceneTagExtractor(new HeuristicClipSceneTagModel(), maxTags: 3, minScore: 0.3);
 
         $result = $extractor->extract('/tmp/scene.jpg', $media);
 
@@ -131,7 +131,7 @@ final class ClipSceneTagExtractorTest extends TestCase
         $media->setMime('image/jpeg');
         $media->setIndexLog('time=exif; tz=UTC; off=+0');
 
-        $extractor = new ClipSceneTagExtractor($model, maxTags: 2, minScore: 0.2);
+        $extractor = new ClipSceneTagExtractor($model, maxTags: 2, minScore: 0.3);
         $result    = $extractor->extract('/tmp/scene2.jpg', $media);
 
         self::assertSame(


### PR DESCRIPTION
## Summary
- raise the configured minimum confidence for the clip scene tag extractor to 0.3
- align the extractor default threshold and documentation with the new minimum
- update the unit tests to expect the higher score cut-off

## Testing
- composer ci:test *(fails: existing phpstan baseline violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e21a6bc43c8323a3354816c2db0c9e