### PR TITLE
CLEANUP: remove redundant default group fallback

### DIFF
--- a/src/Service/Clusterer/Scoring/CompositeClusterScorer.php
+++ b/src/Service/Clusterer/Scoring/CompositeClusterScorer.php
@@ -83,9 +83,6 @@ final class CompositeClusterScorer
             $this->algorithmGroups[$algorithm] = $group;
         }
 
-        if ($this->defaultAlgorithmGroup === '') {
-            $this->defaultAlgorithmGroup = 'default';
-        }
     }
 
     /**

--- a/src/Support/ClusterEntityToDraftMapper.php
+++ b/src/Support/ClusterEntityToDraftMapper.php
@@ -62,9 +62,6 @@ final class ClusterEntityToDraftMapper
             $this->algorithmGroups[$algorithm] = $group;
         }
 
-        if ($this->defaultAlgorithmGroup === '') {
-            $this->defaultAlgorithmGroup = 'default';
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- drop redundant default group fallback checks now that the constructor arguments enforce the value

## Testing
- composer ci:test *(fails: bin/php not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e296d253f48323a3065522c5c93448