### PR TITLE
Refactor density stage photo count extraction

### DIFF
--- a/src/Clusterer/DaySummaryStage/DensityStage.php
+++ b/src/Clusterer/DaySummaryStage/DensityStage.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Clusterer\DaySummaryStage;
 
 use MagicSunday\Memories\Clusterer\Contract\DaySummaryStageInterface;
 
+use function array_map;
 use function array_sum;
 use function count;
 use function sqrt;
@@ -30,10 +31,7 @@ final class DensityStage implements DaySummaryStageInterface
             return [];
         }
 
-        $photoCounts = [];
-        foreach ($days as $summary) {
-            $photoCounts[] = $summary['photoCount'];
-        }
+        $photoCounts = array_map(static fn (array $summary): int => $summary['photoCount'], $days);
 
         $stats = $this->computeMeanStd($photoCounts);
         foreach ($days as &$summary) {


### PR DESCRIPTION
## Summary
- replace the DensityStage photo count loop with array_map
- import the array_map helper for clarity

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml --filter DaySummaryStage
- composer ci:test *(fails: phpstan reports 776 existing errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e28ae8e7e08323b96ddbf693df5527