### PR TITLE
DOC: describe composer autoload guard

### DIFF
--- a/src/Bootstrap/ComposerAutoload.php
+++ b/src/Bootstrap/ComposerAutoload.php
@@ -21,6 +21,11 @@ use function is_file;
  */
 final class ComposerAutoload
 {
+    /**
+     * Guards against requiring the Composer autoloader multiple times within the same process.
+     * The {@see require()} method flips the flag to true after a successful include, so that
+     * subsequent calls respect the lifecycle and do not reload the autoloader.
+     */
     private static bool $autoloadLoaded = false;
 
     /**


### PR DESCRIPTION
## Summary
- document the autoload guard to explain its role in preventing multiple Composer includes
- note that ComposerAutoload::require() updates the guard so future calls respect the lifecycle

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml handling the ci:test:php:lint event returned with error code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68e2220a1f388323aef99b1a321dad86