### PR TITLE
Enhance golden hour and nightlife clustering cues

### DIFF
--- a/test/Unit/Clusterer/ClusterStrategySmokeTest.php
+++ b/test/Unit/Clusterer/ClusterStrategySmokeTest.php
@@ -199,7 +199,8 @@ final class ClusterStrategySmokeTest extends TestCase
             NightlifeEventClusterStrategy::class,
             'nightlife_event',
             static fn (): ClusterStrategyInterface => new NightlifeEventClusterStrategy(
-                localTimeHelper: self::localTimeHelper()
+                localTimeHelper: self::localTimeHelper(),
+                locationHelper: self::locationHelper()
             ),
         ];
         yield 'OnThisDayOverYearsClusterStrategy' => [

--- a/test/Unit/Clusterer/GoldenHourClusterStrategyTest.php
+++ b/test/Unit/Clusterer/GoldenHourClusterStrategyTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\Test;
 final class GoldenHourClusterStrategyTest extends TestCase
 {
     #[Test]
-    public function clustersGoldenHourSequence(): void
+    public function clustersGoldenHourSequenceBasedOnFeatureFlag(): void
     {
         $strategy = new GoldenHourClusterStrategy(
             localTimeHelper: new LocalTimeHelper('Europe/Berlin'),
@@ -33,12 +33,13 @@ final class GoldenHourClusterStrategyTest extends TestCase
             minItemsPerRun: 5,
         );
 
-        $base  = new DateTimeImmutable('2024-08-10 18:00:00', new DateTimeZone('UTC'));
+        $base  = new DateTimeImmutable('2024-08-10 13:00:00', new DateTimeZone('UTC'));
         $items = [];
         for ($i = 0; $i < 5; ++$i) {
             $items[] = $this->createMedia(
                 2700 + $i,
                 $base->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                true,
             );
         }
 
@@ -47,14 +48,20 @@ final class GoldenHourClusterStrategyTest extends TestCase
         self::assertCount(1, $clusters);
         self::assertSame('golden_hour', $clusters[0]->getAlgorithm());
         self::assertSame(range(2700, 2704), $clusters[0]->getMembers());
+
+        $params = $clusters[0]->getParams();
+        self::assertArrayHasKey('scene_tags', $params);
+        $labels = array_map(static fn (array $tag): string => $tag['label'], $params['scene_tags']);
+        self::assertContains('Sunset Skyline', $labels);
+        self::assertContains('Golden light', $labels);
     }
 
     #[Test]
-    public function ignoresPhotosOutsideGoldenHours(): void
+    public function clustersGoldenHourSequenceWithHourFallback(): void
     {
         $strategy = new GoldenHourClusterStrategy(localTimeHelper: new LocalTimeHelper('Europe/Berlin'));
 
-        $base  = new DateTimeImmutable('2024-08-10 13:00:00', new DateTimeZone('UTC'));
+        $base  = new DateTimeImmutable('2024-08-10 18:00:00', new DateTimeZone('UTC'));
         $items = [];
         for ($i = 0; $i < 5; ++$i) {
             $items[] = $this->createMedia(
@@ -63,10 +70,31 @@ final class GoldenHourClusterStrategyTest extends TestCase
             );
         }
 
+        $clusters = $strategy->cluster($items);
+
+        self::assertCount(1, $clusters);
+        self::assertSame(range(2800, 2804), $clusters[0]->getMembers());
+    }
+
+    #[Test]
+    public function ignoresMediaMarkedAsNotGoldenHour(): void
+    {
+        $strategy = new GoldenHourClusterStrategy(localTimeHelper: new LocalTimeHelper('Europe/Berlin'));
+
+        $base  = new DateTimeImmutable('2024-08-10 18:00:00', new DateTimeZone('UTC'));
+        $items = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $items[] = $this->createMedia(
+                2900 + $i,
+                $base->add(new DateInterval('PT' . ($i * 600) . 'S')),
+                false,
+            );
+        }
+
         self::assertSame([], $strategy->cluster($items));
     }
 
-    private function createMedia(int $id, DateTimeImmutable $takenAt): Media
+    private function createMedia(int $id, DateTimeImmutable $takenAt, ?bool $golden = null): Media
     {
         return $this->makeMediaFixture(
             id: $id,
@@ -74,6 +102,16 @@ final class GoldenHourClusterStrategyTest extends TestCase
             takenAt: $takenAt,
             lat: 48.5,
             lon: 9.0,
+            configure: static function (Media $media) use ($golden): void {
+                if ($golden !== null) {
+                    $media->setFeatures(['isGoldenHour' => $golden]);
+                }
+
+                $media->setSceneTags([
+                    ['label' => 'Sunset Skyline', 'score' => 0.91],
+                    ['label' => 'Golden light', 'score' => 0.88],
+                ]);
+            },
         );
     }
 }


### PR DESCRIPTION
## Summary
- Prioritise the explicit golden hour feature flag while retaining hour-based fallbacks and expose supporting scene tags in cluster params
- Require nightlife clusters to surface night/daypart, nightlife-oriented scene tags, or nightlife POI context and persist those cues
- Extend the golden hour, nightlife, and smoke tests to cover feature-, tag-, and POI-driven scenarios

## Testing
- composer ci:test *(fails: `bin/php` missing in container)*
- ./vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68e23154ccd48323b929670d4594f7ad