### PR TITLE
Refactor feed payload mapping

### DIFF
--- a/src/Http/Controller/FeedController.php
+++ b/src/Http/Controller/FeedController.php
@@ -36,6 +36,7 @@ use RuntimeException;
 
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function array_replace;
 use function array_slice;
 use function count;
@@ -157,10 +158,11 @@ final class FeedController
             }
         }
 
-        $data = [];
-        foreach ($filtered as $item) {
-            $data[] = $this->transformItem($item);
-        }
+        /** @var list<array<string, mixed>> $data */
+        $data = array_map(
+            fn (MemoryFeedItem $item): array => $this->transformItem($item),
+            $filtered,
+        );
 
         $meta = [
             'erstelltAm'          =>


### PR DESCRIPTION
## Summary
- replace the feed item transformation loop with an `array_map` to produce a typed payload list
- import the `array_map` helper and document the feed payload structure for static analysis

## Testing
- composer ci:test *(fails: `bin/php` not found in the repository image)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ae6daf08323baf60436b2f706ef