### PR TITLE
Remove redundant exception handling in Nominatim reverse geocoder

### DIFF
--- a/src/Service/Geocoding/NominatimReverseGeocoder.php
+++ b/src/Service/Geocoding/NominatimReverseGeocoder.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Geocoding;
 
 use DateTimeImmutable;
-use Exception;
 use MagicSunday\Memories\Utility\MediaMath;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -101,11 +100,7 @@ final readonly class NominatimReverseGeocoder implements ReverseGeocoderInterfac
 
         $accuracy = $this->accuracyRadius($bbox, (float) $latS, (float) $lonS);
 
-        try {
-            $refreshedAt = new DateTimeImmutable();
-        } catch (Exception) {
-            $refreshedAt = null;
-        }
+        $refreshedAt = new DateTimeImmutable();
 
         return new GeocodeResult(
             provider: 'nominatim',


### PR DESCRIPTION
## Summary
- remove the unused Exception import and create the refreshed timestamp directly in the Nominatim reverse geocoder

## Testing
- composer ci:test *(fails: bin/php vendor/bin/phplint --configuration .build/.phplint.yml; bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b691d4c83239bc599e9b8e9bc7b