### PR TITLE
Refactor cluster consolidation stages to use array_map

### DIFF
--- a/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
+++ b/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Clusterer\Pipeline;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidationStageInterface;
 
+use function array_map;
 use function count;
 
 /**
@@ -57,10 +58,10 @@ final class AnnotationPruningStage implements ClusterConsolidationStageInterface
         }
 
         /** @var list<list<int>> $normalized */
-        $normalized = [];
-        foreach ($drafts as $draft) {
-            $normalized[] = $this->normalizeMembers($draft->getMembers());
-        }
+        $normalized = array_map(
+            static fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
+            $drafts,
+        );
 
         /** @var array<int,int> $memberUse */
         $memberUse = [];

--- a/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
+++ b/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
@@ -16,6 +16,7 @@ use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidationStageInterface;
 
 use function array_keys;
+use function array_map;
 use function count;
 use function usort;
 
@@ -73,10 +74,10 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
         }
 
         /** @var list<list<int>> $normalized */
-        $normalized = [];
-        foreach ($drafts as $draft) {
-            $normalized[] = $this->normalizeMembers($draft->getMembers());
-        }
+        $normalized = array_map(
+            static fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
+            $drafts,
+        );
 
         /** @var array<string,list<int>> $byAlgorithm */
         $byAlgorithm = [];
@@ -170,10 +171,10 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
         }
 
         /** @var list<ClusterDraft> $result */
-        $result = [];
-        foreach ($selected as $index) {
-            $result[] = $drafts[$index];
-        }
+        $result = array_map(
+            static fn (int $index): ClusterDraft => $drafts[$index],
+            $selected,
+        );
 
         return $result;
     }

--- a/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
+++ b/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Clusterer\Pipeline;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidationStageInterface;
 
+use function array_map;
 use function array_values;
 use function count;
 
@@ -64,10 +65,10 @@ final class DuplicateCollapseStage implements ClusterConsolidationStageInterface
         }
 
         /** @var list<list<int>> $normalized */
-        $normalized = [];
-        foreach ($drafts as $draft) {
-            $normalized[] = $this->normalizeMembers($draft->getMembers());
-        }
+        $normalized = array_map(
+            static fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
+            $drafts,
+        );
 
         /** @var array<string,int> $winnerByFingerprint */
         $winnerByFingerprint = [];
@@ -92,11 +93,14 @@ final class DuplicateCollapseStage implements ClusterConsolidationStageInterface
             $progress($total, $total);
         }
 
+        /** @var list<int> $winners */
+        $winners = array_values($winnerByFingerprint);
+
         /** @var list<ClusterDraft> $result */
-        $result = [];
-        foreach ($winnerByFingerprint as $idx) {
-            $result[] = $drafts[$idx];
-        }
+        $result = array_map(
+            static fn (int $index): ClusterDraft => $drafts[$index],
+            $winners,
+        );
 
         return $result;
     }


### PR DESCRIPTION
## Summary
- replace manual member normalization loops with array_map in annotation pruning, dominance selection, and duplicate collapse stages
- return selected drafts via array_map to streamline dominance and duplicate collapse stages

## Testing
- composer ci:test:php:unit *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ae6a9ac832398a4b2d62d7e75b6