### PR TITLE
Refactor phash prefix handling

### DIFF
--- a/src/Service/Metadata/PerceptualHashExtractor.php
+++ b/src/Service/Metadata/PerceptualHashExtractor.php
@@ -143,14 +143,13 @@ final readonly class PerceptualHashExtractor implements SingleMetadataExtractorI
             $media->setDhash($this->computeDhash64($mat));
             $media->setPhash(strtolower($phashHex));
 
-            $prefixLength = max(0, min(32, $this->phashPrefixLength));
-            if ($prefixLength > 0) {
+            if ($this->phashPrefixLength > 0) {
                 $media->setPhashPrefix(
                     strtolower(
                         substr(
                             $phashHex,
                             0,
-                            $prefixLength
+                            $this->phashPrefixLength
                         )
                     )
                 );


### PR DESCRIPTION
## Summary
- simplify perceptual hash extraction by using the validated prefix length directly
- ensure the perceptual hash prefix is set or cleared based solely on the configured length

## Testing
- `./vendor/bin/phpunit --configuration .build/phpunit.xml --filter PerceptualHashExtractorTest`
- `composer ci:test` *(fails: `bin/php` helper binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b464fe88323abd1fabca83a2d51