### PR TITLE
Honor explicit portrait orientation flag in portrait clustering

### DIFF
--- a/src/Clusterer/PortraitOrientationClusterStrategy.php
+++ b/src/Clusterer/PortraitOrientationClusterStrategy.php
@@ -69,6 +69,16 @@ final readonly class PortraitOrientationClusterStrategy implements ClusterStrate
                     }
                 }
 
+                $orientation = $m->isPortrait();
+
+                if ($orientation === true) {
+                    return true;
+                }
+
+                if ($orientation === false) {
+                    return false;
+                }
+
                 $w = $m->getWidth();
                 $h = $m->getHeight();
 


### PR DESCRIPTION
## Summary
- short-circuit the portrait orientation filter when an explicit flag is present
- fall back to ratio checks only when the flag is unknown
- extend the portrait cluster strategy unit tests to cover the new flag behaviour and face/person requirements

## Testing
- composer ci:test *(fails: `bin/php` not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27609d6308323b84c96d4c172b84c