### PR TITLE
Enhance clustering metadata and indexing QA

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -295,6 +295,7 @@ services:
             $calendar: '@MagicSunday\Memories\Service\Metadata\CalendarFeatureEnricher'
             $daypart: '@MagicSunday\Memories\Service\Metadata\DaypartEnricher'
             $solar: '@MagicSunday\Memories\Service\Metadata\SolarEnricher'
+            $metadataQaInspector: '@MagicSunday\Memories\Service\Metadata\MetadataQaInspector'
     MagicSunday\Memories\Service\Indexing\Stage\GeoStage:
         arguments:
             $geo: '@MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher'
@@ -482,6 +483,10 @@ services:
     MagicSunday\Memories\Clusterer\Support\LocalTimeHelper:
         arguments:
             $fallbackTimezone: '%memories.cluster.timezone.default%'
+
+    MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator:
+        arguments:
+            $qualityBaselineMegapixels: '%memories.score.quality_baseline_megapixels%'
 
     MagicSunday\Memories\Clusterer\PhashSimilarityStrategy:
         arguments:
@@ -899,7 +904,7 @@ services:
 
     MagicSunday\Memories\Service\Clusterer\Scoring\QualityClusterScoreHeuristic:
         arguments:
-            $qualityBaselineMegapixels: '%memories.score.quality_baseline_megapixels%'
+            $qualityAggregator: '@MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator'
 
     MagicSunday\Memories\Service\Clusterer\Scoring\PeopleClusterScoreHeuristic: ~
 

--- a/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
@@ -17,6 +17,7 @@ use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Clusterer\ClusterStrategyInterface;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
+use MagicSunday\Memories\Utility\CalendarFeatureHelper;
 
 use function array_map;
 use function assert;
@@ -202,11 +203,20 @@ abstract class AbstractAtHomeClusterStrategy implements ClusterStrategyInterface
             $centroid  = MediaMath::centroid($members);
             $timeRange = MediaMath::timeRange($members);
 
+            $params = ['time_range' => $timeRange];
+
+            $calendar = CalendarFeatureHelper::summarize($members);
+            if ($calendar['isWeekend'] !== null) {
+                $params['isWeekend'] = $calendar['isWeekend'];
+            }
+
+            if ($calendar['holidayId'] !== null) {
+                $params['holidayId'] = $calendar['holidayId'];
+            }
+
             $clusters[] = new ClusterDraft(
                 algorithm: $this->algorithm,
-                params: [
-                    'time_range' => $timeRange,
-                ],
+                params: $params,
                 centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
                 members: array_map(static fn (Media $media): int => $media->getId(), $members),
             );

--- a/src/Clusterer/Support/ClusterQualityAggregator.php
+++ b/src/Clusterer/Support/ClusterQualityAggregator.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Entity\Media;
+
+use function log;
+use function max;
+use function min;
+
+/**
+ * Aggregates per-media quality metrics for cluster level annotations.
+ */
+final class ClusterQualityAggregator
+{
+    public function __construct(private float $qualityBaselineMegapixels = 12.0)
+    {
+    }
+
+    /**
+     * Builds the quality related parameters for a list of media items.
+     *
+     * @param list<Media> $mediaItems
+     *
+     * @return array{
+     *     quality_avg: float,
+     *     aesthetics_score: float|null,
+     *     quality_resolution: float|null,
+     *     quality_sharpness: float|null,
+     *     quality_iso: float|null
+     * }
+     */
+    public function buildParams(array $mediaItems): array
+    {
+        $resolutionSum   = 0.0;
+        $resolutionCount = 0;
+        $sharpnessSum    = 0.0;
+        $sharpnessCount  = 0;
+        $isoSum          = 0.0;
+        $isoCount        = 0;
+
+        $brightnessSum   = 0.0;
+        $brightnessCount = 0;
+        $contrastSum     = 0.0;
+        $contrastCount   = 0;
+        $entropySum      = 0.0;
+        $entropyCount    = 0;
+        $colorSum        = 0.0;
+        $colorCount      = 0;
+
+        foreach ($mediaItems as $media) {
+            $width  = $media->getWidth();
+            $height = $media->getHeight();
+            if ($width !== null && $height !== null && $width > 0 && $height > 0) {
+                $megapixels = ((float) $width * (float) $height) / 1_000_000.0;
+                $resolutionSum += $this->clamp01($megapixels / max(1e-6, $this->qualityBaselineMegapixels));
+                ++$resolutionCount;
+            }
+
+            $sharpness = $media->getSharpness();
+            if ($sharpness !== null) {
+                $sharpnessSum += $this->clamp01($sharpness);
+                ++$sharpnessCount;
+            }
+
+            $iso = $media->getIso();
+            if ($iso !== null && $iso > 0) {
+                $isoSum += $this->normalizeIso($iso);
+                ++$isoCount;
+            }
+
+            $brightness = $media->getBrightness();
+            if ($brightness !== null) {
+                $brightnessSum += $this->clamp01($brightness);
+                ++$brightnessCount;
+            }
+
+            $contrast = $media->getContrast();
+            if ($contrast !== null) {
+                $contrastSum += $this->clamp01($contrast);
+                ++$contrastCount;
+            }
+
+            $entropy = $media->getEntropy();
+            if ($entropy !== null) {
+                $entropySum += $this->clamp01($entropy);
+                ++$entropyCount;
+            }
+
+            $colorfulness = $media->getColorfulness();
+            if ($colorfulness !== null) {
+                $colorSum += $this->clamp01($colorfulness);
+                ++$colorCount;
+            }
+        }
+
+        $resolution = $resolutionCount > 0 ? $resolutionSum / $resolutionCount : null;
+        $sharpness  = $sharpnessCount > 0 ? $sharpnessSum / $sharpnessCount : null;
+        $iso        = $isoCount > 0 ? $isoSum / $isoCount : null;
+
+        $quality = $this->combineScores([
+            [$resolution, 0.45],
+            [$sharpness, 0.35],
+            [$iso, 0.20],
+        ], 0.5);
+
+        $brightnessAvg = $brightnessCount > 0 ? $brightnessSum / $brightnessCount : null;
+        $contrastAvg   = $contrastCount > 0 ? $contrastSum / $contrastCount : null;
+        $entropyAvg    = $entropyCount > 0 ? $entropySum / $entropyCount : null;
+        $colorAvg      = $colorCount > 0 ? $colorSum / $colorCount : null;
+
+        $aesthetics = $this->combineScores([
+            [$brightnessAvg !== null ? $this->balancedScore($brightnessAvg, 0.55, 0.35) : null, 0.30],
+            [$contrastAvg, 0.20],
+            [$entropyAvg, 0.25],
+            [$colorAvg, 0.25],
+        ], null);
+
+        return [
+            'quality_avg'        => $quality ?? 0.0,
+            'aesthetics_score'   => $aesthetics,
+            'quality_resolution' => $resolution,
+            'quality_sharpness'  => $sharpness,
+            'quality_iso'        => $iso,
+        ];
+    }
+
+    private function clamp01(?float $value): float
+    {
+        if ($value === null) {
+            return 0.0;
+        }
+
+        if ($value < 0.0) {
+            return 0.0;
+        }
+
+        if ($value > 1.0) {
+            return 1.0;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<array{0: float|null, 1: float}> $components
+     */
+    private function combineScores(array $components, ?float $default): ?float
+    {
+        $sum       = 0.0;
+        $weightSum = 0.0;
+
+        foreach ($components as [$value, $weight]) {
+            if ($value === null) {
+                continue;
+            }
+
+            $sum += $this->clamp01($value) * $weight;
+            $weightSum += $weight;
+        }
+
+        if ($weightSum <= 0.0) {
+            return $default;
+        }
+
+        return $sum / $weightSum;
+    }
+
+    private function balancedScore(float $value, float $target, float $tolerance): float
+    {
+        $delta = abs($value - $target);
+        if ($delta >= $tolerance) {
+            return 0.0;
+        }
+
+        return $this->clamp01(1.0 - ($delta / $tolerance));
+    }
+
+    private function normalizeIso(int $iso): float
+    {
+        $min   = 50.0;
+        $max   = 6400.0;
+        $value = (float) max($min, min($max, $iso));
+        $ratio = log($value / $min) / log($max / $min);
+
+        return $this->clamp01(1.0 - $ratio);
+    }
+}

--- a/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
@@ -12,13 +12,11 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Clusterer\Scoring;
 
 use MagicSunday\Memories\Clusterer\ClusterDraft;
-use MagicSunday\Memories\Entity\Media;
-
-use function max;
+use MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator;
 
 final class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
-    public function __construct(private float $qualityBaselineMegapixels)
+    public function __construct(private ClusterQualityAggregator $qualityAggregator)
     {
     }
 
@@ -39,12 +37,12 @@ final class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
         $iso        = $this->floatOrNull($params['quality_iso'] ?? null);
 
         if ($quality === null || $aesthetics === null || $resolution === null || $sharpness === null || $iso === null) {
-            $metrics = $this->computeQualityMetrics($mediaList);
-            $quality ??= $metrics['quality'];
-            $aesthetics ??= $metrics['aesthetics'];
-            $resolution ??= $metrics['resolution'];
-            $sharpness ??= $metrics['sharpness'];
-            $iso ??= $metrics['iso'];
+            $metrics = $this->qualityAggregator->buildParams($mediaList);
+            $quality ??= $metrics['quality_avg'];
+            $aesthetics ??= $this->floatOrNull($metrics['aesthetics_score']);
+            $resolution ??= $this->floatOrNull($metrics['quality_resolution']);
+            $sharpness ??= $this->floatOrNull($metrics['quality_sharpness']);
+            $iso ??= $this->floatOrNull($metrics['quality_iso']);
         }
 
         $quality ??= 0.0;
@@ -77,105 +75,5 @@ final class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
     public function weightKey(): string
     {
         return 'quality';
-    }
-
-    /**
-     * @param list<Media> $mediaItems
-     *
-     * @return array{quality:float,aesthetics:float|null,resolution:float|null,sharpness:float|null,iso:float|null}
-     */
-    private function computeQualityMetrics(array $mediaItems): array
-    {
-        $resolutionSum   = 0.0;
-        $resolutionCount = 0;
-        $sharpnessSum    = 0.0;
-        $sharpnessCount  = 0;
-        $isoSum          = 0.0;
-        $isoCount        = 0;
-
-        $brightnessSum   = 0.0;
-        $brightnessCount = 0;
-        $contrastSum     = 0.0;
-        $contrastCount   = 0;
-        $entropySum      = 0.0;
-        $entropyCount    = 0;
-        $colorSum        = 0.0;
-        $colorCount      = 0;
-
-        foreach ($mediaItems as $media) {
-            $w = $media->getWidth();
-            $h = $media->getHeight();
-            if ($w !== null && $h !== null && $w > 0 && $h > 0) {
-                $megapixels = ((float) $w * (float) $h) / 1_000_000.0;
-                $resolutionSum += $this->clamp01($megapixels / max(1e-6, $this->qualityBaselineMegapixels));
-                ++$resolutionCount;
-            }
-
-            $sharpness = $media->getSharpness();
-            if ($sharpness !== null) {
-                $sharpnessSum += $this->clamp01($sharpness);
-                ++$sharpnessCount;
-            }
-
-            $iso = $media->getIso();
-            if ($iso !== null && $iso > 0) {
-                $isoSum += $this->normalizeIso($iso);
-                ++$isoCount;
-            }
-
-            $brightness = $media->getBrightness();
-            if ($brightness !== null) {
-                $brightnessSum += $this->clamp01($brightness);
-                ++$brightnessCount;
-            }
-
-            $contrast = $media->getContrast();
-            if ($contrast !== null) {
-                $contrastSum += $this->clamp01($contrast);
-                ++$contrastCount;
-            }
-
-            $entropy = $media->getEntropy();
-            if ($entropy !== null) {
-                $entropySum += $this->clamp01($entropy);
-                ++$entropyCount;
-            }
-
-            $colorfulness = $media->getColorfulness();
-            if ($colorfulness !== null) {
-                $colorSum += $this->clamp01($colorfulness);
-                ++$colorCount;
-            }
-        }
-
-        $resolution = $resolutionCount > 0 ? $resolutionSum / $resolutionCount : null;
-        $sharpness  = $sharpnessCount > 0 ? $sharpnessSum / $sharpnessCount : null;
-        $iso        = $isoCount > 0 ? $isoSum / $isoCount : null;
-
-        $quality = $this->combineScores([
-            [$resolution, 0.45],
-            [$sharpness, 0.35],
-            [$iso, 0.20],
-        ], 0.5);
-
-        $brightnessAvg = $brightnessCount > 0 ? $brightnessSum / $brightnessCount : null;
-        $contrastAvg   = $contrastCount > 0 ? $contrastSum / $contrastCount : null;
-        $entropyAvg    = $entropyCount > 0 ? $entropySum / $entropyCount : null;
-        $colorAvg      = $colorCount > 0 ? $colorSum / $colorCount : null;
-
-        $aesthetics = $this->combineScores([
-            [$brightnessAvg !== null ? $this->balancedScore($brightnessAvg, 0.55, 0.35) : null, 0.30],
-            [$contrastAvg, 0.20],
-            [$entropyAvg, 0.25],
-            [$colorAvg, 0.25],
-        ], null);
-
-        return [
-            'quality'    => $quality,
-            'aesthetics' => $aesthetics,
-            'resolution' => $resolution,
-            'sharpness'  => $sharpness,
-            'iso'        => $iso,
-        ];
     }
 }

--- a/src/Service/Metadata/MetadataQaInspector.php
+++ b/src/Service/Metadata/MetadataQaInspector.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Support\IndexLogHelper;
+
+use function array_key_exists;
+use function implode;
+use function sprintf;
+
+/**
+ * Validates that mandatory time related metadata has been enriched.
+ */
+final readonly class MetadataQaInspector
+{
+    public function __construct(
+        private DaypartEnricher $daypartEnricher,
+        private SolarEnricher $solarEnricher,
+    ) {
+    }
+
+    public function inspect(string $filepath, Media $media): void
+    {
+        $features = $media->getFeatures() ?? [];
+        $missing  = [];
+
+        if ($this->daypartEnricher->supports($filepath, $media)
+            && !array_key_exists('daypart', $features)
+        ) {
+            $missing[] = 'daypart';
+        }
+
+        if ($this->solarEnricher->supports($filepath, $media)
+            && !array_key_exists('isGoldenHour', $features)
+        ) {
+            $missing[] = 'isGoldenHour';
+        }
+
+        if ($missing === []) {
+            return;
+        }
+
+        $message = sprintf('Warnung: fehlende Zeit-Features (%s).', implode(', ', $missing));
+        IndexLogHelper::append($media, $message);
+    }
+}

--- a/src/Utility/CalendarFeatureHelper.php
+++ b/src/Utility/CalendarFeatureHelper.php
@@ -13,6 +13,8 @@ namespace MagicSunday\Memories\Utility;
 
 use MagicSunday\Memories\Entity\Media;
 
+use function array_key_first;
+use function count;
 use function is_array;
 use function is_bool;
 use function is_string;
@@ -78,6 +80,52 @@ final class CalendarFeatureHelper
             'season'    => $season,
             'isWeekend' => $isWeekend,
             'isHoliday' => $isHoliday,
+            'holidayId' => $holidayId,
+        ];
+    }
+
+    /**
+     * Aggregates the calendar flags for a list of media entries.
+     *
+     * @param list<Media> $items
+     *
+     * @return array{isWeekend: ?bool, holidayId: ?string}
+     */
+    public static function summarize(array $items): array
+    {
+        $weekendTrue  = 0;
+        $weekendFalse = 0;
+        $holidayIds   = [];
+
+        foreach ($items as $media) {
+            $features = self::extract($media);
+            $isWeekend = $features['isWeekend'];
+            if ($isWeekend === true) {
+                ++$weekendTrue;
+            } elseif ($isWeekend === false) {
+                ++$weekendFalse;
+            }
+
+            $holidayId = $features['holidayId'];
+            if ($holidayId !== null) {
+                $holidayIds[$holidayId] = true;
+            }
+        }
+
+        $isWeekend = null;
+        if ($weekendTrue > 0 && $weekendFalse === 0) {
+            $isWeekend = true;
+        } elseif ($weekendFalse > 0 && $weekendTrue === 0) {
+            $isWeekend = false;
+        }
+
+        $holidayId = null;
+        if (count($holidayIds) === 1) {
+            $holidayId = (string) array_key_first($holidayIds);
+        }
+
+        return [
+            'isWeekend' => $isWeekend,
             'holidayId' => $holidayId,
         ];
     }

--- a/test/Unit/Clusterer/AtHomeWeekendClusterStrategyTest.php
+++ b/test/Unit/Clusterer/AtHomeWeekendClusterStrategyTest.php
@@ -60,6 +60,7 @@ final class AtHomeWeekendClusterStrategyTest extends TestCase
             'to'   => (new DateTimeImmutable('2023-04-09 12:20:00', new DateTimeZone('UTC')))->getTimestamp(),
         ];
         self::assertSame($expectedRange, $cluster->getParams()['time_range']);
+        self::assertTrue($cluster->getParams()['isWeekend']);
 
         $centroid = $cluster->getCentroid();
         self::assertEqualsWithDelta(52.52, $centroid['lat'], 0.0002);
@@ -99,6 +100,12 @@ final class AtHomeWeekendClusterStrategyTest extends TestCase
             takenAt: $takenAt,
             lat: $lat,
             lon: $lon,
+            configure: static function (Media $media) use ($takenAt): void {
+                $weekday = (int) (new DateTimeImmutable($takenAt, new DateTimeZone('UTC')))->format('N');
+                $media->setFeatures([
+                    'isWeekend' => $weekday >= 6,
+                ]);
+            },
         );
     }
 }

--- a/test/Unit/Clusterer/CrossDimensionClusterStrategyTest.php
+++ b/test/Unit/Clusterer/CrossDimensionClusterStrategyTest.php
@@ -53,6 +53,7 @@ final class CrossDimensionClusterStrategyTest extends TestCase
             'to'   => (new DateTimeImmutable('2023-08-15 10:12:00', new DateTimeZone('UTC')))->getTimestamp(),
         ];
         self::assertSame($expectedRange, $cluster->getParams()['time_range']);
+        self::assertArrayHasKey('quality_avg', $cluster->getParams());
 
         $centroid = $cluster->getCentroid();
         self::assertEqualsWithDelta(40.712825, $centroid['lat'], 0.00001);
@@ -87,6 +88,16 @@ final class CrossDimensionClusterStrategyTest extends TestCase
             takenAt: $takenAt,
             lat: $lat,
             lon: $lon,
+            configure: static function (Media $media): void {
+                $media->setWidth(4000);
+                $media->setHeight(3000);
+                $media->setSharpness(0.75);
+                $media->setIso(100);
+                $media->setBrightness(0.6);
+                $media->setContrast(0.7);
+                $media->setEntropy(0.8);
+                $media->setColorfulness(0.9);
+            },
         );
     }
 }

--- a/test/Unit/Clusterer/DeviceSimilarityStrategyTest.php
+++ b/test/Unit/Clusterer/DeviceSimilarityStrategyTest.php
@@ -15,6 +15,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Clusterer\DeviceSimilarityStrategy;
+use MagicSunday\Memories\Entity\Enum\ContentKind;
 use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Test\TestCase;
@@ -38,9 +39,9 @@ final class DeviceSimilarityStrategyTest extends TestCase
         );
 
         $mediaItems = [
-            $this->createMedia(301, '2023-05-01 09:00:00', 'Canon EOS R5', $berlin, 52.5200, 13.4050),
-            $this->createMedia(302, '2023-05-01 10:30:00', 'Canon EOS R5', $berlin, 52.5203, 13.4052),
-            $this->createMedia(303, '2023-05-01 11:45:00', 'Canon EOS R5', $berlin, 52.5205, 13.4054),
+            $this->createMedia(301, '2023-05-01 09:00:00', 'Canon EOS R5', $berlin, 52.5200, 13.4050, 'RF24-70mm F2.8', ContentKind::PHOTO),
+            $this->createMedia(302, '2023-05-01 10:30:00', 'Canon EOS R5', $berlin, 52.5203, 13.4052, 'RF24-70mm F2.8', ContentKind::PHOTO),
+            $this->createMedia(303, '2023-05-01 11:45:00', 'Canon EOS R5', $berlin, 52.5205, 13.4054, 'RF24-70mm F2.8', ContentKind::PHOTO),
             // Different day, should not form a cluster because below minItems
             $this->createMedia(304, '2023-05-02 09:15:00', 'Canon EOS R5', $berlin, 52.5206, 13.4056),
             $this->createMedia(305, '2023-05-02 12:00:00', 'Canon EOS R5', $berlin, 52.5207, 13.4057),
@@ -58,6 +59,8 @@ final class DeviceSimilarityStrategyTest extends TestCase
         $params = $cluster->getParams();
         self::assertSame('Canon EOS R5', $params['device']);
         self::assertSame('Berlin', $params['place']);
+        self::assertSame('RF24-70mm F2.8', $params['lensModel']);
+        self::assertSame(ContentKind::PHOTO->value, $params['contentKind']);
 
         $expectedRange = [
             'from' => (new DateTimeImmutable('2023-05-01 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),
@@ -100,6 +103,8 @@ final class DeviceSimilarityStrategyTest extends TestCase
         Location $location,
         float $lat,
         float $lon,
+        ?string $lensModel = null,
+        ?ContentKind $contentKind = null,
     ): Media {
         return $this->makeMediaFixture(
             id: $id,
@@ -108,8 +113,10 @@ final class DeviceSimilarityStrategyTest extends TestCase
             lat: $lat,
             lon: $lon,
             location: $location,
-            configure: static function (Media $media) use ($camera): void {
+            configure: static function (Media $media) use ($camera, $lensModel, $contentKind): void {
                 $media->setCameraModel($camera);
+                $media->setLensModel($lensModel);
+                $media->setContentKind($contentKind);
             },
         );
     }

--- a/test/Unit/Clusterer/PersonCohortClusterStrategyTest.php
+++ b/test/Unit/Clusterer/PersonCohortClusterStrategyTest.php
@@ -53,6 +53,10 @@ final class PersonCohortClusterStrategyTest extends TestCase
 
         self::assertSame('people_cohort', $cluster->getAlgorithm());
         self::assertSame([1700, 1701, 1702, 1703, 1704], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertSame([1, 2, 3], $params['persons']);
+        self::assertArrayNotHasKey('person_labels', $params);
     }
 
     #[Test]
@@ -132,6 +136,10 @@ final class PersonCohortClusterStrategyTest extends TestCase
         $cluster = $clusters[0];
 
         self::assertSame([2000, 2001, 2002, 2003], $cluster->getMembers());
+
+        $params = $cluster->getParams();
+        self::assertArrayHasKey('persons', $params);
+        self::assertSame(['Alice', 'Bob'], $params['person_labels']);
     }
 
     /**

--- a/test/Unit/Clusterer/SeasonClusterStrategyTest.php
+++ b/test/Unit/Clusterer/SeasonClusterStrategyTest.php
@@ -59,6 +59,7 @@ final class SeasonClusterStrategyTest extends TestCase
         self::assertSame([1, 2, 3, 4], $cluster->getMembers());
         self::assertArrayHasKey('scene_tags', $params);
         self::assertArrayHasKey('keywords', $params);
+        self::assertArrayHasKey('quality_avg', $params);
         $sceneTags = $params['scene_tags'];
         self::assertCount(3, $sceneTags);
         self::assertSame('Schnee', $sceneTags[0]['label']);
@@ -114,6 +115,16 @@ final class SeasonClusterStrategyTest extends TestCase
             id: $id,
             filename: sprintf('season-%d.jpg', $id),
             takenAt: $takenAt,
+            configure: static function (Media $media): void {
+                $media->setWidth(4032);
+                $media->setHeight(3024);
+                $media->setSharpness(0.7);
+                $media->setIso(125);
+                $media->setBrightness(0.58);
+                $media->setContrast(0.65);
+                $media->setEntropy(0.72);
+                $media->setColorfulness(0.81);
+            },
         );
     }
 

--- a/test/Unit/Service/Clusterer/Scoring/CompositeClusterScorerTest.php
+++ b/test/Unit/Service/Clusterer/Scoring/CompositeClusterScorerTest.php
@@ -27,6 +27,7 @@ use MagicSunday\Memories\Service\Clusterer\Scoring\NoveltyHeuristic;
 use MagicSunday\Memories\Service\Clusterer\Scoring\NullHolidayResolver;
 use MagicSunday\Memories\Service\Clusterer\Scoring\PeopleClusterScoreHeuristic;
 use MagicSunday\Memories\Service\Clusterer\Scoring\PoiClusterScoreHeuristic;
+use MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator;
 use MagicSunday\Memories\Service\Clusterer\Scoring\QualityClusterScoreHeuristic;
 use MagicSunday\Memories\Service\Clusterer\Scoring\RecencyClusterScoreHeuristic;
 use MagicSunday\Memories\Service\Clusterer\Scoring\TemporalClusterScoreHeuristic;
@@ -60,7 +61,7 @@ final class CompositeClusterScorerTest extends TestCase
 
         $heuristics = [
             new TemporalClusterScoreHeuristic(3, 0.6, 1990),
-            new QualityClusterScoreHeuristic(12.0),
+            new QualityClusterScoreHeuristic(new ClusterQualityAggregator(12.0)),
             new PeopleClusterScoreHeuristic(),
             new ContentClusterScoreHeuristic(),
             new LocationClusterScoreHeuristic(),

--- a/test/Unit/Service/Clusterer/Scoring/QualityClusterScoreHeuristicTest.php
+++ b/test/Unit/Service/Clusterer/Scoring/QualityClusterScoreHeuristicTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Test\Unit\Service\Clusterer\Scoring;
 
 use MagicSunday\Memories\Clusterer\ClusterDraft;
+use MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Clusterer\Scoring\QualityClusterScoreHeuristic;
 use MagicSunday\Memories\Test\TestCase;
@@ -22,7 +23,7 @@ final class QualityClusterScoreHeuristicTest extends TestCase
     #[Test]
     public function enrichCalculatesQualityAndAesthetics(): void
     {
-        $heuristic = new QualityClusterScoreHeuristic(qualityBaselineMegapixels: 12.0);
+        $heuristic = new QualityClusterScoreHeuristic(new ClusterQualityAggregator(12.0));
 
         $cluster = new ClusterDraft(
             algorithm: 'test',

--- a/test/Unit/Service/Metadata/MetadataQaInspectorTest.php
+++ b/test/Unit/Service/Metadata/MetadataQaInspectorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Contract\TimezoneResolverInterface;
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\DaypartEnricher;
+use MagicSunday\Memories\Service\Metadata\MetadataQaInspector;
+use MagicSunday\Memories\Service\Metadata\SolarEnricher;
+use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class MetadataQaInspectorTest extends TestCase
+{
+    #[Test]
+    public function logsMissingFlagsWhenEnrichersSupport(): void
+    {
+        $inspector = $this->createInspector();
+        $media      = $this->makeMediaFixture(
+            id: 1,
+            filename: 'qa-metadata.jpg',
+            takenAt: new DateTimeImmutable('2023-06-01 08:00:00', new DateTimeZone('UTC')),
+            lat: 52.5,
+            lon: 13.4,
+        );
+        $media->setTimezoneOffsetMin(60);
+
+        $inspector->inspect('/tmp/qa-metadata.jpg', $media);
+
+        $log = $media->getIndexLog();
+        self::assertNotNull($log);
+        self::assertStringContainsString('daypart', (string) $log);
+        self::assertStringContainsString('isGoldenHour', (string) $log);
+    }
+
+    #[Test]
+    public function skipsLoggingWhenFlagsArePresent(): void
+    {
+        $inspector = $this->createInspector();
+        $media      = $this->makeMediaFixture(
+            id: 2,
+            filename: 'qa-metadata-present.jpg',
+            takenAt: new DateTimeImmutable('2023-06-02 08:00:00', new DateTimeZone('UTC')),
+            lat: 52.6,
+            lon: 13.5,
+        );
+        $media->setTimezoneOffsetMin(120);
+        $media->setFeatures([
+            'daypart' => 'morning',
+            'isGoldenHour' => true,
+        ]);
+
+        $inspector->inspect('/tmp/qa-metadata-present.jpg', $media);
+
+        self::assertNull($media->getIndexLog());
+    }
+
+    private function createInspector(): MetadataQaInspector
+    {
+        $timezoneResolver = new class implements TimezoneResolverInterface {
+            public function resolveMediaTimezone(Media $media, DateTimeImmutable $takenAt, array $home): DateTimeZone
+            {
+                return new DateTimeZone('UTC');
+            }
+
+            public function resolveSummaryTimezone(array $summary, array $home): DateTimeZone
+            {
+                return new DateTimeZone('UTC');
+            }
+
+            public function determineLocalTimezoneOffset(array $offsetVotes, array $home): ?int
+            {
+                return 0;
+            }
+
+            public function determineLocalTimezoneIdentifier(array $identifierVotes, array $home, ?int $offset): string
+            {
+                return 'UTC';
+            }
+        };
+
+        $resolver = new CaptureTimeResolver($timezoneResolver);
+
+        return new MetadataQaInspector(
+            new DaypartEnricher($resolver),
+            new SolarEnricher($resolver),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- propagate calendar flags and aggregated quality metrics into day album, cross-dimension, season, at-home, and device clusters
- capture person identifiers/labels for person cohort clusters and add a reusable quality aggregator plus QA inspector for metadata stages
- extend tests to cover new metadata parameters, device metadata, inspector behaviour, and updated pipeline expectations

## Testing
- `vendor/bin/phpunit -c .build/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68e272c0dcfc8323b4de650a1621c4af