### PR TITLE
Enable cohort clustering for IPTC person metadata

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -581,6 +581,7 @@ services:
             $minPersons: 2
             $minItemsTotal: 4
             $windowDays: 10
+            $personSignatureHelper: '@MagicSunday\Memories\Clusterer\Support\PersonSignatureHelper'
         tags:
             - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.person_cohort_cluster_strategy%' }
 

--- a/src/Clusterer/Support/PersonSignatureHelper.php
+++ b/src/Clusterer/Support/PersonSignatureHelper.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Clusterer\Contract\PersonTaggedMediaInterface;
+use MagicSunday\Memories\Entity\Media;
+
+use function array_map;
+use function array_unique;
+use function array_values;
+use function hash;
+use function intval;
+use function mb_strtolower;
+use function substr;
+use function trim;
+
+/**
+ * Generates stable numeric person signatures for media items.
+ */
+final class PersonSignatureHelper
+{
+    /**
+     * @var array<string, int>
+     */
+    private array $cache = [];
+
+    /**
+     * Returns person identifiers for the given media, falling back to
+     * a deterministic hash of person names when numeric identifiers are
+     * not provided explicitly.
+     *
+     * @return list<int>
+     */
+    public function personIds(Media $media): array
+    {
+        if ($media instanceof PersonTaggedMediaInterface) {
+            return $media->getPersonIds();
+        }
+
+        $persons = $media->getPersons();
+        if ($persons === null) {
+            return [];
+        }
+
+        $normalised = array_values(array_unique(array_map(
+            static fn (string $name): string => mb_strtolower(trim($name)),
+            $persons
+        )));
+
+        $ids = [];
+        foreach ($normalised as $name) {
+            if ($name === '') {
+                continue;
+            }
+
+            $ids[] = $this->cache[$name] ??= $this->hashPerson($name);
+        }
+
+        return $ids;
+    }
+
+    private function hashPerson(string $name): int
+    {
+        $hash = substr(hash('sha256', $name), 0, 15);
+        $value = intval($hash, 16);
+
+        if ($value < 1) {
+            return 1;
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a PersonSignatureHelper that converts media person names into deterministic numeric identifiers
- update the PersonCohortClusterStrategy to rely on the helper for all timestamped media and wire it into the service container
- expand unit coverage to assert IPTC/XMP-backed media participate in people cohort clustering

## Testing
- composer ci:test *(fails: `bin/php` is not available in the container)*
- ./vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68e22eac74688323b74420feb5b67d1c