### PR TITLE
Use array_fill_keys for boolean maps

### DIFF
--- a/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
+++ b/src/Service/Clusterer/Pipeline/AnnotationPruningStage.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Service\Clusterer\Pipeline;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidationStageInterface;
 
+use function array_fill_keys;
 use function array_map;
 use function count;
 
@@ -35,9 +36,7 @@ final class AnnotationPruningStage implements ClusterConsolidationStageInterface
         private readonly array $annotateOnly,
         private readonly array $minUniqueShare,
     ) {
-        foreach ($annotateOnly as $algorithm) {
-            $this->annotateOnlySet[$algorithm] = true;
-        }
+        $this->annotateOnlySet = array_fill_keys($annotateOnly, true);
     }
 
     public function getLabel(): string

--- a/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
+++ b/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Service\Clusterer\Contract\ClusterConsolidationStageInterface;
 
+use function array_fill_keys;
 use function array_keys;
 use function array_map;
 use function count;
@@ -90,10 +91,7 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
         /** @var list<string> $order */
         $order = $this->keepOrder;
         /** @var array<string,bool> $seen */
-        $seen = [];
-        foreach ($order as $algorithm) {
-            $seen[$algorithm] = true;
-        }
+        $seen = array_fill_keys($order, true);
 
         foreach (array_keys($byAlgorithm) as $algorithm) {
             if (isset($seen[$algorithm])) {


### PR DESCRIPTION
## Summary
- replace manual boolean map initialization with array_fill_keys in clusterer pipeline stages to simplify boolean map setup

## Testing
- composer ci:test *(fails: bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2935cd41083239909f83440bbf6f3