### PR TITLE
Fix cluster pipeline closures and restore vision extractor arguments

### DIFF
--- a/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
+++ b/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
@@ -59,7 +59,7 @@ final class AnnotationPruningStage implements ClusterConsolidationStageInterface
 
         /** @var list<list<int>> $normalized */
         $normalized = array_map(
-            static fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
+            fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
             $drafts,
         );
 

--- a/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
+++ b/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
@@ -75,7 +75,7 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
 
         /** @var list<list<int>> $normalized */
         $normalized = array_map(
-            static fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
+            fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
             $drafts,
         );
 

--- a/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
+++ b/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
@@ -66,7 +66,7 @@ final class DuplicateCollapseStage implements ClusterConsolidationStageInterface
 
         /** @var list<list<int>> $normalized */
         $normalized = array_map(
-            static fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
+            fn (ClusterDraft $draft): array => $this->normalizeMembers($draft->getMembers()),
             $drafts,
         );
 

--- a/src/Service/Metadata/VisionSignatureExtractor.php
+++ b/src/Service/Metadata/VisionSignatureExtractor.php
@@ -50,9 +50,9 @@ final readonly class VisionSignatureExtractor implements SingleMetadataExtractor
     public function __construct(
         private MediaQualityAggregator $qualityAggregator,
         private int                    $sampleSize = 96, // square downsample for analysis
-        private float                  $posterFrameSecond = 1.0,
         string                         $ffmpegBinary = 'ffmpeg',
         string                         $ffprobeBinary = 'ffprobe',
+        private float                  $posterFrameSecond = 1.0,
     ) {
         if ($this->sampleSize < 16) {
             throw new InvalidArgumentException('sampleSize must be >= 16');

--- a/src/Service/Thumbnail/ThumbnailService.php
+++ b/src/Service/Thumbnail/ThumbnailService.php
@@ -58,14 +58,23 @@ class ThumbnailService implements ThumbnailServiceInterface
      */
     public function __construct(string $thumbnailDir, array $sizes = [320, 1024], bool $applyOrientation = false)
     {
-        $this->thumbnailDir = $thumbnailDir;
-        $this->sizes        = $sizes;
+        $this->thumbnailDir     = $thumbnailDir;
+        $this->sizes            = $sizes;
         $this->applyOrientation = $applyOrientation;
 
         // Ensure the output directory exists before thumbnails are generated.
-        if (!is_dir($this->thumbnailDir) && !mkdir($this->thumbnailDir, 0755, true) && !is_dir($this->thumbnailDir)) {
-            throw new RuntimeException(
-                \sprintf('Failed to create thumbnail directory "%s".', $this->thumbnailDir));
+        if (!is_dir($this->thumbnailDir)) {
+            if (\file_exists($this->thumbnailDir)) {
+                throw new RuntimeException(
+                    \sprintf('Failed to create thumbnail directory "%s".', $this->thumbnailDir),
+                );
+            }
+
+            if (!mkdir($this->thumbnailDir, 0755, true) && !is_dir($this->thumbnailDir)) {
+                throw new RuntimeException(
+                    \sprintf('Failed to create thumbnail directory "%s".', $this->thumbnailDir),
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- allow pipeline stage closures to access instance helpers without static binding
- restore the VisionSignatureExtractor constructor signature expected by tests and configuration
- guard thumbnail directory creation to raise clean errors without filesystem warnings

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68e28e9cf35483238a5a2d2ad325f288