### PR TITLE
Chore: clarify docblock variable references

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -25,29 +25,21 @@ class Application extends \Symfony\Component\Console\Application
 {
     /**
      * The name of the application.
-     *
-     * @var string
      */
     private const string NAME = 'memories';
 
     /**
      * The path to the version file.
-     *
-     * @var string
      */
     private const string VERSION_FILE = __DIR__ . '/../version';
 
     /**
      * The default version if the version file is not available.
-     *
-     * @var string
      */
     private const string DEFAULT_VERSION = '0.0.0';
 
     /**
      * The logo.
-     *
-     * @var string
      */
     private static string $logo = ' .____                         .__                                .___               ____.
  |   _|   _____ _____     ____ |__| ____   ________ __  ____    __| _/____  ___.__. |_   |

--- a/src/Clusterer/ClusterDraft.php
+++ b/src/Clusterer/ClusterDraft.php
@@ -22,29 +22,27 @@ final class ClusterDraft
 {
     /**
      * Name of the algorithm that produced the cluster.
-     *
-     * @var string
      */
     private readonly string $algorithm;
 
     /**
      * Raw configuration parameters provided by the clustering strategy.
      *
-     * @var array<string, int|float|string|bool|array|null>
+     * @var array<string, int|float|string|bool|array|null> $params
      */
     private array $params;
 
     /**
      * Geographic centroid coordinates (latitude/longitude pair).
      *
-     * @var array{lat: float, lon: float}
+     * @var array{lat: float, lon: float} $centroid
      */
     private readonly array $centroid;
 
     /**
      * Ordered identifiers of media entities that belong to the cluster.
      *
-     * @var list<int>
+     * @var list<int> $members
      */
     private readonly array $members;
 
@@ -72,85 +70,61 @@ final class ClusterDraft
 
     /**
      * Marks the timestamp of the first media item that belongs to the cluster.
-     *
-     * @var DateTimeImmutable|null
      */
     private ?DateTimeImmutable $startAt = null;
 
     /**
      * Marks the timestamp of the last media item that belongs to the cluster.
-     *
-     * @var DateTimeImmutable|null
      */
     private ?DateTimeImmutable $endAt = null;
 
     /**
      * Cached count of members for quick read access without recalculating the array size.
-     *
-     * @var int
      */
     private int $membersCount = 0;
 
     /**
      * Number of photos that belong to the cluster.
-     *
-     * @var int|null
      */
     private ?int $photoCount = null;
 
     /**
      * Number of videos that belong to the cluster.
-     *
-     * @var int|null
      */
     private ?int $videoCount = null;
 
     /**
      * Identifier of the media entity that represents the cover image.
-     *
-     * @var int|null
      */
     private ?int $coverMediaId = null;
 
     /**
      * Optional location associated with the cluster.
-     *
-     * @var Location|null
      */
     private ?Location $location = null;
 
     /**
      * Version string of the algorithm that produced the cluster.
-     *
-     * @var string|null
      */
     private ?string $algorithmVersion = null;
 
     /**
      * Hash of the configuration that was used during clustering.
-     *
-     * @var string|null
      */
     private ?string $configHash = null;
 
     /**
      * Latitude of the cluster centroid stored for quick access.
-     *
-     * @var float|null
      */
     private ?float $centroidLat = null;
 
     /**
      * Longitude of the cluster centroid stored for quick access.
-     *
-     * @var float|null
      */
     private ?float $centroidLon = null;
 
     /**
      * S2 cell identifier with level 7 precision representing the centroid.
-     *
-     * @var string|null
      */
     private ?string $centroidCell7 = null;
 

--- a/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
@@ -38,7 +38,7 @@ abstract class AbstractAtHomeClusterStrategy implements ClusterStrategyInterface
     use MediaFilterTrait;
 
     /**
-     * @var array<int, true>
+     * @var array<int, true> $allowedWeekdayLookup
      */
     private readonly array $allowedWeekdayLookup;
 

--- a/src/Clusterer/Support/PersonSignatureHelper.php
+++ b/src/Clusterer/Support/PersonSignatureHelper.php
@@ -29,7 +29,7 @@ use function trim;
 final class PersonSignatureHelper
 {
     /**
-     * @var array<string, int>
+     * @var array<string, int> $cache
      */
     private array $cache = [];
 

--- a/src/Entity/Cluster.php
+++ b/src/Entity/Cluster.php
@@ -60,7 +60,7 @@ class Cluster
     /**
      * Configuration parameters used by the clustering algorithm.
      *
-     * @var array<string, mixed>
+     * @var array<string, mixed> $params
      */
     #[ORM\Column(type: Types::JSON)]
     private array $params;
@@ -68,7 +68,7 @@ class Cluster
     /**
      * Geographic centroid of the cluster expressed as latitude/longitude pair.
      *
-     * @var array{lat: float, lon: float}
+     * @var array{lat: float, lon: float} $centroid
      */
     #[ORM\Column(type: Types::JSON)]
     private array $centroid;
@@ -76,7 +76,7 @@ class Cluster
     /**
      * Identifiers of the media records that belong to this cluster.
      *
-     * @var list<int>
+     * @var list<int> $members
      */
     #[ORM\Column(type: Types::JSON)]
     private array $members;

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -138,7 +138,7 @@ class Location
     /**
      * Bounding box coordinates describing the spatial footprint.
      *
-     * @var list<float>|null
+     * @var list<float>|null $boundingBox
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $boundingBox = null;
@@ -146,7 +146,7 @@ class Location
     /**
      * Nearby Points of Interest enriched via Overpass API responses.
      *
-     * @var list<array<string, mixed>>|null
+     * @var list<array<string, mixed>>|null $pois
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $pois = null;
@@ -220,7 +220,7 @@ class Location
     /**
      * Alternative names keyed by qualifier or locale.
      *
-     * @var array<string, string>|null
+     * @var array<string, string>|null $altNames
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $altNames = null;
@@ -228,7 +228,7 @@ class Location
     /**
      * Additional provider specific tags.
      *
-     * @var array<string, string>|null
+     * @var array<string, string>|null $extraTags
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $extraTags = null;

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -431,7 +431,7 @@ class Media
     /**
      * Normalised ffprobe stream metadata for downstream consumers.
      *
-     * @var array<int, array<int|string, int|float|string|bool|null|array<int|string, int|float|string|bool|null|array>>>|null
+     * @var array<int, array<int|string, int|float|string|bool|null|array<int|string, int|float|string|bool|null|array>>>|null $videoStreams
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $videoStreams = null;
@@ -553,7 +553,7 @@ class Media
     /**
      * List of keywords extracted or assigned to the media.
      *
-     * @var array<int, string>|null
+     * @var array<int, string>|null $keywords
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $keywords = null;
@@ -561,7 +561,7 @@ class Media
     /**
      * List of detected or tagged persons.
      *
-     * @var array<int, string>|null
+     * @var array<int, string>|null $persons
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $persons = null;
@@ -581,7 +581,7 @@ class Media
     /**
      * Feature set describing the scene (labels, categories, etc.).
      *
-     * @var array<string, scalar|array|null>|null
+     * @var array<string, scalar|array|null>|null $features
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $features = null;
@@ -589,7 +589,7 @@ class Media
     /**
      * Highest confidence scene tags derived from vision models.
      *
-     * @var list<array{label: string, score: float}>|null
+     * @var list<array{label: string, score: float}>|null $sceneTags
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $sceneTags = null;
@@ -597,7 +597,7 @@ class Media
     /**
      * Generated thumbnails mapped by size identifier.
      *
-     * @var array<string, string>|null
+     * @var array<string, string>|null $thumbnails
      */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $thumbnails = null;

--- a/src/Http/Controller/FeedController.php
+++ b/src/Http/Controller/FeedController.php
@@ -59,7 +59,7 @@ use const SORT_STRING;
 final class FeedController
 {
     /**
-     * @var array<int, Media|null>
+     * @var array<int, Media|null> $mediaCache
      */
     private array $mediaCache = [];
 

--- a/src/Http/Response/Response.php
+++ b/src/Http/Response/Response.php
@@ -27,7 +27,7 @@ use RuntimeException;
  */
 class Response
 {
-    /** @var array<string,string> */
+    /** @var array<string,string> $headers */
     private array $headers;
 
     public function __construct(

--- a/src/Service/Clusterer/HybridClusterer.php
+++ b/src/Service/Clusterer/HybridClusterer.php
@@ -27,7 +27,7 @@ use function iterator_to_array;
  */
 final class HybridClusterer implements HybridClustererInterface
 {
-    /** @var list<ClusterStrategyInterface>|null */
+    /** @var list<ClusterStrategyInterface>|null $strategiesCache */
     private ?array $strategiesCache = null;
 
     /**

--- a/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
+++ b/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
@@ -23,7 +23,7 @@ final class AnnotationPruningStage implements ClusterConsolidationStageInterface
 {
     use StageSupportTrait;
 
-    /** @var array<string,bool> */
+    /** @var array<string,bool> $annotateOnlySet */
     private array $annotateOnlySet = [];
 
     /**

--- a/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
+++ b/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
@@ -26,7 +26,7 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
 {
     use StageSupportTrait;
 
-    /** @var array<string,int> */
+    /** @var array<string,int> $priorityMap */
     private array $priorityMap = [];
 
     /**

--- a/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
+++ b/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
@@ -24,7 +24,7 @@ final class DuplicateCollapseStage implements ClusterConsolidationStageInterface
 {
     use StageSupportTrait;
 
-    /** @var array<string,int> */
+    /** @var array<string,int> $priorityMap */
     private array $priorityMap = [];
 
     /**

--- a/src/Service/Clusterer/Pipeline/PerMediaCapStage.php
+++ b/src/Service/Clusterer/Pipeline/PerMediaCapStage.php
@@ -24,7 +24,7 @@ final class PerMediaCapStage implements ClusterConsolidationStageInterface
 {
     use StageSupportTrait;
 
-    /** @var array<string,int> */
+    /** @var array<string,int> $priorityMap */
     private array $priorityMap = [];
 
     /**

--- a/src/Service/Clusterer/Scoring/CompositeClusterScorer.php
+++ b/src/Service/Clusterer/Scoring/CompositeClusterScorer.php
@@ -30,10 +30,10 @@ use function usort;
  */
 final class CompositeClusterScorer
 {
-    /** @var list<ClusterScoreHeuristicInterface> */
+    /** @var list<ClusterScoreHeuristicInterface> $heuristics */
     private array $heuristics;
 
-    /** @var array<string,string> */
+    /** @var array<string,string> $algorithmGroups */
     private array $algorithmGroups = [];
 
     /**

--- a/src/Service/Clusterer/Scoring/NoveltyHeuristic.php
+++ b/src/Service/Clusterer/Scoring/NoveltyHeuristic.php
@@ -45,13 +45,13 @@ use const SORT_NUMERIC;
  */
 final class NoveltyHeuristic extends AbstractClusterScoreHeuristic
 {
-    /** @var array<string,mixed>|null */
+    /** @var array<string,mixed>|null $stats */
     private ?array $stats = null;
 
     public function __construct(
         private float $gridStepDeg = 0.5,     // ~55 km
         private int $phashPrefixNibbles = 4,  // 4 hex chars -> 16 bit
-        /** @var array{place: float, time: float, device: float, content: float} */
+        /** @var array{place: float, time: float, device: float, content: float} $weights */
         private array $weights = [
             'place'   => 0.35,
             'time'    => 0.25,

--- a/src/Service/Clusterer/Scoring/RecencyClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/RecencyClusterScoreHeuristic.php
@@ -22,7 +22,7 @@ use function time;
  */
 final class RecencyClusterScoreHeuristic extends AbstractTimeRangeClusterScoreHeuristic
 {
-    /** @var callable():int */
+    /** @var callable():int $timeProvider */
     private $timeProvider;
 
     private int $now = 0;

--- a/src/Service/Clusterer/Title/TitleTemplateProvider.php
+++ b/src/Service/Clusterer/Title/TitleTemplateProvider.php
@@ -33,7 +33,7 @@ use function is_string;
  */
 final class TitleTemplateProvider
 {
-    /** @var array<string, array<string, array{title:string,subtitle?:string}>> */
+    /** @var array<string, array<string, array{title:string,subtitle?:string}>> $templates */
     private array $templates = [];
 
     public function __construct(

--- a/src/Service/Geocoding/LocationCellIndex.php
+++ b/src/Service/Geocoding/LocationCellIndex.php
@@ -22,7 +22,9 @@ use MagicSunday\Memories\Entity\Location;
  */
 final class LocationCellIndex
 {
-    /** @var array<string,int> cell -> location id */
+    /**
+     * @var array<string,int> $cellToId cell -> location id
+     */
     private array $cellToId = [];
 
     public function __construct(private readonly EntityManagerInterface $em)

--- a/src/Service/Geocoding/LocationResolver.php
+++ b/src/Service/Geocoding/LocationResolver.php
@@ -29,7 +29,9 @@ use function strtoupper;
  */
 final class LocationResolver implements PoiEnsurerInterface
 {
-    /** @var array<string,Location> provider|placeId -> Location (may be managed or detached) */
+    /**
+     * @var array<string,Location> $cacheByKey provider|placeId -> Location (may be managed or detached)
+     */
     private array $cacheByKey = [];
 
     private bool $lastUsedNetwork = false;

--- a/src/Service/Geocoding/MediaLocationLinker.php
+++ b/src/Service/Geocoding/MediaLocationLinker.php
@@ -22,7 +22,7 @@ use function sprintf;
  */
 final class MediaLocationLinker implements MediaLocationLinkerInterface
 {
-    /** @var array<string,Location> in-run cache: cell -> Location (managed) */
+    /** @var array<string,Location> $cellCache in-run cache: cell -> Location (managed) */
     private array $cellCache = [];
 
     private int $lastNetworkCalls = 0;

--- a/src/Service/Geocoding/OverpassTagConfiguration.php
+++ b/src/Service/Geocoding/OverpassTagConfiguration.php
@@ -25,8 +25,7 @@ final class OverpassTagConfiguration
 {
     /**
      * Default Overpass tag filters considered for POI categorisation.
-     *
-     * @var array<string,list<string>>
+     * Represented as a map of tag keys to lists of allowed values.
      */
     private const array DEFAULT_ALLOWED_COMBINATIONS = [
         ['tourism' => ['attraction', 'viewpoint', 'museum', 'gallery']],
@@ -37,12 +36,12 @@ final class OverpassTagConfiguration
     ];
 
     /**
-     * @var list<array<string,list<string>>>
+     * @var list<array<string,list<string>>> $allowedTagCombinations
      */
     private array $allowedTagCombinations;
 
     /**
-     * @var array<string,list<string>>
+     * @var array<string,list<string>> $allowedTagMap
      */
     private array $allowedTagMap;
 

--- a/src/Service/Geocoding/OverpassTagSelector.php
+++ b/src/Service/Geocoding/OverpassTagSelector.php
@@ -35,8 +35,7 @@ final class OverpassTagSelector implements OverpassTagSelectorInterface
 {
     /**
      * Additional tags that are preserved even if they are not a category key.
-     *
-     * @var list<string>
+     * Represented as a list of tag names.
      */
     private const array AUXILIARY_TAG_KEYS = [
         'wikidata',

--- a/src/Service/Indexing/DefaultMediaFileLocator.php
+++ b/src/Service/Indexing/DefaultMediaFileLocator.php
@@ -26,12 +26,12 @@ use const PATHINFO_EXTENSION;
 final class DefaultMediaFileLocator implements MediaFileLocatorInterface
 {
     /**
-     * @var list<string>
+     * @var list<string> $imageExtensions
      */
     private readonly array $imageExtensions;
 
     /**
-     * @var list<string>
+     * @var list<string> $videoExtensions
      */
     private readonly array $videoExtensions;
 

--- a/src/Service/Indexing/DefaultMediaIngestionPipeline.php
+++ b/src/Service/Indexing/DefaultMediaIngestionPipeline.php
@@ -27,7 +27,7 @@ use function iterator_to_array;
 final readonly class DefaultMediaIngestionPipeline implements MediaIngestionPipelineInterface
 {
     /**
-     * @var list<MediaIngestionStageInterface>
+     * @var list<MediaIngestionStageInterface> $stages
      */
     private array $stages;
 

--- a/src/Service/Indexing/Stage/BurstLiveStage.php
+++ b/src/Service/Indexing/Stage/BurstLiveStage.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class BurstLiveStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/ContentKindStage.php
+++ b/src/Service/Indexing/Stage/ContentKindStage.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class ContentKindStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/FacesStage.php
+++ b/src/Service/Indexing/Stage/FacesStage.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class FacesStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/GeoStage.php
+++ b/src/Service/Indexing/Stage/GeoStage.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class GeoStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/HashStage.php
+++ b/src/Service/Indexing/Stage/HashStage.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class HashStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/MetadataStage.php
+++ b/src/Service/Indexing/Stage/MetadataStage.php
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class MetadataStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/MimeDetectionStage.php
+++ b/src/Service/Indexing/Stage/MimeDetectionStage.php
@@ -33,12 +33,12 @@ use const PATHINFO_EXTENSION;
 final readonly class MimeDetectionStage implements MediaIngestionStageInterface
 {
     /**
-     * @var list<string>
+     * @var list<string> $imageExtensions
      */
     private array $imageExtensions;
 
     /**
-     * @var list<string>
+     * @var list<string> $videoExtensions
      */
     private array $videoExtensions;
 

--- a/src/Service/Indexing/Stage/QualityStage.php
+++ b/src/Service/Indexing/Stage/QualityStage.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class QualityStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/SceneStage.php
+++ b/src/Service/Indexing/Stage/SceneStage.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class SceneStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Indexing/Stage/TimeStage.php
+++ b/src/Service/Indexing/Stage/TimeStage.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class TimeStage extends AbstractExtractorStage
 {
     /**
-     * @var iterable<SingleMetadataExtractorInterface>
+     * @var iterable<SingleMetadataExtractorInterface> $extractors
      */
     private readonly iterable $extractors;
 

--- a/src/Service/Metadata/CompositeMetadataExtractor.php
+++ b/src/Service/Metadata/CompositeMetadataExtractor.php
@@ -20,8 +20,8 @@ use MagicSunday\Memories\Entity\Media;
 final readonly class CompositeMetadataExtractor implements MetadataExtractorInterface
 {
     /**
-     * @var SingleMetadataExtractorInterface[] Prioritised extractor list executed in order of
-     *                                        likelihood/cost to build up the composite metadata set.
+     * @var list<SingleMetadataExtractorInterface> $extractors Prioritised extractor list executed in order of
+     *                                                         likelihood/cost to build up the composite metadata set.
      */
     private array $extractors;
 

--- a/src/Service/Metadata/ContentClassifierExtractor.php
+++ b/src/Service/Metadata/ContentClassifierExtractor.php
@@ -34,7 +34,7 @@ use function strtolower;
  */
 final class ContentClassifierExtractor implements SingleMetadataExtractorInterface
 {
-    /** @var array<int, string> */
+    /** Keywords associated with screenshot detection. */
     private const array SCREENSHOT_KEYWORDS = [
         'screenshot',
         'screen-shot',
@@ -45,7 +45,7 @@ final class ContentClassifierExtractor implements SingleMetadataExtractorInterfa
         'bildschirmaufnahme',
     ];
 
-    /** @var array<int, string> */
+    /** Keywords indicating document-style media. */
     private const array DOCUMENT_KEYWORDS = [
         'document',
         'scan',
@@ -59,7 +59,7 @@ final class ContentClassifierExtractor implements SingleMetadataExtractorInterfa
         'certificate',
     ];
 
-    /** @var array<int, string> */
+    /** Keywords used to recognise map-related media. */
     private const array MAP_KEYWORDS = [
         'map',
         'maps',
@@ -71,7 +71,7 @@ final class ContentClassifierExtractor implements SingleMetadataExtractorInterfa
         'osm',
     ];
 
-    /** @var array<int, string> */
+    /** Keywords marking screen recordings. */
     private const array SCREEN_RECORD_KEYWORDS = [
         'screenrecord',
         'screen-record',

--- a/src/Service/Metadata/MetadataFeatureVersion.php
+++ b/src/Service/Metadata/MetadataFeatureVersion.php
@@ -19,7 +19,7 @@ final class MetadataFeatureVersion
     public const int PIPELINE_VERSION = 1;
 
     /**
-     * @var array<string, int>
+     * Version identifiers per metadata extraction module.
      */
     public const array MODULE_VERSIONS = [
         'core' => 1,

--- a/src/Service/Metadata/Support/MediaFormatGuesser.php
+++ b/src/Service/Metadata/Support/MediaFormatGuesser.php
@@ -20,16 +20,16 @@ use function trim;
  */
 final class MediaFormatGuesser
 {
-    /** @var list<string> */
+    /** Raw file extensions used for detection. */
     private const array RAW_EXTENSIONS = ['cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng'];
 
-    /** @var list<string> */
+    /** HEIC-related file extensions. */
     private const array HEIC_EXTENSIONS = ['heic', 'heif', 'hif'];
 
-    /** @var list<string> */
+    /** HEVC-related file extensions. */
     private const array HEVC_EXTENSIONS = ['hevc', 'h265'];
 
-    /** @var list<string> */
+    /** MIME types considered RAW. */
     private const array RAW_MIME_TYPES = [
         'image/x-canon-cr2',
         'image/x-canon-cr3',
@@ -41,7 +41,7 @@ final class MediaFormatGuesser
         'image/dng',
     ];
 
-    /** @var list<string> */
+    /** MIME types representing HEIC media. */
     private const array HEIC_MIME_TYPES = [
         'image/heic',
         'image/heif',
@@ -49,19 +49,19 @@ final class MediaFormatGuesser
         'image/heif-sequence',
     ];
 
-    /** @var list<string> */
+    /** MIME types representing HEVC video. */
     private const array HEVC_MIME_TYPES = [
         'video/hevc',
         'video/h265',
     ];
 
-    /** @var list<string> */
+    /** File type identifiers used to detect RAW media. */
     private const array RAW_FILE_TYPES = ['cr2', 'cr3', 'nef', 'arw', 'rw2', 'raf', 'dng', 'raw'];
 
-    /** @var list<string> */
+    /** File type identifiers used to detect HEIC media. */
     private const array HEIC_FILE_TYPES = ['heic', 'heif'];
 
-    /** @var list<string> */
+    /** File type identifiers used to detect HEVC media. */
     private const array HEVC_FILE_TYPES = ['hevc', 'h265'];
 
     public static function isRawFromExtension(?string $extension): bool

--- a/src/Service/Slideshow/SlideshowVideoGenerator.php
+++ b/src/Service/Slideshow/SlideshowVideoGenerator.php
@@ -30,7 +30,9 @@ use function trim;
  */
 final class SlideshowVideoGenerator implements SlideshowVideoGeneratorInterface
 {
-    /** @var list<string> */
+    /**
+     * Default list of transition names used when no custom set is provided.
+     */
     private const array DEFAULT_TRANSITIONS = [
         'fade',
         'wipeleft',

--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -42,7 +42,7 @@ class ThumbnailService implements ThumbnailServiceInterface
     private readonly string $thumbnailDir;
 
     /**
-     * @var int[] List of thumbnail widths that should be generated.
+     * @var list<int> $sizes List of thumbnail widths that should be generated.
      */
     private readonly array $sizes;
 

--- a/src/Support/ClusterEntityToDraftMapper.php
+++ b/src/Support/ClusterEntityToDraftMapper.php
@@ -31,14 +31,12 @@ final class ClusterEntityToDraftMapper
      * Lookup table that maps the configured clustering algorithm to a logical
      * group name used by the UI.
      *
-     * @var array<string, string>
+     * @var array<string, string> $algorithmGroups
      */
     private array $algorithmGroups = [];
 
     /**
      * Provides the fallback group name when no explicit mapping exists.
-     *
-     * @var string
      */
     private string $defaultAlgorithmGroup;
 

--- a/src/Utility/DefaultPoiContextAnalyzer.php
+++ b/src/Utility/DefaultPoiContextAnalyzer.php
@@ -102,14 +102,7 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
             }
         );
 
-        /** @var array{
-         *     name:?string,
-         *     names:array{default:?string,localized:array<string,string>,alternates:list<string>},
-         *     categoryKey:?string,
-         *     categoryValue:?string,
-         *     tags:array<string,string>
-         * } $best
-         */
+        /** @var array{name:?string,names:array{default:?string,localized:array<string,string>,alternates:list<string>},categoryKey:?string,categoryValue:?string,tags:array<string,string>} $best */
         return $candidates[0]['data'];
     }
 

--- a/src/Utility/DefaultPoiLabelResolver.php
+++ b/src/Utility/DefaultPoiLabelResolver.php
@@ -28,7 +28,7 @@ use function trim;
 final class DefaultPoiLabelResolver implements PoiLabelResolverInterface
 {
     /**
-     * @var list<string>
+     * @var list<string> $preferredLocaleKeys
      */
     private array $preferredLocaleKeys;
 

--- a/src/Utility/DefaultPoiScorer.php
+++ b/src/Utility/DefaultPoiScorer.php
@@ -31,8 +31,6 @@ final class DefaultPoiScorer implements PoiScoringStrategyInterface
 
     /**
      * Tag specific weightings favouring more significant POIs.
-     *
-     * @var array<string,int>
      */
     private const array POI_TAG_WEIGHTS = [
         'tourism'  => 600,
@@ -47,8 +45,6 @@ final class DefaultPoiScorer implements PoiScoringStrategyInterface
 
     /**
      * Category key bonuses stacked on top of the tag weights.
-     *
-     * @var array<string,int>
      */
     private const array POI_CATEGORY_KEY_BONUS = [
         'tourism'  => 220,
@@ -62,8 +58,6 @@ final class DefaultPoiScorer implements PoiScoringStrategyInterface
 
     /**
      * Additional bonuses for specific tag/value combinations.
-     *
-     * @var array<string,int>
      */
     private const array POI_TAG_VALUE_BONUS = [
         'man_made:tower' => 260,

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -135,7 +135,7 @@ abstract class TestCase extends BaseTestCase
     ): Media {
         $factory = (static fn (string $mediaPath, string $mediaChecksum, int $mediaSize): Media => new class($mediaPath, $mediaChecksum, $mediaSize, $personIds) extends Media implements PersonTaggedMediaInterface {
             /**
-             * @var list<int>
+             * @var list<int> $personIds
              */
             private readonly array $personIds;
 

--- a/test/Unit/Command/IndexCommandTest.php
+++ b/test/Unit/Command/IndexCommandTest.php
@@ -33,7 +33,7 @@ use function unlink;
 final class IndexCommandTest extends TestCase
 {
     /**
-     * @var list<string>
+     * @var list<string> $tempDirs
      */
     private array $tempDirs = [];
 

--- a/test/Unit/Service/Clusterer/SmartTitleGeneratorTest.php
+++ b/test/Unit/Service/Clusterer/SmartTitleGeneratorTest.php
@@ -31,7 +31,7 @@ use function unlink;
 #[CoversClass(ClusterDraft::class)]
 final class SmartTitleGeneratorTest extends TestCase
 {
-    /** @var list<string> */
+    /** @var list<string> $tempFiles */
     private array $tempFiles = [];
 
     protected function tearDown(): void

--- a/test/Unit/Service/Feed/HtmlFeedExportServiceTest.php
+++ b/test/Unit/Service/Feed/HtmlFeedExportServiceTest.php
@@ -45,7 +45,7 @@ use function unlink;
 final class HtmlFeedExportServiceTest extends TestCase
 {
     /**
-     * @var list<string>
+     * @var list<string> $tempDirs
      */
     private array $tempDirs = [];
 

--- a/test/Unit/Service/Geocoding/DefaultMediaGeocodingProcessorTest.php
+++ b/test/Unit/Service/Geocoding/DefaultMediaGeocodingProcessorTest.php
@@ -40,7 +40,7 @@ final class DefaultMediaGeocodingProcessorTest extends TestCase
         $linker = new class($location, $mediaA, $mediaB) implements MediaLocationLinkerInterface {
             private int $invocations = 0;
 
-            /** @var list<int> */
+            /** @var list<int> $networkCalls */
             private array $networkCalls = [1, 0];
 
             public function __construct(

--- a/test/Unit/Service/Geocoding/DefaultPoiUpdateProcessorTest.php
+++ b/test/Unit/Service/Geocoding/DefaultPoiUpdateProcessorTest.php
@@ -34,7 +34,7 @@ final class DefaultPoiUpdateProcessorTest extends TestCase
         $resolver = new class($locationA, $locationB) implements PoiEnsurerInterface {
             private int $calls = 0;
 
-            /** @var list<bool> */
+            /** @var list<bool> $network */
             private array $network = [true, false];
 
             public function __construct(

--- a/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
+++ b/test/Unit/Service/Geocoding/LocationPoiEnricherTest.php
@@ -343,7 +343,7 @@ final class LocationPoiEnricherTest extends TestCase
 final class FakeHttpClient implements HttpClientInterface
 {
     /**
-     * @var list<FakeHttpResponse>
+     * @var list<FakeHttpResponse> $responses
      */
     private array $responses;
 

--- a/test/Unit/Service/Indexing/DefaultMediaFileLocatorTest.php
+++ b/test/Unit/Service/Indexing/DefaultMediaFileLocatorTest.php
@@ -33,7 +33,7 @@ use function unlink;
 final class DefaultMediaFileLocatorTest extends TestCase
 {
     /**
-     * @var list<string>
+     * @var list<string> $tempDirs
      */
     private array $tempDirs = [];
 

--- a/test/Unit/Service/Indexing/DefaultMediaIngestionPipelineTest.php
+++ b/test/Unit/Service/Indexing/DefaultMediaIngestionPipelineTest.php
@@ -58,7 +58,7 @@ use function unlink;
 final class DefaultMediaIngestionPipelineTest extends TestCase
 {
     /**
-     * @var list<string>
+     * @var list<string> $tempFiles
      */
     private array $tempFiles = [];
 

--- a/test/Unit/Service/Indexing/Stage/MimeDetectionStageTest.php
+++ b/test/Unit/Service/Indexing/Stage/MimeDetectionStageTest.php
@@ -26,7 +26,7 @@ use function unlink;
 
 final class MimeDetectionStageTest extends TestCase
 {
-    /** @var list<string> */
+    /** @var list<string> $tempFiles */
     private array $tempFiles = [];
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary
- remove redundant `@var` annotations where type declarations already specify the information
- add explicit variable names to docblocks that provide more specific typing details across services and entities
- align unit test fixtures with the updated docblock conventions

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b9d20948323a601f7b2dd144155