### PR TITLE
Enrich clusters with dominant tags

### DIFF
--- a/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
+++ b/src/Clusterer/OnThisDayOverYearsClusterStrategy.php
@@ -14,12 +14,11 @@ namespace MagicSunday\Memories\Clusterer;
 use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
+use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Utility\MediaMath;
 
 use function array_keys;
-use function array_map;
 use function array_values;
 use function assert;
 use function count;
@@ -34,6 +33,7 @@ use function usort;
 final readonly class OnThisDayOverYearsClusterStrategy implements ClusterStrategyInterface
 {
     use MediaFilterTrait;
+    use ClusterBuildHelperTrait;
 
     public function __construct(
         private string $timezone = 'Europe/Berlin',
@@ -101,18 +101,25 @@ final readonly class OnThisDayOverYearsClusterStrategy implements ClusterStrateg
 
         usort($picked, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
 
-        $centroid = MediaMath::centroid($picked);
-        $time     = MediaMath::timeRange($picked);
+        $centroid = $this->computeCentroid($picked);
+        $time     = $this->computeTimeRange($picked);
+
+        $params = [
+            'time_range' => $time,
+            'years'      => array_values(array_keys($years)),
+        ];
+
+        $tags = $this->collectDominantTags($picked);
+        if ($tags !== []) {
+            $params = [...$params, ...$tags];
+        }
 
         return [
             new ClusterDraft(
                 algorithm: $this->name(),
-                params: [
-                    'time_range' => $time,
-                    'years'      => array_values(array_keys($years)),
-                ],
+                params: $params,
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
-                members: array_map(static fn (Media $m): int => $m->getId(), $picked)
+                members: $this->toMemberIds($picked)
             ),
         ];
     }


### PR DESCRIPTION
## Summary
- integrate the ClusterBuildHelperTrait into the day, season, monthly, yearly, and on-this-day clustering strategies
- merge dominant scene tags and keywords into cluster parameters when available
- extend the corresponding unit tests to assert the aggregated tag metadata

## Testing
- `vendor/bin/phpunit test/Unit/Clusterer/DayAlbumClusterStrategyTest.php test/Unit/Clusterer/SeasonClusterStrategyTest.php test/Unit/Clusterer/SeasonOverYearsClusterStrategyTest.php test/Unit/Clusterer/MonthlyHighlightsClusterStrategyTest.php test/Unit/Clusterer/YearInReviewClusterStrategyTest.php test/Unit/Clusterer/OnThisDayOverYearsClusterStrategyTest.php`
- `composer ci:test` *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e23a5130cc8323b87a61aee0fa4cd1