### PR TITLE
Refine binary response header detection

### DIFF
--- a/src/Http/Response/BinaryFileResponse.php
+++ b/src/Http/Response/BinaryFileResponse.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Http\Response;
 use finfo;
 use RuntimeException;
 
+use function array_any;
 use function array_keys;
 use function file_get_contents;
 use function filesize;
@@ -124,13 +125,10 @@ final class BinaryFileResponse extends Response
      */
     private function hasHeader(array $headers, string $name): bool
     {
-        foreach (array_keys($headers) as $headerName) {
-            if (strcasecmp($headerName, $name) === 0) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            array_keys($headers),
+            static fn (string $headerName): bool => strcasecmp($headerName, $name) === 0,
+        );
     }
 
     private function resolveMimeType(string $filePath): string


### PR DESCRIPTION
## Summary
- switch BinaryFileResponse::hasHeader to use array_any for case-insensitive matching
- import array_any to support the functional header lookup

## Testing
- composer ci:test *(fails: bin/php not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ae175648323b431587c6e670d54