### PR TITLE
Refactor Overpass tag value checks

### DIFF
--- a/src/Service/Geocoding/OverpassPrimaryTagResolver.php
+++ b/src/Service/Geocoding/OverpassPrimaryTagResolver.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Service\Geocoding;
 
 use MagicSunday\Memories\Service\Geocoding\Contract\OverpassPrimaryTagResolverInterface;
 
+use function array_any;
 use function is_string;
 
 /**
@@ -49,15 +50,10 @@ final readonly class OverpassPrimaryTagResolver implements OverpassPrimaryTagRes
             return false;
         }
 
-        if (in_array(
-            $value,
+        return array_any(
             $allowedValues,
-            true
-        )) {
-            return true;
-        }
-
-        return false;
+            static fn (string $allowed): bool => $allowed === $value
+        );
     }
 
     private function stringOrNull(mixed $value): ?string

--- a/src/Service/Geocoding/OverpassTagSelector.php
+++ b/src/Service/Geocoding/OverpassTagSelector.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Service\Geocoding;
 
 use MagicSunday\Memories\Service\Geocoding\Contract\OverpassTagSelectorInterface;
 
+use function array_any;
 use function array_filter;
 use function array_map;
 use function array_unique;
@@ -158,15 +159,10 @@ final class OverpassTagSelector implements OverpassTagSelectorInterface
             return false;
         }
 
-        if (in_array(
-            $value,
+        return array_any(
             $allowedValues,
-            true
-        )) {
-            return true;
-        }
-
-        return false;
+            static fn (string $allowed): bool => $allowed === $value
+        );
     }
 
     private function stringOrNull(mixed $value): ?string


### PR DESCRIPTION
## Summary
- switch Overpass tag value validation helpers to array_any to streamline comparisons
- keep empty allowed value guards so disallowed sets still return false

## Testing
- composer ci:test *(fails: sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ae1c4fc83238f742e9e949c7c35