### PR TITLE
Switch EXIF processor iterator attribute to AutowireIterator

### DIFF
--- a/src/Service/Metadata/ExifMetadataExtractor.php
+++ b/src/Service/Metadata/ExifMetadataExtractor.php
@@ -13,7 +13,7 @@ namespace MagicSunday\Memories\Service\Metadata;
 
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Metadata\Exif\Contract\ExifMetadataProcessorInterface;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Throwable;
 
 use function array_key_exists;
@@ -57,7 +57,7 @@ final readonly class ExifMetadataExtractor implements SingleMetadataExtractorInt
      * @param iterable<ExifMetadataProcessorInterface> $processors
      */
     public function __construct(
-        #[TaggedIterator('memories.metadata.exif.processor')]
+        #[AutowireIterator('memories.metadata.exif.processor')]
         private iterable $processors,
         private bool $readExifForVideos = false,
     ) {


### PR DESCRIPTION
## Summary
- replace the TaggedIterator attribute with AutowireIterator when injecting EXIF metadata processors

## Testing
- composer ci:test *(fails: phpstan reports numerous existing strict rules errors in the current tree)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b71263c83238ccc2775ff137d85