### PR TITLE
Refactor filtering loops to array_filter

### DIFF
--- a/src/Http/Controller/FeedController.php
+++ b/src/Http/Controller/FeedController.php
@@ -35,6 +35,9 @@ use MagicSunday\Memories\Entity\Media;
 use RuntimeException;
 
 use function array_filter;
+use function array_fill_keys;
+use function array_flip;
+use function array_intersect_key;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
@@ -348,13 +351,17 @@ final class FeedController
             }
         }
 
-        $result = [];
-        foreach ($ids as $id) {
-            $media = $this->mediaCache[$id] ?? null;
-            if ($media instanceof Media) {
-                $result[$id] = $media;
-            }
-        }
+        /** @var array<int, Media|null> $orderedCache */
+        $orderedCache = array_replace(
+            array_fill_keys($ids, null),
+            array_intersect_key($this->mediaCache, array_flip($ids)),
+        );
+
+        /** @var array<int, Media> $result */
+        $result = array_filter(
+            $orderedCache,
+            static fn (?Media $media): bool => $media instanceof Media,
+        );
 
         return $result;
     }

--- a/src/Service/Clusterer/Scoring/AbstractClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/AbstractClusterScoreHeuristic.php
@@ -15,6 +15,9 @@ use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Entity\Media;
 
 use function abs;
+use function array_filter;
+use function array_map;
+use function array_values;
 use function is_numeric;
 use function is_string;
 use function log;
@@ -35,13 +38,17 @@ abstract class AbstractClusterScoreHeuristic implements ClusterScoreHeuristicInt
      */
     protected function collectMediaItems(ClusterDraft $cluster, array $mediaMap): array
     {
-        $items = [];
-        foreach ($cluster->getMembers() as $id) {
-            $media = $mediaMap[$id] ?? null;
-            if ($media instanceof Media) {
-                $items[] = $media;
-            }
-        }
+        /** @var list<Media|null> $mapped */
+        $mapped = array_map(
+            static fn (int $id): ?Media => $mediaMap[$id] ?? null,
+            $cluster->getMembers(),
+        );
+
+        /** @var list<Media> $items */
+        $items = array_values(array_filter(
+            $mapped,
+            static fn (?Media $media): bool => $media instanceof Media,
+        ));
 
         return $items;
     }

--- a/src/Service/Feed/DefaultCoverPicker.php
+++ b/src/Service/Feed/DefaultCoverPicker.php
@@ -14,6 +14,9 @@ namespace MagicSunday\Memories\Service\Feed;
 use MagicSunday\Memories\Entity\Media;
 
 use function abs;
+use function array_filter;
+use function array_map;
+use function array_values;
 use function count;
 use function floor;
 use function max;
@@ -39,13 +42,17 @@ final class DefaultCoverPicker implements CoverPickerInterface
         }
 
         // Median timestamp (for temporal proximity)
-        $ts = [];
-        foreach ($members as $m) {
-            $t = $m->getTakenAt()?->getTimestamp() ?? null;
-            if ($t !== null) {
-                $ts[] = $t;
-            }
-        }
+        /** @var list<int|null> $timestamps */
+        $timestamps = array_map(
+            static fn (Media $media): ?int => $media->getTakenAt()?->getTimestamp(),
+            $members,
+        );
+
+        /** @var list<int> $ts */
+        $ts = array_values(array_filter(
+            $timestamps,
+            static fn (?int $timestamp): bool => $timestamp !== null,
+        ));
 
         sort($ts, SORT_NUMERIC);
         $medianTs = $ts !== [] ? $ts[(int) floor(count($ts) / 2)] : null;

--- a/src/Service/Feed/HtmlFeedExportService.php
+++ b/src/Service/Feed/HtmlFeedExportService.php
@@ -21,7 +21,10 @@ use MagicSunday\Memories\Support\ClusterEntityToDraftMapper;
 use RuntimeException;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function array_filter;
+use function array_map;
 use function array_slice;
+use function array_values;
 use function basename;
 use function copy;
 use function count;
@@ -93,18 +96,20 @@ final class HtmlFeedExportService implements FeedExportServiceInterface
             $items = array_slice($items, 0, $request->getMaxItems());
         }
 
-        $cards             = [];
         $copiedFileCount   = 0;
         $skippedThumbCount = 0;
 
-        foreach ($items as $item) {
-            $cardData = $this->createCard($item, $request, $imageDirectory, $copiedFileCount, $skippedThumbCount);
-            if ($cardData === null) {
-                continue;
-            }
+        /** @var list<array<string, mixed>|null> $cardCandidates */
+        $cardCandidates = array_map(
+            fn (MemoryFeedItem $item): ?array => $this->createCard($item, $request, $imageDirectory, $copiedFileCount, $skippedThumbCount),
+            $items,
+        );
 
-            $cards[] = $cardData;
-        }
+        /** @var list<array<string, mixed>> $cards */
+        $cards = array_values(array_filter(
+            $cardCandidates,
+            static fn (?array $cardData): bool => $cardData !== null,
+        ));
 
         if ($cards === []) {
             $io->warning('Keine Bilder für die HTML-Ausgabe gefunden.');


### PR DESCRIPTION
## Summary
- refactor media collection in AbstractClusterScoreHeuristic to use array_filter and array_map
- streamline timestamp extraction in DefaultCoverPicker with array_filter
- replace manual filtering in FeedController and HtmlFeedExportService with array_filter preserving ordering

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29368f9988323b380527718b0d6c9