### PR TITLE
Refactor cluster member ID extraction

### DIFF
--- a/src/Clusterer/Support/ClusterBuildHelperTrait.php
+++ b/src/Clusterer/Support/ClusterBuildHelperTrait.php
@@ -46,12 +46,7 @@ trait ClusterBuildHelperTrait
      */
     private function toMemberIds(array $members): array
     {
-        $out = [];
-        foreach ($members as $m) {
-            $out[] = $m->getId();
-        }
-
-        return $out;
+        return array_map(static fn (Media $member): int => $member->getId(), $members);
     }
 
     /**


### PR DESCRIPTION
## Summary
- simplify ClusterBuildHelperTrait::toMemberIds by using array_map to extract media IDs

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ae9e7908323b084b061e014c230