### PR TITLE
Fix phpunit failures caused by readonly inheritance

### DIFF
--- a/bin/php
+++ b/bin/php
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -eu
+
+exec php "$@"

--- a/src/Command/ClusterCommand.php
+++ b/src/Command/ClusterCommand.php
@@ -33,7 +33,7 @@ use function sprintf;
     name: 'memories:cluster',
     description: 'Erstellt Erinnerungs-Cluster anhand konfigurierter Strategien.'
 )]
-final readonly class ClusterCommand extends Command
+final class ClusterCommand extends Command
 {
     public function __construct(private readonly ClusterJobRunnerInterface $runner)
     {

--- a/src/Command/FeedExportHtmlCommand.php
+++ b/src/Command/FeedExportHtmlCommand.php
@@ -35,7 +35,7 @@ use function sprintf;
     name: 'memories:feed:export-html',
     description: 'Erzeugt eine HTML-Vorschau des Rückblick-Feeds (statisch, mit Lazy-Loading).'
 )]
-final readonly class FeedExportHtmlCommand extends Command
+final class FeedExportHtmlCommand extends Command
 {
     public function __construct(
         private readonly FeedExportServiceInterface $exportService,

--- a/src/Command/FeedPreviewCommand.php
+++ b/src/Command/FeedPreviewCommand.php
@@ -42,7 +42,7 @@ use function sprintf;
     name: 'memories:feed:preview',
     description: 'Zeigt eine Vorschau des Rückblick-Feeds.'
 )]
-final readonly class FeedPreviewCommand extends Command
+final class FeedPreviewCommand extends Command
 {
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -30,7 +30,7 @@ use function trim;
     name: 'memories:geocode',
     description: 'Orte aus GPS-Daten ermitteln und speichern'
 )]
-final readonly class GeocodeCommand extends Command
+final class GeocodeCommand extends Command
 {
     public function __construct(
         private readonly DefaultGeocodingWorkflow $workflow,

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -43,7 +43,7 @@ use function sprintf;
     name: 'memories:index',
     description: 'Indexiert Medien: Metadaten extrahieren und in DB speichern. Thumbnails optional mit --thumbnails.'
 )]
-final readonly class IndexCommand extends Command
+final class IndexCommand extends Command
 {
     public function __construct(
         private readonly MediaFileLocatorInterface $locator,

--- a/src/Command/SlideshowGenerateCommand.php
+++ b/src/Command/SlideshowGenerateCommand.php
@@ -34,7 +34,7 @@ use const LOCK_EX;
  * Console command that executes slideshow generation jobs.
  */
 #[AsCommand(name: 'slideshow:generate', description: 'Erstellt ein Slideshow-Video für die angegebene Job-Datei.')]
-final readonly class SlideshowGenerateCommand extends Command
+final class SlideshowGenerateCommand extends Command
 {
     public function __construct(private readonly SlideshowVideoGeneratorInterface $generator)
     {

--- a/src/Service/Clusterer/Scoring/PoiClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/PoiClusterScoreHeuristic.php
@@ -19,7 +19,7 @@ use function is_numeric;
 /**
  * Class PoiClusterScoreHeuristic
  */
-final readonly class PoiClusterScoreHeuristic extends AbstractClusterScoreHeuristic
+final class PoiClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
     /** @param array<string,float> $poiCategoryBoosts */
     public function __construct(private readonly array $poiCategoryBoosts = [])

--- a/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/QualityClusterScoreHeuristic.php
@@ -17,7 +17,7 @@ use MagicSunday\Memories\Clusterer\Support\ClusterQualityAggregator;
 /**
  * Class QualityClusterScoreHeuristic
  */
-final readonly class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
+final class QualityClusterScoreHeuristic extends AbstractClusterScoreHeuristic
 {
     public function __construct(private readonly ClusterQualityAggregator $qualityAggregator)
     {

--- a/src/Service/Feed/HtmlFeedExportService.php
+++ b/src/Service/Feed/HtmlFeedExportService.php
@@ -100,10 +100,10 @@ final readonly class HtmlFeedExportService implements FeedExportServiceInterface
         $skippedThumbCount = 0;
 
         /** @var list<array<string, mixed>|null> $cardCandidates */
-        $cardCandidates = array_map(
-            fn (MemoryFeedItem $item): ?array => $this->createCard($item, $request, $imageDirectory, $copiedFileCount, $skippedThumbCount),
-            $items,
-        );
+        $cardCandidates = [];
+        foreach ($items as $item) {
+            $cardCandidates[] = $this->createCard($item, $request, $imageDirectory, $copiedFileCount, $skippedThumbCount);
+        }
 
         /** @var list<array<string, mixed>> $cards */
         $cards = array_values(array_filter(

--- a/src/Service/Indexing/Stage/BurstLiveStage.php
+++ b/src/Service/Indexing/Stage/BurstLiveStage.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class BurstLiveStage
  */
-final readonly class BurstLiveStage extends AbstractExtractorStage
+final class BurstLiveStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/ContentKindStage.php
+++ b/src/Service/Indexing/Stage/ContentKindStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class ContentKindStage
  */
-final readonly class ContentKindStage extends AbstractExtractorStage
+final class ContentKindStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/FacesStage.php
+++ b/src/Service/Indexing/Stage/FacesStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class FacesStage
  */
-final readonly class FacesStage extends AbstractExtractorStage
+final class FacesStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/GeoStage.php
+++ b/src/Service/Indexing/Stage/GeoStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class GeoStage
  */
-final readonly class GeoStage extends AbstractExtractorStage
+final class GeoStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/HashStage.php
+++ b/src/Service/Indexing/Stage/HashStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class HashStage
  */
-final readonly class HashStage extends AbstractExtractorStage
+final class HashStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/MetadataStage.php
+++ b/src/Service/Indexing/Stage/MetadataStage.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class MetadataStage
  */
-final readonly class MetadataStage extends AbstractExtractorStage
+final class MetadataStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/QualityStage.php
+++ b/src/Service/Indexing/Stage/QualityStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class QualityStage
  */
-final readonly class QualityStage extends AbstractExtractorStage
+final class QualityStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/SceneStage.php
+++ b/src/Service/Indexing/Stage/SceneStage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class SceneStage
  */
-final readonly class SceneStage extends AbstractExtractorStage
+final class SceneStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors

--- a/src/Service/Indexing/Stage/TimeStage.php
+++ b/src/Service/Indexing/Stage/TimeStage.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Class TimeStage
  */
-final readonly class TimeStage extends AbstractExtractorStage
+final class TimeStage extends AbstractExtractorStage
 {
     /**
      * @var iterable<SingleMetadataExtractorInterface> $extractors


### PR DESCRIPTION
## Summary
- remove the readonly modifier from Symfony command subclasses and scoring/indexing stages so they can extend non-readonly parents on PHP 8.4
- iterate feed export items with a foreach so thumbnail copy counters update correctly
- add a simple bin/php shim so Composer QA scripts can run in environments without a custom PHP launcher

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: phpstan reports existing project issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e29ac453e08323bb3d3bf575a76c62