### PR TITLE
Fix strict comparison guard in anniversary clustering

### DIFF
--- a/src/Clusterer/AnniversaryClusterStrategy.php
+++ b/src/Clusterer/AnniversaryClusterStrategy.php
@@ -128,8 +128,8 @@ final readonly class AnniversaryClusterStrategy implements ClusterStrategyInterf
             $yearKeys  = array_keys($years);
             $spanYears = max($yearKeys) - min($yearKeys) + 1;
 
-            $maxPerYear     = $years === [] ? 0 : max($years);
-            $averagePerYear = $distinctYears === 0 ? 0.0 : $total / $distinctYears;
+            $maxPerYear     = max($years);
+            $averagePerYear = $total / $distinctYears;
 
             // Weight recurring anniversaries stronger than one-off bursts while still
             // favouring days that contain many media overall.

--- a/src/Clusterer/FirstVisitPlaceClusterStrategy.php
+++ b/src/Clusterer/FirstVisitPlaceClusterStrategy.php
@@ -21,7 +21,6 @@ use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 
-use function assert;
 use MagicSunday\Memories\Utility\MediaMath;
 
 use function array_keys;

--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -19,7 +19,6 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
 
-use function assert;
 use function array_any;
 use function array_map;
 use function array_values;


### PR DESCRIPTION
## Summary
- remove redundant strict comparisons in AnniversaryClusterStrategy to satisfy phpstan's stricter type assumptions
- clean up duplicated assert imports flagged by phpstan in cluster strategy classes

## Testing
- `composer ci:test` *(fails: bin/php not found in the container image)*
- `./vendor/bin/phpstan analyze --configuration .build/phpstan.neon --memory-limit=-1 src/Clusterer/AnniversaryClusterStrategy.php`


------
https://chatgpt.com/codex/tasks/task_e_68e296f283008323b7241ee60c76270a