### PR TITLE
Use cached home distances in at-home clustering

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -558,6 +558,7 @@ services:
             $minHomeShare: 0.62
             $minItemsPerDay: 3
             $minItemsTotal: 6
+            $homeVersionHash: '%memories.home.version_hash%'
         tags:
             - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.at_home_weekend_cluster_strategy%' }
 
@@ -569,6 +570,7 @@ services:
             $minHomeShare: 0.60
             $minItemsPerDay: 3
             $minItemsTotal: 5
+            $homeVersionHash: '%memories.home.version_hash%'
         tags:
             - { name: 'memories.cluster_strategy', priority: '%memories.cluster.priority.at_home_weekday_cluster_strategy%' }
 

--- a/src/Clusterer/AtHomeWeekdayClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekdayClusterStrategy.php
@@ -27,6 +27,7 @@ final class AtHomeWeekdayClusterStrategy extends AbstractAtHomeClusterStrategy
         float $minHomeShare = 0.7,
         int $minItemsPerDay = 4,
         int $minItemsTotal = 8,
+        string $homeVersionHash = '',
     ) {
         parent::__construct(
             algorithm: 'at_home_weekday',
@@ -38,6 +39,7 @@ final class AtHomeWeekdayClusterStrategy extends AbstractAtHomeClusterStrategy
             minItemsPerDay: $minItemsPerDay,
             minItemsTotal: $minItemsTotal,
             localTimeHelper: $localTimeHelper,
+            homeVersionHash: $homeVersionHash,
         );
     }
 }

--- a/src/Clusterer/AtHomeWeekendClusterStrategy.php
+++ b/src/Clusterer/AtHomeWeekendClusterStrategy.php
@@ -27,6 +27,7 @@ final class AtHomeWeekendClusterStrategy extends AbstractAtHomeClusterStrategy
         float $minHomeShare = 0.7,
         int $minItemsPerDay = 4,
         int $minItemsTotal = 6,
+        string $homeVersionHash = '',
     ) {
         parent::__construct(
             algorithm: 'at_home_weekend',
@@ -38,6 +39,7 @@ final class AtHomeWeekendClusterStrategy extends AbstractAtHomeClusterStrategy
             minItemsPerDay: $minItemsPerDay,
             minItemsTotal: $minItemsTotal,
             localTimeHelper: $localTimeHelper,
+            homeVersionHash: $homeVersionHash,
         );
     }
 }

--- a/test/Unit/Clusterer/AtHomeWeekdayClusterStrategyTest.php
+++ b/test/Unit/Clusterer/AtHomeWeekdayClusterStrategyTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\Attributes\Test;
 
 final class AtHomeWeekdayClusterStrategyTest extends TestCase
 {
+    private const HOME_VERSION_HASH = 'test-home-version';
+
     #[Test]
     public function clustersConsecutiveWeekdaysWithinHomeRadius(): void
     {
@@ -32,6 +34,7 @@ final class AtHomeWeekdayClusterStrategyTest extends TestCase
             minHomeShare: 0.6,
             minItemsPerDay: 2,
             minItemsTotal: 4,
+            homeVersionHash: self::HOME_VERSION_HASH,
         );
 
         $mediaItems = [
@@ -42,6 +45,20 @@ final class AtHomeWeekdayClusterStrategyTest extends TestCase
             $this->createMedia(105, '2023-04-04 08:20:00', 52.5198, 13.4048),
             $this->createMedia(106, '2023-04-08 10:00:00', 52.5200, 13.4050),
         ];
+
+        $hash = $this->computeHomeConfigHash(52.5200, 13.4050, 500.0);
+        $mediaItems[0]->setDistanceKmFromHome(0.12);
+        $mediaItems[0]->setHomeConfigHash($hash);
+        $mediaItems[1]->setDistanceKmFromHome(0.18);
+        $mediaItems[1]->setHomeConfigHash($hash);
+        $mediaItems[2]->setDistanceKmFromHome(1.80);
+        $mediaItems[2]->setHomeConfigHash($hash);
+        $mediaItems[3]->setDistanceKmFromHome(0.10);
+        $mediaItems[3]->setHomeConfigHash($hash);
+        $mediaItems[4]->setDistanceKmFromHome(0.16);
+        $mediaItems[4]->setHomeConfigHash($hash);
+        $mediaItems[5]->setDistanceKmFromHome(0.05);
+        $mediaItems[5]->setHomeConfigHash($hash);
 
         $clusters = $strategy->cluster($mediaItems);
 
@@ -85,6 +102,20 @@ final class AtHomeWeekdayClusterStrategyTest extends TestCase
             takenAt: $takenAt,
             lat: $lat,
             lon: $lon,
+        );
+    }
+
+    private function computeHomeConfigHash(float $homeLat, float $homeLon, float $homeRadiusMeters): string
+    {
+        return hash(
+            'sha256',
+            sprintf(
+                '%.8f|%.8f|%.8f|%s',
+                $homeLat,
+                $homeLon,
+                $homeRadiusMeters / 1000.0,
+                self::HOME_VERSION_HASH,
+            ),
         );
     }
 }

--- a/test/Unit/Clusterer/AtHomeWeekendClusterStrategyTest.php
+++ b/test/Unit/Clusterer/AtHomeWeekendClusterStrategyTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\Attributes\Test;
 
 final class AtHomeWeekendClusterStrategyTest extends TestCase
 {
+    private const HOME_VERSION_HASH = 'test-home-version';
+
     #[Test]
     public function clustersWeekendSessionsWithinHomeRadius(): void
     {
@@ -32,6 +34,7 @@ final class AtHomeWeekendClusterStrategyTest extends TestCase
             minHomeShare: 0.6,
             minItemsPerDay: 2,
             minItemsTotal: 4,
+            homeVersionHash: self::HOME_VERSION_HASH,
         );
 
         $mediaItems = [
@@ -46,6 +49,22 @@ final class AtHomeWeekendClusterStrategyTest extends TestCase
             // Weekday entry that should be ignored entirely
             $this->createMedia(307, '2023-04-10 07:45:00', 52.5203, 13.4053),
         ];
+
+        $hash = $this->computeHomeConfigHash(52.5200, 13.4050, 400.0);
+        $mediaItems[0]->setDistanceKmFromHome(0.08);
+        $mediaItems[0]->setHomeConfigHash($hash);
+        $mediaItems[1]->setDistanceKmFromHome(0.12);
+        $mediaItems[1]->setHomeConfigHash($hash);
+        $mediaItems[2]->setDistanceKmFromHome(2.50);
+        $mediaItems[2]->setHomeConfigHash($hash);
+        $mediaItems[3]->setDistanceKmFromHome(0.15);
+        $mediaItems[3]->setHomeConfigHash($hash);
+        $mediaItems[4]->setDistanceKmFromHome(0.11);
+        $mediaItems[4]->setHomeConfigHash($hash);
+        $mediaItems[5]->setDistanceKmFromHome(3.10);
+        $mediaItems[5]->setHomeConfigHash($hash);
+        $mediaItems[6]->setDistanceKmFromHome(0.05);
+        $mediaItems[6]->setHomeConfigHash($hash);
 
         $clusters = $strategy->cluster($mediaItems);
 
@@ -78,6 +97,7 @@ final class AtHomeWeekendClusterStrategyTest extends TestCase
             minHomeShare: 0.7,
             minItemsPerDay: 2,
             minItemsTotal: 4,
+            homeVersionHash: self::HOME_VERSION_HASH,
         );
 
         $mediaItems = [
@@ -106,6 +126,20 @@ final class AtHomeWeekendClusterStrategyTest extends TestCase
                     'isWeekend' => $weekday >= 6,
                 ]);
             },
+        );
+    }
+
+    private function computeHomeConfigHash(float $homeLat, float $homeLon, float $homeRadiusMeters): string
+    {
+        return hash(
+            'sha256',
+            sprintf(
+                '%.8f|%.8f|%.8f|%s',
+                $homeLat,
+                $homeLon,
+                $homeRadiusMeters / 1000.0,
+                self::HOME_VERSION_HASH,
+            ),
         );
     }
 }


### PR DESCRIPTION
## Summary
- reuse cached distance-to-home values in the at-home clustering strategy when the stored configuration hash matches
- accept the home version hash in weekday/weekend strategy constructors and service wiring so cached distances stay valid across config changes
- extend the weekday and weekend strategy tests to cover clustering with precomputed distances

## Testing
- composer ci:test *(fails: `bin/php` missing in container)*
- composer ci:test:php:unit *(fails: `bin/php` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2795d79108323962039382bc616bc