### PR TITLE
Add documentation for EnvironmentBootstrap class

### DIFF
--- a/src/Bootstrap/EnvironmentBootstrap.php
+++ b/src/Bootstrap/EnvironmentBootstrap.php
@@ -17,6 +17,14 @@ use Throwable;
 
 use function dirname;
 
+/**
+ * Selects and loads the applicable .env file from the available application roots.
+ *
+ * The loader considers the current working directory, the directory of a running
+ * PHAR archive, and the project root to determine the first readable candidate.
+ * Side effects: delegates to Dotenv::bootEnv() for cascading .env variants and
+ * utilises Phar::running() to discover packaged execution contexts.
+ */
 final class EnvironmentBootstrap
 {
     /**


### PR DESCRIPTION
## Summary
- document the EnvironmentBootstrap class to explain its .env selection process and dependencies

## Testing
- composer ci:test *(fails: `bin/php` not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e222085e888323bc20a84bd6eb8805