### PR TITLE
REFACTOR: remove redundant float casts

### DIFF
--- a/src/Clusterer/CrossDimensionClusterStrategy.php
+++ b/src/Clusterer/CrossDimensionClusterStrategy.php
@@ -18,6 +18,8 @@ use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 
+use function assert;
+
 use function count;
 use function usort;
 
@@ -109,11 +111,15 @@ final readonly class CrossDimensionClusterStrategy implements ClusterStrategyInt
 
             $ok = true;
             foreach ($gps as $m) {
+                $lat = $m->getGpsLat();
+                $lon = $m->getGpsLon();
+                assert($lat !== null && $lon !== null);
+
                 $dist = MediaMath::haversineDistanceInMeters(
                     $centroid['lat'],
                     $centroid['lon'],
-                    (float) $m->getGpsLat(),
-                    (float) $m->getGpsLon()
+                    $lat,
+                    $lon
                 );
 
                 if ($dist > $this->radiusMeters) {
@@ -145,7 +151,7 @@ final readonly class CrossDimensionClusterStrategy implements ClusterStrategyInt
             $out[] = new ClusterDraft(
                 algorithm: 'cross_dimension',
                 params: $params,
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
+                centroid: ['lat' => $centroid['lat'], 'lon' => $centroid['lon']],
                 members: $this->toMemberIds($run)
             );
         }

--- a/src/Clusterer/DaySummaryStage/GpsMetricsStage.php
+++ b/src/Clusterer/DaySummaryStage/GpsMetricsStage.php
@@ -83,11 +83,15 @@ final class GpsMetricsStage implements DaySummaryStageInterface
                     assert($lat !== null && $lon !== null && $takenAt instanceof DateTimeImmutable);
 
                     if ($previous instanceof Media) {
+                        $prevLat = $previous->getGpsLat();
+                        $prevLon = $previous->getGpsLon();
+                        assert($prevLat !== null && $prevLon !== null);
+
                         $travelKm += MediaMath::haversineDistanceInMeters(
-                            (float) $previous->getGpsLat(),
-                            (float) $previous->getGpsLon(),
-                            (float) $lat,
-                            (float) $lon,
+                            $prevLat,
+                            $prevLon,
+                            $lat,
+                            $lon,
                         ) / 1000.0;
                     }
 
@@ -98,11 +102,15 @@ final class GpsMetricsStage implements DaySummaryStageInterface
 
                 $centroid = MediaMath::centroid($gpsMembers);
                 foreach ($gpsMembers as $gpsMedia) {
+                    $gpsLat = $gpsMedia->getGpsLat();
+                    $gpsLon = $gpsMedia->getGpsLon();
+                    assert($gpsLat !== null && $gpsLon !== null);
+
                     $distance = MediaMath::haversineDistanceInMeters(
-                        (float) $gpsMedia->getGpsLat(),
-                        (float) $gpsMedia->getGpsLon(),
-                        (float) $centroid['lat'],
-                        (float) $centroid['lon'],
+                        $gpsLat,
+                        $gpsLon,
+                        $centroid['lat'],
+                        $centroid['lon'],
                     ) / 1000.0;
 
                     $summary['distanceSum']   += $distance;

--- a/src/Clusterer/DefaultHomeLocator.php
+++ b/src/Clusterer/DefaultHomeLocator.php
@@ -19,6 +19,7 @@ use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 
+use function assert;
 use function count;
 use function intdiv;
 use function is_array;
@@ -181,11 +182,15 @@ final class DefaultHomeLocator implements HomeLocatorInterface
 
         $maxDistance = 0.0;
         foreach ($members as $media) {
+            $lat = $media->getGpsLat();
+            $lon = $media->getGpsLon();
+            assert($lat !== null && $lon !== null);
+
             $distance = MediaMath::haversineDistanceInMeters(
-                (float) $media->getGpsLat(),
-                (float) $media->getGpsLon(),
-                (float) $centroid['lat'],
-                (float) $centroid['lon'],
+                $lat,
+                $lon,
+                $centroid['lat'],
+                $centroid['lon'],
             ) / 1000.0;
 
             if ($distance > $maxDistance) {
@@ -218,8 +223,8 @@ final class DefaultHomeLocator implements HomeLocatorInterface
         }
 
         return [
-            'lat'             => (float) $centroid['lat'],
-            'lon'             => (float) $centroid['lon'],
+            'lat'             => $centroid['lat'],
+            'lon'             => $centroid['lon'],
             'radius_km'       => max($maxDistance, $this->defaultHomeRadiusKm),
             'country'         => $country,
             'timezone_offset' => $timezoneOffset,

--- a/src/Clusterer/FirstVisitPlaceClusterStrategy.php
+++ b/src/Clusterer/FirstVisitPlaceClusterStrategy.php
@@ -18,6 +18,8 @@ use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
+
+use function assert;
 use MagicSunday\Memories\Utility\MediaMath;
 
 use function array_keys;
@@ -99,8 +101,9 @@ final readonly class FirstVisitPlaceClusterStrategy implements ClusterStrategyIn
         foreach ($timestampedGps as $m) {
             $t = $m->getTakenAt();
             assert($t instanceof DateTimeImmutable);
-            $lat   = (float) $m->getGpsLat();
-            $lon   = (float) $m->getGpsLon();
+            $lat   = $m->getGpsLat();
+            $lon   = $m->getGpsLon();
+            assert($lat !== null && $lon !== null);
             $local = $t->setTimezone($tz);
             $day   = $local->format('Y-m-d');
             $cell  = $this->cellKey($lat, $lon);

--- a/src/Clusterer/LocationSimilarityStrategy.php
+++ b/src/Clusterer/LocationSimilarityStrategy.php
@@ -190,6 +190,10 @@ final readonly class LocationSimilarityStrategy implements ClusterStrategyInterf
             $start  = null;
 
             foreach ($group as $media) {
+                if ($media->getGpsLat() === null || $media->getGpsLon() === null) {
+                    continue;
+                }
+
                 $ts = $media->getTakenAt()?->getTimestamp() ?? 0;
 
                 if ($bucket === []) {
@@ -198,12 +202,21 @@ final readonly class LocationSimilarityStrategy implements ClusterStrategyInterf
                     continue;
                 }
 
-                $anchor = $bucket[0];
-                $dist   = MediaMath::haversineDistanceInMeters(
-                    (float) $anchor->getGpsLat(),
-                    (float) $anchor->getGpsLon(),
-                    (float) $media->getGpsLat(),
-                    (float) $media->getGpsLon()
+                $anchor    = $bucket[0];
+                $anchorLat = $anchor->getGpsLat();
+                $anchorLon = $anchor->getGpsLon();
+                $mediaLat  = $media->getGpsLat();
+                $mediaLon  = $media->getGpsLon();
+
+                if ($anchorLat === null || $anchorLon === null || $mediaLat === null || $mediaLon === null) {
+                    continue;
+                }
+
+                $dist = MediaMath::haversineDistanceInMeters(
+                    $anchorLat,
+                    $anchorLon,
+                    $mediaLat,
+                    $mediaLon
                 );
                 $spanOk = !($start !== null) || ($ts - $start) <= $this->maxSpanHours * 3600;
 

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -19,6 +19,8 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
 
+use function assert;
+
 use function array_map;
 use function array_values;
 use function assert;
@@ -121,11 +123,15 @@ final readonly class NightlifeEventClusterStrategy implements ClusterStrategyInt
 
             $ok = true;
             foreach ($gps as $m) {
+                $lat = $m->getGpsLat();
+                $lon = $m->getGpsLon();
+                assert($lat !== null && $lon !== null);
+
                 $dist = MediaMath::haversineDistanceInMeters(
                     $centroid['lat'],
                     $centroid['lon'],
-                    (float) $m->getGpsLat(),
-                    (float) $m->getGpsLon()
+                    $lat,
+                    $lon
                 );
 
                 if ($dist > $this->radiusMeters) {
@@ -178,7 +184,7 @@ final readonly class NightlifeEventClusterStrategy implements ClusterStrategyInt
             $out[] = new ClusterDraft(
                 algorithm: 'nightlife_event',
                 params: $params,
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
+                centroid: ['lat' => $centroid['lat'], 'lon' => $centroid['lon']],
                 members: array_map(static fn (Media $m): int => $m->getId(), $run)
             );
         }

--- a/src/Clusterer/Service/BaseLocationResolver.php
+++ b/src/Clusterer/Service/BaseLocationResolver.php
@@ -17,6 +17,7 @@ use MagicSunday\Memories\Clusterer\Contract\BaseLocationResolverInterface;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\MediaMath;
 
+use function assert;
 use function max;
 use function usort;
 
@@ -182,9 +183,13 @@ final class BaseLocationResolver implements BaseLocationResolverInterface
 
     private function mediaCoordinates(Media $media): array
     {
+        $lat = $media->getGpsLat();
+        $lon = $media->getGpsLon();
+        assert($lat !== null && $lon !== null);
+
         return [
-            'lat' => (float) $media->getGpsLat(),
-            'lon' => (float) $media->getGpsLon(),
+            'lat' => $lat,
+            'lon' => $lon,
         ];
     }
 
@@ -215,9 +220,9 @@ final class BaseLocationResolver implements BaseLocationResolverInterface
         $centroid = MediaMath::centroid($gpsMembers);
 
         return [
-            'lat'         => (float) $centroid['lat'],
-            'lon'         => (float) $centroid['lon'],
-            'distance_km' => $this->distanceToHomeKm((float) $centroid['lat'], (float) $centroid['lon'], $home),
+            'lat'         => $centroid['lat'],
+            'lon'         => $centroid['lon'],
+            'distance_km' => $this->distanceToHomeKm($centroid['lat'], $centroid['lon'], $home),
             'source'      => 'day_centroid',
         ];
     }

--- a/src/Clusterer/Service/StaypointDetector.php
+++ b/src/Clusterer/Service/StaypointDetector.php
@@ -16,6 +16,7 @@ use MagicSunday\Memories\Clusterer\Contract\StaypointDetectorInterface;
 use MagicSunday\Memories\Utility\MediaMath;
 
 use function array_slice;
+use function assert;
 use function count;
 
 /**
@@ -52,11 +53,17 @@ final class StaypointDetector implements StaypointDetectorInterface
                     continue;
                 }
 
+                $startLat = $startMedia->getGpsLat();
+                $startLon = $startMedia->getGpsLon();
+                $candLat  = $candidate->getGpsLat();
+                $candLon  = $candidate->getGpsLon();
+                assert($startLat !== null && $startLon !== null && $candLat !== null && $candLon !== null);
+
                 $distanceKm = MediaMath::haversineDistanceInMeters(
-                    (float) $startMedia->getGpsLat(),
-                    (float) $startMedia->getGpsLon(),
-                    (float) $candidate->getGpsLat(),
-                    (float) $candidate->getGpsLon(),
+                    $startLat,
+                    $startLon,
+                    $candLat,
+                    $candLon,
                 ) / 1000.0;
 
                 if ($distanceKm > 0.2) {
@@ -86,8 +93,8 @@ final class StaypointDetector implements StaypointDetectorInterface
                 $centroid = MediaMath::centroid($segment);
 
                 $staypoints[] = [
-                    'lat'   => (float) $centroid['lat'],
-                    'lon'   => (float) $centroid['lon'],
+                    'lat'   => $centroid['lat'],
+                    'lon'   => $centroid['lon'],
                     'start' => $startTime->getTimestamp(),
                     'end'   => $endTime->getTimestamp(),
                     'dwell' => $dwell,

--- a/src/Clusterer/Service/VacationScoreCalculator.php
+++ b/src/Clusterer/Service/VacationScoreCalculator.php
@@ -191,8 +191,8 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
         $centroidDistanceKm = MediaMath::haversineDistanceInMeters(
             $home['lat'],
             $home['lon'],
-            (float) $centroid['lat'],
-            (float) $centroid['lon'],
+            $centroid['lat'],
+            $centroid['lon'],
         ) / 1000.0;
 
         $countries = [];

--- a/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
+++ b/src/Clusterer/Support/AbstractAtHomeClusterStrategy.php
@@ -153,7 +153,7 @@ abstract class AbstractAtHomeClusterStrategy implements ClusterStrategyInterface
                     continue;
                 }
 
-                $distanceKm = $this->distanceKmFromHome($media, (float) $lat, (float) $lon);
+                $distanceKm = $this->distanceKmFromHome($media, $lat, $lon);
 
                 if ($distanceKm <= $this->homeRadiusMeters / 1000.0) {
                     $within[] = $media;

--- a/src/Clusterer/Support/GeoDbscanHelper.php
+++ b/src/Clusterer/Support/GeoDbscanHelper.php
@@ -49,8 +49,8 @@ final class GeoDbscanHelper
             }
 
             $points[] = [
-                'lat'   => (float) $lat,
-                'lon'   => (float) $lon,
+                'lat'   => $lat,
+                'lon'   => $lon,
                 'media' => $media,
             ];
         }

--- a/src/Clusterer/Support/MediaFilterTrait.php
+++ b/src/Clusterer/Support/MediaFilterTrait.php
@@ -197,7 +197,7 @@ trait MediaFilterTrait
                 return $items;
             }
 
-            $coordinates[] = [(float) $lat, (float) $lon];
+            $coordinates[] = [$lat, $lon];
         }
 
         $count        = count($coordinates);

--- a/src/Clusterer/TransitTravelDayClusterStrategy.php
+++ b/src/Clusterer/TransitTravelDayClusterStrategy.php
@@ -90,13 +90,22 @@ final readonly class TransitTravelDayClusterStrategy implements ClusterStrategyI
 
                 $distKm = 0.0;
                 for ($i = 1, $n = count($sorted); $i < $n; ++$i) {
-                    $p = $sorted[$i - 1];
-                    $q = $sorted[$i];
+                    $p    = $sorted[$i - 1];
+                    $q    = $sorted[$i];
+                    $pLat = $p->getGpsLat();
+                    $pLon = $p->getGpsLon();
+                    $qLat = $q->getGpsLat();
+                    $qLon = $q->getGpsLon();
+
+                    if ($pLat === null || $pLon === null || $qLat === null || $qLon === null) {
+                        continue;
+                    }
+
                     $distKm += MediaMath::haversineDistanceInMeters(
-                        (float) $p->getGpsLat(),
-                        (float) $p->getGpsLon(),
-                        (float) $q->getGpsLat(),
-                        (float) $q->getGpsLon()
+                        $pLat,
+                        $pLon,
+                        $qLat,
+                        $qLon
                     ) / 1000.0;
                 }
 
@@ -129,7 +138,7 @@ final readonly class TransitTravelDayClusterStrategy implements ClusterStrategyI
             $out[] = new ClusterDraft(
                 algorithm: $this->name(),
                 params: $params,
-                centroid: ['lat' => (float) $centroid['lat'], 'lon' => (float) $centroid['lon']],
+                centroid: ['lat' => $centroid['lat'], 'lon' => $centroid['lon']],
                 members: array_map(static fn (Media $m): int => $m->getId(), $list)
             );
         }

--- a/src/Service/Clusterer/Scoring/LocationClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/LocationClusterScoreHeuristic.php
@@ -77,7 +77,7 @@ final class LocationClusterScoreHeuristic extends AbstractClusterScoreHeuristic
                 continue;
             }
 
-            $coords[] = [(float) $lat, (float) $lon];
+            $coords[] = [$lat, $lon];
         }
 
         $withGeo  = count($coords);

--- a/src/Service/Clusterer/Scoring/NoveltyHeuristic.php
+++ b/src/Service/Clusterer/Scoring/NoveltyHeuristic.php
@@ -131,7 +131,8 @@ final class NoveltyHeuristic extends AbstractClusterScoreHeuristic
             $lat = $m->getGpsLat();
             $lon = $m->getGpsLon();
             if ($lat !== null && $lon !== null) {
-                $grid[$this->gridCell((float) $lat, (float) $lon)] = ($grid[$this->gridCell((float) $lat, (float) $lon)] ?? 0) + 1;
+                $cell = $this->gridCell($lat, $lon);
+                $grid[$cell] = ($grid[$cell] ?? 0) + 1;
             }
 
             // day-of-year (only if time present)

--- a/src/Service/Metadata/GeoFeatureEnricher.php
+++ b/src/Service/Metadata/GeoFeatureEnricher.php
@@ -15,6 +15,7 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\GeoHash;
 use MagicSunday\Memories\Utility\MediaMath;
 
+use function assert;
 use function floor;
 use function hash;
 use function sprintf;
@@ -47,8 +48,9 @@ final readonly class GeoFeatureEnricher implements SingleMetadataExtractorInterf
             || $media->getGeoCell8() === null
             || $media->getDistanceKmFromHome() === null;
 
-        $lat = (float) $media->getGpsLat();
-        $lon = (float) $media->getGpsLon();
+        $lat = $media->getGpsLat();
+        $lon = $media->getGpsLon();
+        assert($lat !== null && $lon !== null);
 
         if ($shouldUpdateHomeMetrics) {
             $cell = $this->cellKey($lat, $lon, $this->cellDegrees);

--- a/src/Service/Metadata/SolarEnricher.php
+++ b/src/Service/Metadata/SolarEnricher.php
@@ -17,6 +17,7 @@ use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
 
 use function acos;
 use function asin;
+use function assert;
 use function cos;
 use function deg2rad;
 use function floor;
@@ -54,8 +55,9 @@ final readonly class SolarEnricher implements SingleMetadataExtractorInterface
             return $media;
         }
 
-        $lat = (float) $media->getGpsLat();
-        $lon = (float) $media->getGpsLon();
+        $lat = $media->getGpsLat();
+        $lon = $media->getGpsLon();
+        assert($lat !== null && $lon !== null);
 
         $sunUtc = $this->sunTimesUtc($local, $lat, $lon);
         if ($sunUtc === null) {


### PR DESCRIPTION
## Summary
- remove redundant float casts in metadata enrichers and assert required GPS coordinates before using them
- simplify clustering strategies and helpers by skipping items without coordinates and relying on native float values for distance calculations

## Testing
- `composer ci:test` *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e293ced9908323b1e8e0030d6e9818