### PR TITLE
Refactor loops to array_map

### DIFF
--- a/src/Http/Response/Response.php
+++ b/src/Http/Response/Response.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Http\Response;
 
+use function array_map;
 use function explode;
 use function header;
 use function http_response_code;
@@ -105,10 +106,10 @@ class Response
 
     private function normalizeHeaderName(string $name): string
     {
-        $parts = explode('-', $name);
-        foreach ($parts as $index => $part) {
-            $parts[$index] = strtoupper($part[0]) . strtolower(substr($part, 1));
-        }
+        $parts = array_map(
+            static fn (string $part): string => strtoupper($part[0]) . strtolower(substr($part, 1)),
+            explode('-', $name),
+        );
 
         return implode('-', $parts);
     }

--- a/src/Service/Slideshow/SlideshowVideoGenerator.php
+++ b/src/Service/Slideshow/SlideshowVideoGenerator.php
@@ -15,6 +15,8 @@ use RuntimeException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
+use function array_keys;
+use function array_map;
 use function array_merge;
 use function count;
 use function dirname;
@@ -160,9 +162,8 @@ final class SlideshowVideoGenerator implements SlideshowVideoGeneratorInterface
             ]);
         }
 
-        $filters = [];
-        foreach ($images as $index => $image) {
-            $filters[] = sprintf(
+        $filters = array_map(
+            fn (int $index): string => sprintf(
                 '[%1$d:v]scale=%2$d:%3$d:force_original_aspect_ratio=decrease,' .
                 'pad=%2$d:%3$d:(ow-iw)/2:(oh-ih)/2:black,format=yuv420p,setsar=1,' .
                 'trim=duration=%4$.3f,setpts=PTS-STARTPTS[s%1$d]',
@@ -170,8 +171,9 @@ final class SlideshowVideoGenerator implements SlideshowVideoGeneratorInterface
                 $this->width,
                 $this->height,
                 $durationWithOverlap
-            );
-        }
+            ),
+            array_keys($images),
+        );
 
         $transitionCount = count($this->transitions);
         $current = '[s0]';

--- a/src/Support/ClusterEntityToDraftMapper.php
+++ b/src/Support/ClusterEntityToDraftMapper.php
@@ -14,6 +14,7 @@ namespace MagicSunday\Memories\Support;
 use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Entity\Cluster;
 
+use function array_map;
 use function array_unique;
 use function array_values;
 use function is_string;
@@ -76,43 +77,40 @@ final class ClusterEntityToDraftMapper
      */
     public function mapMany(array $entities): array
     {
-        $out = [];
-        foreach ($entities as $e) {
-            $algorithm = $e->getAlgorithm();
-            $params    = $e->getParams() ?? [];
+        return array_map(function (Cluster $entity): ClusterDraft {
+            $algorithm = $entity->getAlgorithm();
+            $params    = $entity->getParams() ?? [];
 
             // Ensure every cluster is assigned to a group even if the entity did not persist one.
             if (!isset($params['group']) || !is_string($params['group']) || $params['group'] === '') {
                 $params['group'] = $this->resolveGroup($algorithm);
             }
-            $centroid  = $e->getCentroid();
-            $members   = $this->normalizeMembers($e->getMembers());
+
+            $members = $this->normalizeMembers($entity->getMembers());
 
             // Create a fresh draft object to avoid mutating the persisted entity state.
             $draft = new ClusterDraft(
                 algorithm: $algorithm,
                 params: $params,
-                centroid: $centroid,
+                centroid: $entity->getCentroid(),
                 members: $members
             );
 
-            $draft->setStartAt($e->getStartAt());
-            $draft->setEndAt($e->getEndAt());
-            $draft->setMembersCount($e->getMembersCount());
-            $draft->setPhotoCount($e->getPhotoCount());
-            $draft->setVideoCount($e->getVideoCount());
-            $draft->setCoverMediaId($e->getCover()?->getId());
-            $draft->setLocation($e->getLocation());
-            $draft->setAlgorithmVersion($e->getAlgorithmVersion());
-            $draft->setConfigHash($e->getConfigHash());
-            $draft->setCentroidLat($e->getCentroidLat());
-            $draft->setCentroidLon($e->getCentroidLon());
-            $draft->setCentroidCell7($e->getCentroidCell7());
+            $draft->setStartAt($entity->getStartAt());
+            $draft->setEndAt($entity->getEndAt());
+            $draft->setMembersCount($entity->getMembersCount());
+            $draft->setPhotoCount($entity->getPhotoCount());
+            $draft->setVideoCount($entity->getVideoCount());
+            $draft->setCoverMediaId($entity->getCover()?->getId());
+            $draft->setLocation($entity->getLocation());
+            $draft->setAlgorithmVersion($entity->getAlgorithmVersion());
+            $draft->setConfigHash($entity->getConfigHash());
+            $draft->setCentroidLat($entity->getCentroidLat());
+            $draft->setCentroidLon($entity->getCentroidLon());
+            $draft->setCentroidCell7($entity->getCentroidCell7());
 
-            $out[] = $draft;
-        }
-
-        return $out;
+            return $draft;
+        }, $entities);
     }
 
     /**


### PR DESCRIPTION
## Summary
- refactor cluster draft mapping to use `array_map`
- build slideshow filter list with `array_map`
- simplify HTTP header normalization via `array_map`

## Testing
- composer ci:test *(fails: bin/php: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29373595083239ba7b01a1e205423