### PR TITLE
Remove unreachable catch when resolving refreshed timestamp

### DIFF
--- a/src/Service/Geocoding/LocationResolver.php
+++ b/src/Service/Geocoding/LocationResolver.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Geocoding;
 
 use DateTimeImmutable;
-use Exception;
 use Doctrine\ORM\EntityManagerInterface;
 use MagicSunday\Memories\Entity\Location;
 
@@ -278,10 +277,6 @@ final class LocationResolver implements PoiEnsurerInterface
             return $geocode->refreshedAt;
         }
 
-        try {
-            return new DateTimeImmutable();
-        } catch (Exception) {
-            return null;
-        }
+        return new DateTimeImmutable();
     }
 }


### PR DESCRIPTION
## Summary
- drop the unused Exception import in `LocationResolver`
- return a `DateTimeImmutable` directly when no refreshed timestamp is supplied instead of relying on an unreachable catch block

## Testing
- `composer ci:test` *(fails: bin/php not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b66670c8323b56f8902c6bfd2ea