### PR TITLE
Use array_find to simplify search loops

### DIFF
--- a/src/Service/Feed/ThumbnailPathResolver.php
+++ b/src/Service/Feed/ThumbnailPathResolver.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Service\Feed;
 
 use MagicSunday\Memories\Entity\Media;
 
+use function array_find;
 use function array_values;
 use function basename;
 use function is_array;
@@ -73,10 +74,14 @@ final class ThumbnailPathResolver
             // Or treat as list of paths
             $values = array_values($thumbs);
             sort($values, SORT_STRING);
-            foreach ($values as $p) {
-                if (is_string($p) && is_file($p)) {
-                    return $p;
-                }
+
+            $match = array_find(
+                $values,
+                static fn (mixed $path): bool => is_string($path) && is_file($path)
+            );
+
+            if (is_string($match)) {
+                return $match;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the fallback thumbnail search loop with array_find()
- rely on array_find() when choosing the first matching filename date pattern

## Testing
- composer ci:test *(fails: bin/php not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2866feeb48323aed671a43297befd