### PR TITLE
Remove redundant timestamp casts in cluster strategies

### DIFF
--- a/src/Clusterer/CrossDimensionClusterStrategy.php
+++ b/src/Clusterer/CrossDimensionClusterStrategy.php
@@ -81,7 +81,7 @@ final readonly class CrossDimensionClusterStrategy implements ClusterStrategyInt
         $lastTs = null;
 
         foreach ($withTime as $m) {
-            $ts = (int) $m->getTakenAt()->getTimestamp();
+            $ts = $m->getTakenAt()->getTimestamp();
 
             if ($lastTs !== null && ($ts - $lastTs) > $this->timeGapSeconds && $buf !== []) {
                 $runs[] = $buf;

--- a/src/Clusterer/GoldenHourClusterStrategy.php
+++ b/src/Clusterer/GoldenHourClusterStrategy.php
@@ -112,7 +112,7 @@ final readonly class GoldenHourClusterStrategy implements ClusterStrategyInterfa
         $lastTs = null;
 
         foreach ($cand as $m) {
-            $ts = (int) $m->getTakenAt()->getTimestamp();
+            $ts = $m->getTakenAt()->getTimestamp();
             if ($lastTs !== null && ($ts - $lastTs) > $this->sessionGapSeconds && $buf !== []) {
                 $runs[] = $buf;
                 $buf    = [];

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -94,7 +94,7 @@ final readonly class NightlifeEventClusterStrategy implements ClusterStrategyInt
         $lastTs = null;
 
         foreach ($night as $m) {
-            $ts = (int) $m->getTakenAt()->getTimestamp();
+            $ts = $m->getTakenAt()->getTimestamp();
             if ($lastTs !== null && ($ts - $lastTs) > $this->timeGapSeconds && $buf !== []) {
                 $runs[] = $buf;
                 $buf    = [];


### PR DESCRIPTION
## Summary
- remove redundant integer casting when computing timestamps in golden hour, cross dimension, and nightlife cluster strategies

## Testing
- composer ci:test *(fails: `bin/php` not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b25838883238bb90d91d998a4ce