### PR TITLE
Refine memory feed filtering logic

### DIFF
--- a/src/Service/Feed/MemoryFeedBuilder.php
+++ b/src/Service/Feed/MemoryFeedBuilder.php
@@ -62,21 +62,17 @@ final readonly class MemoryFeedBuilder implements FeedBuilderInterface
     public function build(array $clusters): array
     {
         // 1) filter
-        $filtered = [];
-        foreach ($clusters as $c) {
-            $score        = (float) ($c->getParams()['score'] ?? 0.0);
-            $membersCount = $c->getMembersCount();
-            if ($score < $this->minScore) {
-                continue;
-            }
+        $filtered = array_values(array_filter(
+            $clusters,
+            function (ClusterDraft $c): bool {
+                $score = (float) ($c->getParams()['score'] ?? 0.0);
+                if ($score < $this->minScore) {
+                    return false;
+                }
 
-            if ($membersCount < $this->minMembers) {
-                continue;
+                return $c->getMembersCount() >= $this->minMembers;
             }
-
-            $members = $c->getMembers();
-            $filtered[] = $c;
-        }
+        ));
 
         if ($filtered === []) {
             return [];


### PR DESCRIPTION
## Summary
- replace the manual cluster filtering loop with an array_filter closure enforcing score and member thresholds
- ensure filtered clusters remain a reindexed list before sorting

## Testing
- composer ci:test *(fails: bin/php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ac80c7083238ea5eaf270aa3eb3