### PR TITLE
BUGFIX: Align ensurePois signature with interface

### DIFF
--- a/src/Service/Geocoding/LocationResolver.php
+++ b/src/Service/Geocoding/LocationResolver.php
@@ -131,15 +131,15 @@ final class LocationResolver implements PoiEnsurerInterface
      *
      * This is used when we re-use Locations from the cell cache/index without
      * going through the full reverse-geocoding pipeline again. When
-     * $forceRefresh is true, existing POI data is cleared before the re-fetch.
+     * $refreshPois is true, existing POI data is cleared before the re-fetch.
      */
-    public function ensurePois(Location $location, bool $forceRefresh = false): void
+    public function ensurePois(Location $location, bool $refreshPois = false): void
     {
         if (!($this->poiEnricher instanceof LocationPoiEnricher)) {
             return;
         }
 
-        if ($forceRefresh && $location->getPois() !== null) {
+        if ($refreshPois && $location->getPois() !== null) {
             $location->setPois(null);
         }
 


### PR DESCRIPTION
## Summary
- rename the `ensurePois` refresh flag parameter to match `PoiEnsurerInterface`
- update docblock and method body to use the renamed variable

## Testing
- ⚠️ `composer ci:test` *(fails: `bin/php` executable not found in container)*
- ⚠️ `composer ci:test:php:lint` *(fails: `bin/php` executable not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b790ac48323ad0e39141336d9ac