### PR TITLE
Refine cached cluster score lookups

### DIFF
--- a/src/Service/Clusterer/Scoring/ContentClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/ContentClusterScoreHeuristic.php
@@ -65,13 +65,15 @@ final class ContentClusterScoreHeuristic extends AbstractClusterScoreHeuristic
      */
     private function computeContentMetrics(array $mediaItems, int $members, array $params): array
     {
-        if (isset($params['content']) && $this->floatOrNull($params['content']) !== null) {
+        $cachedContentScore = $this->floatOrNull($params['content'] ?? null);
+
+        if (($score = $cachedContentScore) !== null) {
             $unique   = (int) ($params['content_keywords_unique'] ?? 0);
             $total    = (int) ($params['content_keywords_total'] ?? 0);
             $coverage = $this->clamp01($this->floatOrNull($params['content_coverage'] ?? null));
 
             return [
-                'score'           => $this->clamp01((float) $params['content']),
+                'score'           => $this->clamp01($score),
                 'unique_keywords' => $unique,
                 'total_keywords'  => $total,
                 'coverage'        => $coverage,

--- a/src/Service/Clusterer/Scoring/LocationClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/LocationClusterScoreHeuristic.php
@@ -60,9 +60,11 @@ final class LocationClusterScoreHeuristic extends AbstractClusterScoreHeuristic
      */
     private function computeLocationMetrics(array $mediaItems, int $members, array $params): array
     {
-        if (isset($params['location_score']) && $this->floatOrNull($params['location_score']) !== null) {
+        $cachedLocationScore = $this->floatOrNull($params['location_score'] ?? null);
+
+        if (($score = $cachedLocationScore) !== null) {
             return [
-                'score'        => $this->clamp01((float) $params['location_score']),
+                'score'        => $this->clamp01($score),
                 'geo_coverage' => $this->clamp01($this->floatOrNull($params['location_geo_coverage'] ?? null)),
             ];
         }

--- a/src/Service/Clusterer/Scoring/PeopleClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/PeopleClusterScoreHeuristic.php
@@ -63,8 +63,10 @@ final class PeopleClusterScoreHeuristic extends AbstractClusterScoreHeuristic
      */
     private function computePeopleMetrics(array $mediaItems, int $members, array $params): array
     {
-        if (isset($params['people']) && $this->floatOrNull($params['people']) !== null) {
-            $score    = $this->clamp01((float) $params['people']);
+        $cachedPeopleScore = $this->floatOrNull($params['people'] ?? null);
+
+        if (($score = $cachedPeopleScore) !== null) {
+            $score    = $this->clamp01($score);
             $mentions = (int) ($params['people_count'] ?? 0);
             $unique   = (int) ($params['people_unique'] ?? 0);
             $coverage = $this->clamp01($this->floatOrNull($params['people_coverage'] ?? null));


### PR DESCRIPTION
## Summary
- cache cached score values before checking reuse across content, people, and location heuristics
- reuse the cached score variable within each heuristic while keeping clamping behaviour unchanged

## Testing
- composer ci:test *(fails: `bin/php` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b59e00883239ae175c59eb24567