### PR TITLE
Fix type guard for majority locality key

### DIFF
--- a/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
+++ b/src/Clusterer/WeekendGetawaysOverYearsClusterStrategy.php
@@ -415,6 +415,6 @@ final readonly class WeekendGetawaysOverYearsClusterStrategy implements ClusterS
 
         $firstKey = array_key_first($counts);
 
-        return $firstKey instanceof string ? $firstKey : null;
+        return is_string($firstKey) ? $firstKey : null;
     }
 }


### PR DESCRIPTION
## Summary
- replace the invalid `instanceof` check in `WeekendGetawaysOverYearsClusterStrategy` with `is_string` so the return type matches the signature

## Testing
- composer ci:test *(fails: `bin/php` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e291429dd48323991cc112a91c9b2f