### PR TITLE
Add burst representative flag and update burst processing

### DIFF
--- a/migrations/Version20250325120000.php
+++ b/migrations/Version20250325120000.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250325120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add burstRepresentative flag to media and supporting index.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media ADD burstRepresentative TINYINT(1) DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_media_burst_repr ON media (burstUuid, burstRepresentative)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_media_burst_repr ON media');
+        $this->addSql('ALTER TABLE media DROP burstRepresentative');
+    }
+}

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -38,6 +38,7 @@ use function min;
         new ORM\Index(name: 'idx_media_geohash5', columns: ['geohash5']),
         new ORM\Index(name: 'idx_media_phash_prefix', columns: ['phashPrefix']),
         new ORM\Index(name: 'idx_media_burst_taken', columns: ['burstUuid', 'takenAt']),
+        new ORM\Index(name: 'idx_media_burst_repr', columns: ['burstUuid', 'burstRepresentative']),
         new ORM\Index(name: 'idx_media_video_taken', columns: ['isVideo', 'takenAt']),
         new ORM\Index(name: 'idx_media_location', columns: ['location_id']),
         new ORM\Index(name: 'idx_media_needs_geocode', columns: ['needsGeocode']),
@@ -341,6 +342,12 @@ class Media
      */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     private ?int $burstIndex = null;
+
+    /**
+     * Flag marking the canonical member of a burst sequence.
+     */
+    #[ORM\Column(type: Types::BOOLEAN, nullable: true)]
+    private ?bool $burstRepresentative = null;
 
     /**
      * Fractional capture seconds extracted from EXIF metadata.
@@ -1540,6 +1547,22 @@ class Media
     public function setBurstIndex(?int $v): void
     {
         $this->burstIndex = $v;
+    }
+
+    /**
+     * Returns whether the media is the representative member of its burst.
+     */
+    public function isBurstRepresentative(): ?bool
+    {
+        return $this->burstRepresentative;
+    }
+
+    /**
+     * Marks the media as burst representative.
+     */
+    public function setBurstRepresentative(?bool $v): void
+    {
+        $this->burstRepresentative = $v;
     }
 
     /**

--- a/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
+++ b/src/Service/Clusterer/Pipeline/MemberQualityRankingStage.php
@@ -265,6 +265,10 @@ final class MemberQualityRankingStage extends AbstractClusterScoreHeuristic impl
                 continue;
             }
 
+            if ($media->isBurstRepresentative() === false) {
+                continue;
+            }
+
             $map[$media->getId()] = $media;
         }
 


### PR DESCRIPTION
## Summary
- add a nullable `burstRepresentative` flag on media together with a supporting migration and index
- update burst detection to pick a canonical member, reuse existing burst groupings, and filter repository lookups by the representative flag
- respect the representative flag in consolidation services and extend test coverage for burst handling

## Testing
- composer ci:test *(fails: phpstan reports existing baseline issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e21b50d144832389bd4ac249ff3859