### PR TITLE
Add dominant tag metadata to cluster strategies

### DIFF
--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -170,6 +170,11 @@ final readonly class AnniversaryClusterStrategy implements ClusterStrategyInterf
                 $params['place'] = $label;
             }
 
+            $tags = $this->collectDominantTags($group);
+            if ($tags !== []) {
+                $params = [...$params, ...$tags];
+            }
+
             $drafts[] = new ClusterDraft(
                 algorithm: $this->name(),
                 params: $params,

--- a/test/Unit/Clusterer/AnniversaryClusterStrategyTest.php
+++ b/test/Unit/Clusterer/AnniversaryClusterStrategyTest.php
@@ -48,6 +48,11 @@ final class AnniversaryClusterStrategyTest extends TestCase
             $this->createMedia(1103, '2020-03-10 11:10:00', $munich, 48.1373, 11.5755),
         ];
 
+        $mediaItems[0]->setSceneTags([
+            ['label' => 'Familienfest', 'score' => 0.9],
+        ]);
+        $mediaItems[0]->setKeywords(['Jubiläum']);
+
         $clusters = $strategy->cluster($mediaItems);
 
         self::assertCount(1, $clusters);
@@ -59,6 +64,10 @@ final class AnniversaryClusterStrategyTest extends TestCase
 
         $params = $cluster->getParams();
         self::assertSame('Berlin', $params['place']);
+        self::assertSame([
+            ['label' => 'Familienfest', 'score' => 0.9],
+        ], $params['scene_tags']);
+        self::assertSame(['Jubiläum'], $params['keywords']);
 
         $expectedRange = [
             'from' => (new DateTimeImmutable('2019-01-05 09:00:00', new DateTimeZone('UTC')))->getTimestamp(),

--- a/test/Unit/Clusterer/BurstClusterStrategyTest.php
+++ b/test/Unit/Clusterer/BurstClusterStrategyTest.php
@@ -34,6 +34,10 @@ final class BurstClusterStrategyTest extends TestCase
         ];
 
         $mediaItems[2]->setBurstRepresentative(true);
+        $mediaItems[0]->setSceneTags([
+            ['label' => 'Serienaufnahme', 'score' => 0.8],
+        ]);
+        $mediaItems[0]->setKeywords(['Serienaufnahme']);
 
         $clusters = $strategy->cluster($mediaItems);
 
@@ -51,6 +55,10 @@ final class BurstClusterStrategyTest extends TestCase
         ];
         self::assertSame($expectedRange, $params['time_range']);
         self::assertSame(3003, $params['representative_media_id']);
+        self::assertSame([
+            ['label' => 'Serienaufnahme', 'score' => 0.8],
+        ], $params['scene_tags']);
+        self::assertSame(['Serienaufnahme'], $params['keywords']);
 
         $centroid = $cluster->getCentroid();
         self::assertEqualsWithDelta(52.5202, $centroid['lat'], 0.0001);

--- a/test/Unit/Clusterer/HolidayEventClusterStrategyTest.php
+++ b/test/Unit/Clusterer/HolidayEventClusterStrategyTest.php
@@ -34,6 +34,11 @@ final class HolidayEventClusterStrategyTest extends TestCase
             $this->createMedia(7, '2023-05-01 09:15:00', 49.0, 12.0),
         ];
 
+        $mediaItems[0]->setSceneTags([
+            ['label' => 'Weihnachten', 'score' => 0.95],
+        ]);
+        $mediaItems[0]->setKeywords(['Weihnachten']);
+
         $clusters = $strategy->cluster($mediaItems);
 
         self::assertCount(2, $clusters);
@@ -43,6 +48,10 @@ final class HolidayEventClusterStrategyTest extends TestCase
         self::assertSame(2023, $first->getParams()['year']);
         self::assertSame('1. Weihnachtstag', $first->getParams()['holiday_name']);
         self::assertSame([1, 2, 3], $first->getMembers());
+        self::assertSame([
+            ['label' => 'Weihnachten', 'score' => 0.95],
+        ], $first->getParams()['scene_tags']);
+        self::assertSame(['Weihnachten'], $first->getParams()['keywords']);
 
         $second = $clusters[1];
         self::assertSame(2024, $second->getParams()['year']);

--- a/test/Unit/Clusterer/OneYearAgoClusterStrategyTest.php
+++ b/test/Unit/Clusterer/OneYearAgoClusterStrategyTest.php
@@ -44,6 +44,11 @@ final class OneYearAgoClusterStrategyTest extends TestCase
                     $this->createMedia(5, $anchorBase->modify('+5 days')),
                 ];
 
+                $mediaItems[0]->setSceneTags([
+                    ['label' => 'Jahresrückblick', 'score' => 0.85],
+                ]);
+                $mediaItems[0]->setKeywords(['Jahresrückblick']);
+
                 $clusters = $strategy->cluster($mediaItems);
 
                 if (!$isStable()) {
@@ -56,6 +61,10 @@ final class OneYearAgoClusterStrategyTest extends TestCase
                 self::assertSame('one_year_ago', $cluster->getAlgorithm());
                 self::assertSame([1, 2, 3, 4], $cluster->getMembers());
                 self::assertArrayHasKey('time_range', $cluster->getParams());
+                self::assertSame([
+                    ['label' => 'Jahresrückblick', 'score' => 0.85],
+                ], $cluster->getParams()['scene_tags']);
+                self::assertSame(['Jahresrückblick'], $cluster->getParams()['keywords']);
 
                 return true;
             }

--- a/test/Unit/Clusterer/ThisMonthOverYearsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/ThisMonthOverYearsClusterStrategyTest.php
@@ -49,6 +49,11 @@ final class ThisMonthOverYearsClusterStrategyTest extends TestCase
                     $this->createMedia(7, $anchor->setDate($noiseYear, $nextMonth, 1)->setTime(7, 0)),
                 ];
 
+                $mediaItems[0]->setSceneTags([
+                    ['label' => 'Frühlingsausflug', 'score' => 0.82],
+                ]);
+                $mediaItems[0]->setKeywords(['Frühlingsausflug']);
+
                 $clusters = $strategy->cluster($mediaItems);
 
                 if (!$isStable()) {
@@ -61,6 +66,10 @@ final class ThisMonthOverYearsClusterStrategyTest extends TestCase
                 self::assertSame('this_month_over_years', $cluster->getAlgorithm());
                 self::assertSame([1, 2, 3, 4, 5, 6], $cluster->getMembers());
                 self::assertSame($month, $cluster->getParams()['month']);
+                self::assertSame([
+                    ['label' => 'Frühlingsausflug', 'score' => 0.82],
+                ], $cluster->getParams()['scene_tags']);
+                self::assertSame(['Frühlingsausflug'], $cluster->getParams()['keywords']);
 
                 return true;
             }

--- a/test/Unit/Clusterer/VideoStoriesClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VideoStoriesClusterStrategyTest.php
@@ -54,6 +54,13 @@ final class VideoStoriesClusterStrategyTest extends TestCase
                 $video->setVideoHasStabilization($hasStabilization);
             }
 
+            if ($i === 0) {
+                $video->setSceneTags([
+                    ['label' => 'Filmabend', 'score' => 0.88],
+                ]);
+                $video->setKeywords(['Filmabend']);
+            }
+
             $videos[] = $video;
         }
 
@@ -76,6 +83,10 @@ final class VideoStoriesClusterStrategyTest extends TestCase
         self::assertSame(30.0, $params['video_duration_total_s']);
         self::assertSame(1, $params['video_slow_mo_count']);
         self::assertSame(2, $params['video_stabilized_count']);
+        self::assertSame([
+            ['label' => 'Filmabend', 'score' => 0.88],
+        ], $params['scene_tags']);
+        self::assertSame(['Filmabend'], $params['keywords']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- ensure cluster strategies reuse ClusterBuildHelperTrait for centroid/time/member calculations and merge dominant scene tags and keywords into cluster params
- update cluster unit tests to cover the new metadata

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml --testsuite "Unit Tests"

------
https://chatgpt.com/codex/tasks/task_e_68e27d818e8c83239201bfbeec24a832