### PR TITLE
Remove redundant readonly property modifiers in readonly classes

### DIFF
--- a/src/Repository/ClusterRepository.php
+++ b/src/Repository/ClusterRepository.php
@@ -21,7 +21,7 @@ use function max;
  */
 readonly class ClusterRepository
 {
-    public function __construct(private readonly EntityManagerInterface $em)
+    public function __construct(private EntityManagerInterface $em)
     {
     }
 

--- a/src/Repository/MediaDuplicateRepository.php
+++ b/src/Repository/MediaDuplicateRepository.php
@@ -24,7 +24,7 @@ use function strcmp;
  */
 readonly class MediaDuplicateRepository
 {
-    public function __construct(private readonly EntityManagerInterface $entityManager)
+    public function __construct(private EntityManagerInterface $entityManager)
     {
     }
 

--- a/src/Service/Clusterer/Pipeline/PipelineClusterConsolidator.php
+++ b/src/Service/Clusterer/Pipeline/PipelineClusterConsolidator.php
@@ -23,7 +23,7 @@ final readonly class PipelineClusterConsolidator implements ClusterConsolidatorI
     /**
      * @param iterable<ClusterConsolidationStageInterface> $stages
      */
-    public function __construct(private readonly iterable $stages)
+    public function __construct(private iterable $stages)
     {
     }
 

--- a/src/Service/Clusterer/SmartTitleGenerator.php
+++ b/src/Service/Clusterer/SmartTitleGenerator.php
@@ -29,7 +29,7 @@ use function trim;
  */
 final readonly class SmartTitleGenerator implements TitleGeneratorInterface
 {
-    public function __construct(private readonly TitleTemplateProvider $provider)
+    public function __construct(private TitleTemplateProvider $provider)
     {
     }
 

--- a/src/Service/Geocoding/OverpassPrimaryTagResolver.php
+++ b/src/Service/Geocoding/OverpassPrimaryTagResolver.php
@@ -21,7 +21,7 @@ use function is_string;
  */
 final readonly class OverpassPrimaryTagResolver implements OverpassPrimaryTagResolverInterface
 {
-    public function __construct(private readonly OverpassTagConfiguration $configuration)
+    public function __construct(private OverpassTagConfiguration $configuration)
     {
     }
 

--- a/src/Service/Metadata/BurstDetector.php
+++ b/src/Service/Metadata/BurstDetector.php
@@ -33,7 +33,7 @@ use function usort;
  */
 final readonly class BurstDetector implements SingleMetadataExtractorInterface
 {
-    public function __construct(private readonly MediaRepository $mediaRepository)
+    public function __construct(private MediaRepository $mediaRepository)
     {
     }
 

--- a/src/Service/Metadata/DaypartEnricher.php
+++ b/src/Service/Metadata/DaypartEnricher.php
@@ -20,7 +20,7 @@ use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
  */
 final readonly class DaypartEnricher implements SingleMetadataExtractorInterface
 {
-    public function __construct(private readonly CaptureTimeResolver $captureTimeResolver)
+    public function __construct(private CaptureTimeResolver $captureTimeResolver)
     {
     }
 

--- a/src/Service/Metadata/LivePairLinker.php
+++ b/src/Service/Metadata/LivePairLinker.php
@@ -29,7 +29,7 @@ use function usort;
  */
 final readonly class LivePairLinker implements SingleMetadataExtractorInterface
 {
-    public function __construct(private readonly MediaRepository $mediaRepository)
+    public function __construct(private MediaRepository $mediaRepository)
     {
     }
 

--- a/test/Integration/Service/Geocoding/OverpassClientTest.php
+++ b/test/Integration/Service/Geocoding/OverpassClientTest.php
@@ -95,7 +95,7 @@ final class RecordingHttpClient implements HttpClientInterface
 {
     public string $lastQuery = '';
 
-    public function __construct(private readonly ResponseInterface $response)
+    public function __construct(private ResponseInterface $response)
     {
     }
 


### PR DESCRIPTION
## Summary
- remove redundant property-level readonly modifiers from readonly classes to rely on implicit readonly semantics

## Testing
- composer ci:test *(fails: phpstan analyze reports pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e293b422c48323afa4064e313e92d0