### PR TITLE
Ensure cluster filters exclude hidden media

### DIFF
--- a/src/Clusterer/Support/MediaFilterTrait.php
+++ b/src/Clusterer/Support/MediaFilterTrait.php
@@ -25,6 +25,14 @@ use function count;
 trait MediaFilterTrait
 {
     /**
+     * Indicates whether the media item can participate in clustering.
+     */
+    private function isEligibleMedia(Media $media): bool
+    {
+        return $media->isNoShow() === false && $media->isLowQuality() === false;
+    }
+
+    /**
      * @param list<Media> $items
      *
      * @return list<Media>
@@ -33,7 +41,8 @@ trait MediaFilterTrait
     {
         return array_values(array_filter(
             $items,
-            static fn (Media $m): bool => $m->getTakenAt() instanceof DateTimeImmutable
+            fn (Media $m): bool => $this->isEligibleMedia($m)
+                && $m->getTakenAt() instanceof DateTimeImmutable
         ));
     }
 
@@ -62,7 +71,9 @@ trait MediaFilterTrait
     {
         return array_values(array_filter(
             $items,
-            static fn (Media $m): bool => $m->getGpsLat() !== null && $m->getGpsLon() !== null
+            fn (Media $m): bool => $this->isEligibleMedia($m)
+                && $m->getGpsLat() !== null
+                && $m->getGpsLon() !== null
         ));
     }
 
@@ -75,7 +86,8 @@ trait MediaFilterTrait
     {
         return array_values(array_filter(
             $items,
-            static fn (Media $m): bool => $m->getTakenAt() instanceof DateTimeImmutable
+            fn (Media $m): bool => $this->isEligibleMedia($m)
+                && $m->getTakenAt() instanceof DateTimeImmutable
                 && $m->getGpsLat() !== null
                 && $m->getGpsLon() !== null
         ));


### PR DESCRIPTION
## Summary
- add a central eligibility guard in `MediaFilterTrait` to skip `noShow` and low-quality media across all helper filters
- cover the behaviour with a clustering test to ensure hidden media never end up in draft member lists

## Testing
- `composer ci:test` *(fails: bin/php not found in container)*
- `vendor/bin/phpunit test/Unit/Clusterer/TimeSimilarityStrategyTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68e235a2d43c8323ab56f15dbecaca3e