### PR TITLE
Refactor for-loops to foreach where applicable

### DIFF
--- a/src/Clusterer/BurstClusterStrategy.php
+++ b/src/Clusterer/BurstClusterStrategy.php
@@ -182,9 +182,13 @@ final readonly class BurstClusterStrategy implements ClusterStrategyInterface
         /** @var list<Media> $current */
         $current = [$items[0]];
 
-        for ($i = 1; $i < $count; ++$i) {
-            $media = $items[$i];
-            $prev  = $items[$i - 1];
+        $previous = $items[0];
+        foreach ($items as $index => $media) {
+            if ($index === 0) {
+                continue;
+            }
+
+            $prev = $previous;
 
             $currTakenAt = $media->getTakenAt();
             $prevTakenAt = $prev->getTakenAt();
@@ -205,11 +209,14 @@ final readonly class BurstClusterStrategy implements ClusterStrategyInterface
 
             if ($timeOk && $distOk) {
                 $current[] = $media;
+                $previous  = $media;
                 continue;
             }
 
             $sessions[] = $current;
             $current    = [$media];
+            $previous   = $media;
+            continue;
         }
 
         if ($current !== []) {

--- a/src/Clusterer/DaySummaryStage/AwayFlagStage.php
+++ b/src/Clusterer/DaySummaryStage/AwayFlagStage.php
@@ -16,6 +16,7 @@ use MagicSunday\Memories\Clusterer\Contract\DaySummaryStageInterface;
 use MagicSunday\Memories\Clusterer\Contract\TimezoneResolverInterface;
 
 use function array_keys;
+use function array_slice;
 use function count;
 
 /**
@@ -102,13 +103,17 @@ final readonly class AwayFlagStage implements DaySummaryStageInterface
             return $flags;
         }
 
-        for ($i = 1; $i < $count - 1; ++$i) {
-            $prev = $flags[$keys[$i - 1]];
-            $curr = $flags[$keys[$i]];
-            $next = $flags[$keys[$i + 1]];
+        foreach ($keys as $index => $key) {
+            if ($index === 0 || $index === $count - 1) {
+                continue;
+            }
+
+            $prev = $flags[$keys[$index - 1]];
+            $curr = $flags[$key];
+            $next = $flags[$keys[$index + 1]];
 
             if ($curr === false && $prev === true && $next === true) {
-                $flags[$keys[$i]] = true;
+                $flags[$key] = true;
             }
         }
 
@@ -135,8 +140,8 @@ final readonly class AwayFlagStage implements DaySummaryStageInterface
         }
 
         if ($first !== null && $last !== null && $last > $first) {
-            for ($i = $first; $i <= $last; ++$i) {
-                $flags[$keys[$i]] = true;
+            foreach (array_slice($keys, $first, $last - $first + 1) as $key) {
+                $flags[$key] = true;
             }
         }
 
@@ -154,16 +159,15 @@ final readonly class AwayFlagStage implements DaySummaryStageInterface
     {
         $count = count($orderedKeys);
 
-        for ($i = 0; $i < $count; ++$i) {
-            $key     = $orderedKeys[$i];
+        foreach ($orderedKeys as $index => $key) {
             $summary = $days[$key];
 
             if ($summary['isSynthetic'] === false) {
                 continue;
             }
 
-            $prev = $i > 0 ? $flags[$orderedKeys[$i - 1]] : null;
-            $next = $i + 1 < $count ? $flags[$orderedKeys[$i + 1]] : null;
+            $prev = $index > 0 ? $flags[$orderedKeys[$index - 1]] : null;
+            $next = $index + 1 < $count ? $flags[$orderedKeys[$index + 1]] : null;
 
             if ($prev === true || $next === true) {
                 $flags[$key] = true;

--- a/src/Clusterer/PhashSimilarityStrategy.php
+++ b/src/Clusterer/PhashSimilarityStrategy.php
@@ -124,8 +124,8 @@ final readonly class PhashSimilarityStrategy implements ClusterStrategyInterface
         /** @var array<int,list<int>> $adj */
         $adj    = array_fill(0, $n, []);
         $hashes = [];
-        for ($i = 0; $i < $n; ++$i) {
-            $hashes[$i] = (string) $items[$i]->getPhash();
+        foreach ($items as $index => $item) {
+            $hashes[$index] = (string) $item->getPhash();
         }
 
         for ($i = 0; $i < $n; ++$i) {
@@ -139,14 +139,14 @@ final readonly class PhashSimilarityStrategy implements ClusterStrategyInterface
 
         $seen = array_fill(0, $n, false);
         $out  = [];
-        for ($i = 0; $i < $n; ++$i) {
-            if ($seen[$i]) {
+        foreach ($items as $index => $_item) {
+            if ($seen[$index]) {
                 continue;
             }
 
             // BFS
-            $queue    = [$i];
-            $seen[$i] = true;
+            $queue    = [$index];
+            $seen[$index] = true;
             $comp     = [];
             while ($queue !== []) {
                 $v = array_shift($queue);

--- a/src/Clusterer/Service/RunDetector.php
+++ b/src/Clusterer/Service/RunDetector.php
@@ -74,8 +74,7 @@ final class RunDetector implements VacationRunDetectorInterface
         }
 
         $countKeys = count($keys);
-        for ($i = 0; $i < $countKeys; ++$i) {
-            $key = $keys[$i];
+        foreach ($keys as $i => $key) {
             if ($isAwayCandidate[$key] ?? false) {
                 continue;
             }

--- a/src/Clusterer/Service/VacationScoreCalculator.php
+++ b/src/Clusterer/Service/VacationScoreCalculator.php
@@ -25,6 +25,7 @@ use MagicSunday\Memories\Utility\MediaMath;
 use function abs;
 use function array_keys;
 use function array_map;
+use function array_slice;
 use function count;
 use function explode;
 use function implode;
@@ -416,9 +417,8 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
                 $interleaved[] = $first;
             }
 
-            $queueCount = count($queue);
-            for ($index = 1; $index < $queueCount; ++$index) {
-                $media = $queue[$index];
+            $remaining = array_slice($queue, 1);
+            foreach ($remaining as $media) {
                 $takenAt = $media->getTakenAt();
                 $leftovers[] = [
                     'media' => $media,
@@ -515,10 +515,7 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
                 $winners[] = $winner;
             }
 
-            $entryCount = count($entries);
-            for ($i = 1; $i < $entryCount; ++$i) {
-                $fallback[] = $entries[$i];
-            }
+            $fallback = [...$fallback, ...array_slice($entries, 1)];
         }
 
         usort($winners, static function (array $a, array $b): int {

--- a/src/Clusterer/Support/GeoDbscanHelper.php
+++ b/src/Clusterer/Support/GeoDbscanHelper.php
@@ -65,13 +65,13 @@ final class GeoDbscanHelper
         $clusters    = [];
         $clusterId   = -1;
 
-        for ($i = 0; $i < $count; ++$i) {
-            if ($visited[$i] === true) {
+        foreach ($points as $index => $_point) {
+            if ($visited[$index] === true) {
                 continue;
             }
 
-            $visited[$i] = true;
-            $neighbors   = $this->regionQuery($points, $i, $epsKm);
+            $visited[$index] = true;
+            $neighbors       = $this->regionQuery($points, $index, $epsKm);
 
             if (count($neighbors) + 1 < $minSamples) {
                 continue;
@@ -82,7 +82,7 @@ final class GeoDbscanHelper
 
             $this->expandCluster(
                 $points,
-                $i,
+                $index,
                 $neighbors,
                 $clusterId,
                 $epsKm,
@@ -124,12 +124,11 @@ final class GeoDbscanHelper
         $count     = count($points);
         $origin    = $points[$pointIndex];
 
-        for ($i = 0; $i < $count; ++$i) {
-            if ($i === $pointIndex) {
+        foreach ($points as $index => $candidate) {
+            if ($index === $pointIndex) {
                 continue;
             }
 
-            $candidate = $points[$i];
             $distance  = MediaMath::haversineDistanceInMeters(
                 $origin['lat'],
                 $origin['lon'],
@@ -138,7 +137,7 @@ final class GeoDbscanHelper
             );
 
             if ($distance <= $epsKm * 1000.0) {
-                $neighbors[] = $i;
+                $neighbors[] = $index;
             }
         }
 

--- a/src/Clusterer/Support/MediaFilterTrait.php
+++ b/src/Clusterer/Support/MediaFilterTrait.php
@@ -219,19 +219,19 @@ trait MediaFilterTrait
             return $neighbors;
         };
 
-        for ($i = 0; $i < $count; ++$i) {
-            if ($labels[$i] !== null) {
+        foreach ($coordinates as $index => $_coordinate) {
+            if ($labels[$index] !== null) {
                 continue;
             }
 
-            $neighbors = $regionQuery($coordinates, $i, $radiusMeters);
+            $neighbors = $regionQuery($coordinates, $index, $radiusMeters);
             if (count($neighbors) < $minSamples) {
-                $labels[$i] = -1;
+                $labels[$index] = -1;
                 continue;
             }
 
-            $labels[$i] = $clusterId;
-            $queue      = $neighbors;
+            $labels[$index] = $clusterId;
+            $queue          = $neighbors;
             for ($queueIndex = 0; $queueIndex < count($queue); ++$queueIndex) {
                 $neighborIndex = $queue[$queueIndex];
 

--- a/src/Clusterer/TransitTravelDayClusterStrategy.php
+++ b/src/Clusterer/TransitTravelDayClusterStrategy.php
@@ -88,16 +88,27 @@ final readonly class TransitTravelDayClusterStrategy implements ClusterStrategyI
                 $sorted = $list;
                 usort($sorted, static fn (Media $a, Media $b): int => $a->getTakenAt() <=> $b->getTakenAt());
 
-                $distKm = 0.0;
-                for ($i = 1, $n = count($sorted); $i < $n; ++$i) {
-                    $p = $sorted[$i - 1];
-                    $q = $sorted[$i];
+                $distKm  = 0.0;
+                $previous = null;
+                foreach ($sorted as $index => $current) {
+                    if ($index === 0) {
+                        $previous = $current;
+                        continue;
+                    }
+
+                    if (!$previous instanceof Media) {
+                        $previous = $current;
+                        continue;
+                    }
+
                     $distKm += MediaMath::haversineDistanceInMeters(
-                        (float) $p->getGpsLat(),
-                        (float) $p->getGpsLon(),
-                        (float) $q->getGpsLat(),
-                        (float) $q->getGpsLon()
+                        (float) $previous->getGpsLat(),
+                        (float) $previous->getGpsLon(),
+                        (float) $current->getGpsLat(),
+                        (float) $current->getGpsLon()
                     ) / 1000.0;
+
+                    $previous = $current;
                 }
 
                 if ($distKm < $this->minTravelKm) {

--- a/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
+++ b/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
@@ -44,8 +44,8 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
         }
 
         $base = count($keepOrder);
-        for ($index = 0; $index < $base; ++$index) {
-            $this->priorityMap[$keepOrder[$index]] = $base - $index;
+        foreach ($keepOrder as $index => $algorithm) {
+            $this->priorityMap[$algorithm] = $base - $index;
         }
     }
 

--- a/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
+++ b/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
@@ -34,8 +34,8 @@ final class DuplicateCollapseStage implements ClusterConsolidationStageInterface
     public function __construct(private readonly array $keepOrder)
     {
         $base = count($keepOrder);
-        for ($index = 0; $index < $base; ++$index) {
-            $this->priorityMap[$keepOrder[$index]] = $base - $index;
+        foreach ($keepOrder as $index => $algorithm) {
+            $this->priorityMap[$algorithm] = $base - $index;
         }
     }
 

--- a/src/Service/Clusterer/Pipeline/PerMediaCapStage.php
+++ b/src/Service/Clusterer/Pipeline/PerMediaCapStage.php
@@ -38,8 +38,8 @@ final class PerMediaCapStage implements ClusterConsolidationStageInterface
         private readonly string $defaultAlgorithmGroup,
     ) {
         $base = count($keepOrder);
-        for ($index = 0; $index < $base; ++$index) {
-            $this->priorityMap[$keepOrder[$index]] = $base - $index;
+        foreach ($keepOrder as $index => $algorithm) {
+            $this->priorityMap[$algorithm] = $base - $index;
         }
     }
 

--- a/src/Service/Geocoding/DefaultMediaGeocodingProcessor.php
+++ b/src/Service/Geocoding/DefaultMediaGeocodingProcessor.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function count;
 use function is_array;
 use function iterator_to_array;
+use function range;
 use function spl_object_id;
 use function usleep;
 
@@ -70,7 +71,7 @@ final readonly class DefaultMediaGeocodingProcessor implements MediaGeocodingPro
                 $networkCalls += $networkCallsForMedia;
 
                 if ($this->delayMs > 0) {
-                    for ($i = 0; $i < $networkCallsForMedia; ++$i) {
+                    foreach (range(1, $networkCallsForMedia) as $_) {
                         usleep($this->delayMs * 1000);
                     }
                 }

--- a/src/Service/Metadata/Support/ImagickImageAdapter.php
+++ b/src/Service/Metadata/Support/ImagickImageAdapter.php
@@ -143,12 +143,10 @@ final readonly class ImagickImageAdapter implements ImageAdapterInterface
         unset($clone);
 
         // normalisieren auf ints 0..255
-        $out    = [];
-        $outLen = count($buf);
+        $out = [];
 
-        for ($i = 0; $i < $outLen; ++$i) {
-            $v     = $buf[$i];
-            $out[] = (int) (is_float($v) ? round($v) : $v);
+        foreach ($buf as $value) {
+            $out[] = (int) (is_float($value) ? round($value) : $value);
         }
 
         /** @var list<int> $out */

--- a/src/Service/Slideshow/SlideshowVideoGenerator.php
+++ b/src/Service/Slideshow/SlideshowVideoGenerator.php
@@ -176,16 +176,21 @@ final readonly class SlideshowVideoGenerator implements SlideshowVideoGeneratorI
         );
 
         $transitionCount = count($this->transitions);
-        $current = '[s0]';
-        $offset  = max(0.1, $this->slideDuration);
+        $current         = '[s0]';
+        $offset          = max(0.1, $this->slideDuration);
+        $imageCount      = count($images);
 
-        for ($index = 1; $index < count($images); $index++) {
+        foreach (array_keys($images) as $index) {
+            if ($index === 0) {
+                continue;
+            }
+
             $transition = $this->transitions[($index - 1) % $transitionCount] ?? 'fade';
             if ($transition === '') {
                 $transition = 'fade';
             }
 
-            $targetLabel = $index === count($images) - 1 ? '[vout]' : sprintf('[tmp%d]', $index);
+            $targetLabel = $index === $imageCount - 1 ? '[vout]' : sprintf('[tmp%d]', $index);
             $filters[] = sprintf(
                 '%s[s%d]xfade=transition=%s:duration=%0.3f:offset=%0.3f:shortest=1%s',
                 $current,


### PR DESCRIPTION
## Summary
- replace index-based `for` loops with `foreach` iterations across cluster strategies and helpers where index arithmetic was unnecessary
- update slideshow, geocoding, and metadata services to rely on `foreach` for clarity while preserving behaviour

## Testing
- composer ci:test *(fails: bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2960eb91483238d79f88c2239bcd2