### PR TITLE
Add face metadata filtering to portrait clusters

### DIFF
--- a/src/Clusterer/PortraitOrientationClusterStrategy.php
+++ b/src/Clusterer/PortraitOrientationClusterStrategy.php
@@ -61,6 +61,14 @@ final readonly class PortraitOrientationClusterStrategy implements ClusterStrate
         $cand = $this->filterTimestampedItemsBy(
             $items,
             function (Media $m): bool {
+                if ($m->hasFaces() === false) {
+                    $persons = $m->getPersons();
+
+                    if ($persons === null || count($persons) === 0) {
+                        return false;
+                    }
+                }
+
                 $w = $m->getWidth();
                 $h = $m->getHeight();
 

--- a/test/Unit/Clusterer/PortraitOrientationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PortraitOrientationClusterStrategyTest.php
@@ -72,6 +72,7 @@ final class PortraitOrientationClusterStrategyTest extends TestCase
             configure: static function (Media $media): void {
                 $media->setWidth(1000);
                 $media->setHeight(1500);
+                $media->setPersons(['Alice']);
             },
         );
     }
@@ -85,6 +86,7 @@ final class PortraitOrientationClusterStrategyTest extends TestCase
             configure: static function (Media $media): void {
                 $media->setWidth(1600);
                 $media->setHeight(900);
+                $media->setPersons(['Bob']);
             },
         );
     }


### PR DESCRIPTION
## Summary
- require portrait clustering candidates to have detected faces or person metadata
- ensure portrait cluster unit fixtures set person tags for test media

## Testing
- ./vendor/bin/phpunit test/Unit/Clusterer/PortraitOrientationClusterStrategyTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e23a51a3408323b783c1a35efb870e