### PR TITLE
Adjust video detection fallback for video stories clustering

### DIFF
--- a/src/Clusterer/VideoStoriesClusterStrategy.php
+++ b/src/Clusterer/VideoStoriesClusterStrategy.php
@@ -59,9 +59,17 @@ final readonly class VideoStoriesClusterStrategy implements ClusterStrategyInter
         $videoItems = $this->filterTimestampedItemsBy(
             $items,
             static function (Media $m): bool {
-                $mime = $m->getMime();
+                if ($m->isVideo() === true) {
+                    return true;
+                }
 
-                return is_string($mime) && str_starts_with($mime, 'video/');
+                if ($m->isVideo() === false && $m->getIndexedAt() === null) {
+                    $mime = $m->getMime();
+
+                    return is_string($mime) && str_starts_with($mime, 'video/');
+                }
+
+                return false;
             }
         );
 


### PR DESCRIPTION
## Summary
- favour the media `isVideo` flag when filtering video stories and only fall back to MIME detection if metadata has not yet been indexed
- extend the VideoStoriesClusterStrategy unit tests to cover flag-only videos and explicit non-video overrides while keeping existing assertions intact

## Testing
- composer ci:test *(fails: bin/php missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2760c86d08323ab15d54f75cb71e5