### PR TITLE
Add missing parameter type declarations

### DIFF
--- a/src/Command/FeedPreviewCommand.php
+++ b/src/Command/FeedPreviewCommand.php
@@ -171,9 +171,9 @@ final readonly class FeedPreviewCommand extends Command
 }
 
     /**
-     * @param mixed $value
+     * @param array|bool|float|int|string|null $value
      */
-    private function formatSceneTags($value): string
+    private function formatSceneTags(array|bool|float|int|string|null $value): string
     {
         if (!is_array($value)) {
             return '–';

--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -510,9 +510,9 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
     }
 
     /**
-     * @param mixed $value
+     * @param array|bool|float|int|string|null $value
      */
-    private function numericOrNull($value): ?float
+    private function numericOrNull(array|bool|float|int|string|null $value): ?float
     {
         if ($value === null) {
             return null;
@@ -584,12 +584,12 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
     }
 
     /**
-     * @param mixed     $value
-     * @param list<int> $original
+     * @param array|bool|float|int|string|null $value
+     * @param list<int>                        $original
      *
      * @return list<int>|null
      */
-    private function extractOrderedList($value, array $original): ?array
+    private function extractOrderedList(array|bool|float|int|string|null $value, array $original): ?array
     {
         if (!is_array($value)) {
             return null;
@@ -628,12 +628,12 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
     }
 
     /**
-     * @param mixed     $raw
-     * @param list<int> $original
+     * @param array|bool|float|int|string|null $raw
+     * @param list<int>                        $original
      *
      * @return list<int>|null
      */
-    private function normaliseOrderList($raw, array $original): ?array
+    private function normaliseOrderList(array|bool|float|int|string|null $raw, array $original): ?array
     {
         if (!is_array($raw) || $raw === []) {
             return null;

--- a/src/Service/Feed/HtmlFeedExportService.php
+++ b/src/Service/Feed/HtmlFeedExportService.php
@@ -284,11 +284,11 @@ final readonly class HtmlFeedExportService implements FeedExportServiceInterface
     }
 
     /**
-     * @param mixed $value
+     * @param array|bool|float|int|string|null $value
      *
      * @return list<array{label: string, score: float}>
      */
-    private function normalizeSceneTags($value): array
+    private function normalizeSceneTags(array|bool|float|int|string|null $value): array
     {
         if (!is_array($value)) {
             return [];

--- a/src/Service/Metadata/XmpIptcExtractor.php
+++ b/src/Service/Metadata/XmpIptcExtractor.php
@@ -86,8 +86,8 @@ final class XmpIptcExtractor implements SingleMetadataExtractorInterface
         return $media;
     }
 
-    /** @param mixed $v @return list<string> */
-    private function fromIptcStrings($v): array
+    /** @param array|bool|float|int|string|null $v @return list<string> */
+    private function fromIptcStrings(array|bool|float|int|string|null $v): array
     {
         if (is_array($v)) {
             /** @var list<string> $out */


### PR DESCRIPTION
## Summary
- add explicit parameter types to helper methods handling cluster metadata
- declare accepted value types for feed scene tag formatters and IPTC parsing

## Testing
- composer ci:test *(fails: bin/php not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2971d635483239472c3bb0ef5d27e