### PR TITLE
Mark immutable classes as readonly

### DIFF
--- a/src/Clusterer/DaySummaryStage/GpsMetricsStage.php
+++ b/src/Clusterer/DaySummaryStage/GpsMetricsStage.php
@@ -27,7 +27,7 @@ use function usort;
 /**
  * Computes GPS-based metrics for day summaries.
  */
-final class GpsMetricsStage implements DaySummaryStageInterface
+final readonly class GpsMetricsStage implements DaySummaryStageInterface
 {
     use MediaFilterTrait;
 

--- a/src/Clusterer/DefaultHomeLocator.php
+++ b/src/Clusterer/DefaultHomeLocator.php
@@ -30,7 +30,7 @@ use function strtolower;
 /**
  * Default implementation that derives the home location from timestamped media.
  */
-final class DefaultHomeLocator implements HomeLocatorInterface
+final readonly class DefaultHomeLocator implements HomeLocatorInterface
 {
     private const int NIGHT_START_HOUR = 22;
 

--- a/src/Clusterer/Service/TimezoneResolver.php
+++ b/src/Clusterer/Service/TimezoneResolver.php
@@ -23,7 +23,7 @@ use function is_string;
 /**
  * Default timezone resolver used by the vacation clustering pipeline.
  */
-final class TimezoneResolver implements TimezoneResolverInterface
+final readonly class TimezoneResolver implements TimezoneResolverInterface
 {
     use VacationTimezoneTrait {
         resolveMediaTimezone as private traitResolveMediaTimezone;

--- a/src/Clusterer/Support/ClusterQualityAggregator.php
+++ b/src/Clusterer/Support/ClusterQualityAggregator.php
@@ -20,7 +20,7 @@ use function min;
 /**
  * Aggregates per-media quality metrics for cluster level annotations.
  */
-final class ClusterQualityAggregator
+final readonly class ClusterQualityAggregator
 {
     public function __construct(private readonly float $qualityBaselineMegapixels = 12.0)
     {

--- a/src/Command/ClusterCommand.php
+++ b/src/Command/ClusterCommand.php
@@ -33,7 +33,7 @@ use function sprintf;
     name: 'memories:cluster',
     description: 'Erstellt Erinnerungs-Cluster anhand konfigurierter Strategien.'
 )]
-final class ClusterCommand extends Command
+final readonly class ClusterCommand extends Command
 {
     public function __construct(private readonly ClusterJobRunnerInterface $runner)
     {

--- a/src/Command/FeedExportHtmlCommand.php
+++ b/src/Command/FeedExportHtmlCommand.php
@@ -35,7 +35,7 @@ use function sprintf;
     name: 'memories:feed:export-html',
     description: 'Erzeugt eine HTML-Vorschau des Rückblick-Feeds (statisch, mit Lazy-Loading).'
 )]
-final class FeedExportHtmlCommand extends Command
+final readonly class FeedExportHtmlCommand extends Command
 {
     public function __construct(
         private readonly FeedExportServiceInterface $exportService,

--- a/src/Command/FeedPreviewCommand.php
+++ b/src/Command/FeedPreviewCommand.php
@@ -42,7 +42,7 @@ use function sprintf;
     name: 'memories:feed:preview',
     description: 'Zeigt eine Vorschau des Rückblick-Feeds.'
 )]
-final class FeedPreviewCommand extends Command
+final readonly class FeedPreviewCommand extends Command
 {
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -30,7 +30,7 @@ use function trim;
     name: 'memories:geocode',
     description: 'Orte aus GPS-Daten ermitteln und speichern'
 )]
-final class GeocodeCommand extends Command
+final readonly class GeocodeCommand extends Command
 {
     public function __construct(
         private readonly DefaultGeocodingWorkflow $workflow,

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -43,7 +43,7 @@ use function sprintf;
     name: 'memories:index',
     description: 'Indexiert Medien: Metadaten extrahieren und in DB speichern. Thumbnails optional mit --thumbnails.'
 )]
-final class IndexCommand extends Command
+final readonly class IndexCommand extends Command
 {
     public function __construct(
         private readonly MediaFileLocatorInterface $locator,

--- a/src/Command/SlideshowGenerateCommand.php
+++ b/src/Command/SlideshowGenerateCommand.php
@@ -34,7 +34,7 @@ use const LOCK_EX;
  * Console command that executes slideshow generation jobs.
  */
 #[AsCommand(name: 'slideshow:generate', description: 'Erstellt ein Slideshow-Video für die angegebene Job-Datei.')]
-final class SlideshowGenerateCommand extends Command
+final readonly class SlideshowGenerateCommand extends Command
 {
     public function __construct(private readonly SlideshowVideoGeneratorInterface $generator)
     {

--- a/src/Service/Clusterer/Scoring/PoiClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/PoiClusterScoreHeuristic.php
@@ -19,7 +19,7 @@ use function is_numeric;
 /**
  * Class PoiClusterScoreHeuristic
  */
-final class PoiClusterScoreHeuristic extends AbstractClusterScoreHeuristic
+final readonly class PoiClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
     /** @param array<string,float> $poiCategoryBoosts */
     public function __construct(private readonly array $poiCategoryBoosts = [])

--- a/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
@@ -17,7 +17,7 @@ use MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator;
 /**
  * Class QualityClusterScoreHeuristic
  */
-final class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
+final readonly class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
     public function __construct(private readonly ClusterQualityAggregator $qualityAggregator)
     {

--- a/src/Service/Feed/HtmlFeedExportService.php
+++ b/src/Service/Feed/HtmlFeedExportService.php
@@ -42,7 +42,7 @@ use function usort;
 /**
  * Class HtmlFeedExportService
  */
-final class HtmlFeedExportService implements FeedExportServiceInterface
+final readonly class HtmlFeedExportService implements FeedExportServiceInterface
 {
     private const string FEED_TITLE = 'Rückblick – Für dich';
 

--- a/src/Service/Geocoding/OverpassTagSelector.php
+++ b/src/Service/Geocoding/OverpassTagSelector.php
@@ -32,7 +32,7 @@ use const SORT_STRING;
 /**
  * Class OverpassTagSelector
  */
-final class OverpassTagSelector implements OverpassTagSelectorInterface
+final readonly class OverpassTagSelector implements OverpassTagSelectorInterface
 {
     /**
      * Additional tags that are preserved even if they are not a category key.

--- a/src/Service/Indexing/DefaultMediaFileLocator.php
+++ b/src/Service/Indexing/DefaultMediaFileLocator.php
@@ -23,7 +23,7 @@ use const PATHINFO_EXTENSION;
 /**
  * Default implementation locating image and video files by extension.
  */
-final class DefaultMediaFileLocator implements MediaFileLocatorInterface
+final readonly class DefaultMediaFileLocator implements MediaFileLocatorInterface
 {
     /**
      * @var list<string> $imageExtensions

--- a/src/Service/Indexing/Stage/BurstLiveStage.php
+++ b/src/Service/Indexing/Stage/BurstLiveStage.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class BurstLiveStage
  */
-final class BurstLiveStage extends AbstractExtractorStage
+final readonly class BurstLiveStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/ContentKindStage.php
+++ b/src/Service/Indexing/Stage/ContentKindStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class ContentKindStage
  */
-final class ContentKindStage extends AbstractExtractorStage
+final readonly class ContentKindStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/FacesStage.php
+++ b/src/Service/Indexing/Stage/FacesStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class FacesStage
  */
-final class FacesStage extends AbstractExtractorStage
+final readonly class FacesStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/GeoStage.php
+++ b/src/Service/Indexing/Stage/GeoStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class GeoStage
  */
-final class GeoStage extends AbstractExtractorStage
+final readonly class GeoStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/HashStage.php
+++ b/src/Service/Indexing/Stage/HashStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class HashStage
  */
-final class HashStage extends AbstractExtractorStage
+final readonly class HashStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/MetadataStage.php
+++ b/src/Service/Indexing/Stage/MetadataStage.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class MetadataStage
  */
-final class MetadataStage extends AbstractExtractorStage
+final readonly class MetadataStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/QualityStage.php
+++ b/src/Service/Indexing/Stage/QualityStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class QualityStage
  */
-final class QualityStage extends AbstractExtractorStage
+final readonly class QualityStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/SceneStage.php
+++ b/src/Service/Indexing/Stage/SceneStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class SceneStage
  */
-final class SceneStage extends AbstractExtractorStage
+final readonly class SceneStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/TimeStage.php
+++ b/src/Service/Indexing/Stage/TimeStage.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class TimeStage
  */
-final class TimeStage extends AbstractExtractorStage
+final readonly class TimeStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Slideshow/SlideshowVideoGenerator.php
+++ b/src/Service/Slideshow/SlideshowVideoGenerator.php
@@ -28,7 +28,7 @@ use function trim;
 /**
  * FFmpeg based slideshow generator.
  */
-final class SlideshowVideoGenerator implements SlideshowVideoGeneratorInterface
+final readonly class SlideshowVideoGenerator implements SlideshowVideoGeneratorInterface
 {
     /**
      * Default list of transition names used when no custom set is provided.

--- a/src/Service/Slideshow/SlideshowVideoStatus.php
+++ b/src/Service/Slideshow/SlideshowVideoStatus.php
@@ -16,7 +16,7 @@ use function round;
 /**
  * Value object describing the current slideshow video state.
  */
-final class SlideshowVideoStatus
+final readonly class SlideshowVideoStatus
 {
     public const string STATUS_READY = 'bereit';
 


### PR DESCRIPTION
## Summary
- mark console commands and slideshow services with the readonly class modifier where only readonly dependencies are held
- apply readonly to cluster scoring helpers and geocoding utilities that already use readonly properties
- tighten indexing pipeline stages and feed export helpers by making the classes readonly for immutability guarantees

## Testing
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e293349a7883238c88e210cf62c8f9