### PR TITLE
Adjust MediaRepository phash prefix handling

### DIFF
--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -33,11 +33,12 @@ use function trim;
  */
 readonly class MediaRepository implements MemberMediaLookupInterface
 {
-    public function __construct(private EntityManagerInterface $em, private int $phashPrefixLength = 16)
+    private int $phashPrefixLength;
+
+    public function __construct(private EntityManagerInterface $em, int $phashPrefixLength = 16)
     {
-        if ($this->phashPrefixLength < 0) {
-            $this->phashPrefixLength = 0;
-        }
+        $phashPrefixLength       = max(0, $phashPrefixLength);
+        $this->phashPrefixLength = $phashPrefixLength;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add an explicit property for the media repository pHash prefix length
- sanitize the constructor argument before storing it on the repository

## Testing
- composer ci:test *(fails: sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b909b1c8323a8db5a2c4fd1a8d0