### PR TITLE
Add readonly to constructor-promoted dependencies

### DIFF
--- a/src/Clusterer/DefaultHomeLocator.php
+++ b/src/Clusterer/DefaultHomeLocator.php
@@ -37,11 +37,11 @@ final class DefaultHomeLocator implements HomeLocatorInterface
     private const int NIGHT_END_HOUR = 6;
 
     public function __construct(
-        private string $timezone = 'Europe/Berlin',
-        private float $defaultHomeRadiusKm = 15.0,
-        private ?float $homeLat = null,
-        private ?float $homeLon = null,
-        private ?float $homeRadiusKm = null,
+        private readonly string $timezone = 'Europe/Berlin',
+        private readonly float $defaultHomeRadiusKm = 15.0,
+        private readonly ?float $homeLat = null,
+        private readonly ?float $homeLon = null,
+        private readonly ?float $homeRadiusKm = null,
     ) {
         if ($this->timezone === '') {
             throw new InvalidArgumentException('timezone must not be empty.');

--- a/src/Clusterer/Service/TimezoneResolver.php
+++ b/src/Clusterer/Service/TimezoneResolver.php
@@ -31,7 +31,7 @@ final class TimezoneResolver implements TimezoneResolverInterface
         createTimezoneFromOffset as private traitCreateTimezoneFromOffset;
     }
 
-    public function __construct(private string $timezone = 'Europe/Berlin')
+    public function __construct(private readonly string $timezone = 'Europe/Berlin')
     {
         if ($this->timezone === '') {
             throw new InvalidArgumentException('timezone must not be empty.');

--- a/src/Clusterer/Support/ClusterQualityAggregator.php
+++ b/src/Clusterer/Support/ClusterQualityAggregator.php
@@ -22,7 +22,7 @@ use function min;
  */
 final class ClusterQualityAggregator
 {
-    public function __construct(private float $qualityBaselineMegapixels = 12.0)
+    public function __construct(private readonly float $qualityBaselineMegapixels = 12.0)
     {
     }
 

--- a/src/Repository/ClusterRepository.php
+++ b/src/Repository/ClusterRepository.php
@@ -21,7 +21,7 @@ use function max;
  */
 readonly class ClusterRepository
 {
-    public function __construct(private EntityManagerInterface $em)
+    public function __construct(private readonly EntityManagerInterface $em)
     {
     }
 

--- a/src/Repository/MediaDuplicateRepository.php
+++ b/src/Repository/MediaDuplicateRepository.php
@@ -24,7 +24,7 @@ use function strcmp;
  */
 readonly class MediaDuplicateRepository
 {
-    public function __construct(private EntityManagerInterface $entityManager)
+    public function __construct(private readonly EntityManagerInterface $entityManager)
     {
     }
 

--- a/src/Repository/MediaRepository.php
+++ b/src/Repository/MediaRepository.php
@@ -33,7 +33,7 @@ use function trim;
  */
 readonly class MediaRepository implements MemberMediaLookupInterface
 {
-    public function __construct(private EntityManagerInterface $em, private int $phashPrefixLength = 16)
+    public function __construct(private readonly EntityManagerInterface $em, private int $phashPrefixLength = 16)
     {
         if ($this->phashPrefixLength < 0) {
             $this->phashPrefixLength = 0;

--- a/src/Service/Clusterer/Pipeline/PipelineClusterConsolidator.php
+++ b/src/Service/Clusterer/Pipeline/PipelineClusterConsolidator.php
@@ -23,7 +23,7 @@ final readonly class PipelineClusterConsolidator implements ClusterConsolidatorI
     /**
      * @param iterable<ClusterConsolidationStageInterface> $stages
      */
-    public function __construct(private iterable $stages)
+    public function __construct(private readonly iterable $stages)
     {
     }
 

--- a/src/Service/Clusterer/Scoring/PoiClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/PoiClusterScoreHeuristic.php
@@ -22,7 +22,7 @@ use function is_numeric;
 final class PoiClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
     /** @param array<string,float> $poiCategoryBoosts */
-    public function __construct(private array $poiCategoryBoosts = [])
+    public function __construct(private readonly array $poiCategoryBoosts = [])
     {
     }
 

--- a/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
@@ -19,7 +19,7 @@ use MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator;
  */
 final class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
-    public function __construct(private ClusterQualityAggregator $qualityAggregator)
+    public function __construct(private readonly ClusterQualityAggregator $qualityAggregator)
     {
     }
 

--- a/src/Service/Clusterer/SmartTitleGenerator.php
+++ b/src/Service/Clusterer/SmartTitleGenerator.php
@@ -29,7 +29,7 @@ use function trim;
  */
 final readonly class SmartTitleGenerator implements TitleGeneratorInterface
 {
-    public function __construct(private TitleTemplateProvider $provider)
+    public function __construct(private readonly TitleTemplateProvider $provider)
     {
     }
 

--- a/src/Service/Geocoding/OverpassPrimaryTagResolver.php
+++ b/src/Service/Geocoding/OverpassPrimaryTagResolver.php
@@ -20,7 +20,7 @@ use function is_string;
  */
 final readonly class OverpassPrimaryTagResolver implements OverpassPrimaryTagResolverInterface
 {
-    public function __construct(private OverpassTagConfiguration $configuration)
+    public function __construct(private readonly OverpassTagConfiguration $configuration)
     {
     }
 

--- a/src/Service/Metadata/BurstDetector.php
+++ b/src/Service/Metadata/BurstDetector.php
@@ -33,7 +33,7 @@ use function usort;
  */
 final readonly class BurstDetector implements SingleMetadataExtractorInterface
 {
-    public function __construct(private MediaRepository $mediaRepository)
+    public function __construct(private readonly MediaRepository $mediaRepository)
     {
     }
 

--- a/src/Service/Metadata/DaypartEnricher.php
+++ b/src/Service/Metadata/DaypartEnricher.php
@@ -20,7 +20,7 @@ use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
  */
 final readonly class DaypartEnricher implements SingleMetadataExtractorInterface
 {
-    public function __construct(private CaptureTimeResolver $captureTimeResolver)
+    public function __construct(private readonly CaptureTimeResolver $captureTimeResolver)
     {
     }
 

--- a/src/Service/Metadata/LivePairLinker.php
+++ b/src/Service/Metadata/LivePairLinker.php
@@ -29,7 +29,7 @@ use function usort;
  */
 final readonly class LivePairLinker implements SingleMetadataExtractorInterface
 {
-    public function __construct(private MediaRepository $mediaRepository)
+    public function __construct(private readonly MediaRepository $mediaRepository)
     {
     }
 


### PR DESCRIPTION
## Summary
- mark constructor-promoted dependencies and configuration scalars as readonly where they are never reassigned
- keep mutable properties such as MediaRepository::$phashPrefixLength unchanged to preserve runtime clamping logic

## Testing
- `composer ci:test` *(fails: phpstan reports 776 pre-existing errors such as cast.useless and missingType.iterableValue)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b89a6808323b9252635995a57e1