### PR TITLE
Handle Imagick API changes in thumbnail service

### DIFF
--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -1560,12 +1560,12 @@ final class ThumbnailServiceTest extends TestCase
             $row = [];
 
             for ($x = 0; $x < $width; ++$x) {
-                $color = $imagick->getImagePixelColor($x, $y)->getColor(true);
+                $pixel = $imagick->getImagePixelColor($x, $y);
 
                 $row[] = $this->rgbToHex(
-                    (int) round($color['r'] * 255),
-                    (int) round($color['g'] * 255),
-                    (int) round($color['b'] * 255),
+                    (int) round($pixel->getColorValue(Imagick::COLOR_RED) * 255),
+                    (int) round($pixel->getColorValue(Imagick::COLOR_GREEN) * 255),
+                    (int) round($pixel->getColorValue(Imagick::COLOR_BLUE) * 255),
                 );
             }
 


### PR DESCRIPTION
## Summary
- broaden Imagick failure handling so GD fallback works even when write operations return false while still enforcing the HEIC requirement
- clean up Imagick clones safely and destroy handles, avoiding double clear calls for required-imagick flows
- adjust the thumbnail layout helper in the unit test suite to use channel getters compatible with Imagick 3.7+

## Testing
- vendor/bin/phpunit -c .build/phpunit.xml --filter ThumbnailServiceTest
- vendor/bin/phpunit -c .build/phpunit.xml --filter PerceptualHashExtractorTest
- vendor/bin/phpunit -c .build/phpunit.xml --filter VisionSignatureExtractorTest
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e290d01dc88323a20f4fa701c60314