### PR TITLE
Remove redundant boolean guards in scene tagging

### DIFF
--- a/src/Service/Metadata/HeuristicClipSceneTagModel.php
+++ b/src/Service/Metadata/HeuristicClipSceneTagModel.php
@@ -157,12 +157,12 @@ final class HeuristicClipSceneTagModel implements VisionSceneTagModelInterface
         }
 
         $isHoliday = $features['isHoliday'] ?? null;
-        if (is_bool($isHoliday) && $isHoliday === true) {
+        if ($isHoliday === true) {
             $this->bump($scores, 'Feiertag', 0.55);
         }
 
         $isWeekend = $features['isWeekend'] ?? null;
-        if (is_bool($isWeekend) && $isWeekend === true) {
+        if ($isWeekend === true) {
             $this->bump($scores, 'Wochenende', 0.52);
         }
     }


### PR DESCRIPTION
## Summary
- remove redundant boolean guard clauses in `HeuristicClipSceneTagModel` for holiday and weekend scoring

## Testing
- composer ci:test *(fails: phpstan reports pre-existing analyse errors about docblock-driven types)*

------
https://chatgpt.com/codex/tasks/task_e_68e293f535a88323a8d806a4a7a36bf8