### PR TITLE
BUGFIX: replace deprecated Imagick destroy calls

### DIFF
--- a/src/Service/Metadata/Support/ImagickImageAdapter.php
+++ b/src/Service/Metadata/Support/ImagickImageAdapter.php
@@ -101,7 +101,6 @@ final readonly class ImagickImageAdapter implements ImageAdapterInterface
     public function destroy(): void
     {
         $this->image->clear();
-        $this->image->destroy();
     }
 
     public function getNative(): Imagick
@@ -134,7 +133,8 @@ final readonly class ImagickImageAdapter implements ImageAdapterInterface
             Imagick::PIXEL_CHAR
         );
 
-        $clone->destroy();
+        $clone->clear();
+        unset($clone);
 
         // normalisieren auf ints 0..255
         $out    = [];

--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -187,7 +187,7 @@ class ThumbnailService implements ThumbnailServiceInterface
                         // Flatten transparent images on a white background to avoid artefacts in the final JPEG file.
                         $flattened = $clone->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
                         $clone->clear();
-                        $clone->destroy();
+                        unset($clone);
                         $clone = $flattened;
                     }
 
@@ -205,14 +205,14 @@ class ThumbnailService implements ThumbnailServiceInterface
                     $results[$targetWidth] = $out;
                 } finally {
                     $clone->clear();
-                    $clone->destroy();
+                    unset($clone);
                 }
             }
 
             return $results;
         } finally {
             $imagick->clear();
-            $imagick->destroy();
+            unset($imagick);
         }
     }
 


### PR DESCRIPTION
## Summary
- replace direct calls to the deprecated `Imagick::destroy()` method with `clear()` and `unset` to avoid runtime notices
- ensure the Imagick image adapter releases temporary clones without invoking the deprecated API

## Testing
- composer ci:test *(fails: `bin/php` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2854a05708323b35d25fd4db69f0a