### PR TITLE
Refactor for loops to foreach

### DIFF
--- a/src/Clusterer/PhashSimilarityStrategy.php
+++ b/src/Clusterer/PhashSimilarityStrategy.php
@@ -124,8 +124,8 @@ final readonly class PhashSimilarityStrategy implements ClusterStrategyInterface
         /** @var array<int,list<int>> $adj */
         $adj    = array_fill(0, $n, []);
         $hashes = [];
-        for ($i = 0; $i < $n; ++$i) {
-            $hashes[$i] = (string) $items[$i]->getPhash();
+        foreach ($items as $index => $item) {
+            $hashes[$index] = (string) $item->getPhash();
         }
 
         for ($i = 0; $i < $n; ++$i) {

--- a/src/Clusterer/Service/VacationScoreCalculator.php
+++ b/src/Clusterer/Service/VacationScoreCalculator.php
@@ -24,6 +24,7 @@ use MagicSunday\Memories\Utility\MediaMath;
 
 use function abs;
 use function array_keys;
+use function array_slice;
 use function array_map;
 use function count;
 use function explode;
@@ -515,9 +516,8 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
                 $winners[] = $winner;
             }
 
-            $entryCount = count($entries);
-            for ($i = 1; $i < $entryCount; ++$i) {
-                $fallback[] = $entries[$i];
+            foreach (array_slice($entries, 1) as $entry) {
+                $fallback[] = $entry;
             }
         }
 

--- a/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
+++ b/src/Service/Clusterer/Pipeline/DominanceSelectionStage.php
@@ -44,8 +44,8 @@ final class DominanceSelectionStage implements ClusterConsolidationStageInterfac
         }
 
         $base = count($keepOrder);
-        for ($index = 0; $index < $base; ++$index) {
-            $this->priorityMap[$keepOrder[$index]] = $base - $index;
+        foreach ($keepOrder as $index => $algorithm) {
+            $this->priorityMap[$algorithm] = $base - $index;
         }
     }
 

--- a/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
+++ b/src/Service/Clusterer/Pipeline/DuplicateCollapseStage.php
@@ -34,8 +34,8 @@ final class DuplicateCollapseStage implements ClusterConsolidationStageInterface
     public function __construct(private readonly array $keepOrder)
     {
         $base = count($keepOrder);
-        for ($index = 0; $index < $base; ++$index) {
-            $this->priorityMap[$keepOrder[$index]] = $base - $index;
+        foreach ($keepOrder as $index => $algorithm) {
+            $this->priorityMap[$algorithm] = $base - $index;
         }
     }
 

--- a/src/Service/Clusterer/Pipeline/PerMediaCapStage.php
+++ b/src/Service/Clusterer/Pipeline/PerMediaCapStage.php
@@ -38,8 +38,8 @@ final class PerMediaCapStage implements ClusterConsolidationStageInterface
         private readonly string $defaultAlgorithmGroup,
     ) {
         $base = count($keepOrder);
-        for ($index = 0; $index < $base; ++$index) {
-            $this->priorityMap[$keepOrder[$index]] = $base - $index;
+        foreach ($keepOrder as $index => $algorithm) {
+            $this->priorityMap[$algorithm] = $base - $index;
         }
     }
 


### PR DESCRIPTION
## Summary
- replace index-based loops with foreach when building priority maps in clusterer pipeline stages
- iterate cluster items with foreach when deriving perceptual hashes in the pHash similarity strategy
- simplify vacation score fallback accumulation with foreach iteration

## Testing
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e298fe31b08323805e8222ace58f13