### PR TITLE
Refactor search loops to array_find

### DIFF
--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -23,6 +23,7 @@ use MagicSunday\Memories\Service\Feed\CoverPickerInterface;
 use MagicSunday\Memories\Utility\GeoCell;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
+use function array_find;
 use function array_is_list;
 use function array_keys;
 use function array_key_exists;
@@ -438,14 +439,17 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
             $params['version'] ?? null,
         ];
 
-        foreach ($candidates as $candidate) {
-            if (is_string($candidate) && $candidate !== '') {
-                return $candidate;
-            }
+        $candidate = array_find(
+            $candidates,
+            static fn ($value): bool => (is_string($value) && $value !== '') || is_int($value)
+        );
 
-            if (is_int($candidate)) {
-                return (string) $candidate;
-            }
+        if (is_string($candidate)) {
+            return $candidate;
+        }
+
+        if (is_int($candidate)) {
+            return (string) $candidate;
         }
 
         return null;

--- a/src/Service/Geocoding/PoiNameExtractor.php
+++ b/src/Service/Geocoding/PoiNameExtractor.php
@@ -13,6 +13,8 @@ namespace MagicSunday\Memories\Service\Geocoding;
 
 use MagicSunday\Memories\Service\Geocoding\Contract\PoiNameExtractorInterface;
 
+use function array_find;
+
 /**
  * Class PoiNameExtractor
  */
@@ -25,16 +27,20 @@ final class PoiNameExtractor implements PoiNameExtractorInterface
             return $default;
         }
 
-        foreach ($names['localized'] as $name) {
-            if ($name !== '') {
-                return $name;
-            }
+        $localized = array_find(
+            $names['localized'],
+            static fn ($name): bool => $name !== ''
+        );
+        if ($localized !== null) {
+            return $localized;
         }
 
-        foreach ($names['alternates'] as $alternate) {
-            if ($alternate !== '') {
-                return $alternate;
-            }
+        $alternate = array_find(
+            $names['alternates'],
+            static fn ($alternate): bool => $alternate !== ''
+        );
+        if ($alternate !== null) {
+            return $alternate;
         }
 
         return null;

--- a/src/Utility/DefaultPoiNormalizer.php
+++ b/src/Utility/DefaultPoiNormalizer.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Utility;
 
 use MagicSunday\Memories\Utility\Contract\PoiNormalizerInterface;
 
+use function array_find;
 use function array_keys;
 use function is_array;
 use function is_string;
@@ -142,16 +143,20 @@ final class DefaultPoiNormalizer implements PoiNormalizerInterface
             return $default;
         }
 
-        foreach ($names['localized'] as $value) {
-            if (is_string($value) && $value !== '') {
-                return $value;
-            }
+        $localized = array_find(
+            $names['localized'],
+            static fn ($value): bool => is_string($value) && $value !== ''
+        );
+        if (is_string($localized)) {
+            return $localized;
         }
 
-        foreach ($names['alternates'] as $alternate) {
-            if (is_string($alternate) && $alternate !== '') {
-                return $alternate;
-            }
+        $alternate = array_find(
+            $names['alternates'],
+            static fn ($value): bool => is_string($value) && $value !== ''
+        );
+        if (is_string($alternate)) {
+            return $alternate;
         }
 
         return null;


### PR DESCRIPTION
## Summary
- replace POI label, normalization, and name extraction foreach searches with array_find() to leverage PHP 8.4 utilities
- simplify algorithm version detection in cluster persistence by using array_find()

## Testing
- composer ci:test *(fails: `bin/php` executable is missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2938ba51c8323ad92155890bf7a6c