### PR TITLE
BUGFIX: Preserve blank lines in index log

### DIFF
--- a/src/Support/IndexLogHelper.php
+++ b/src/Support/IndexLogHelper.php
@@ -13,7 +13,7 @@ namespace MagicSunday\Memories\Support;
 
 use MagicSunday\Memories\Entity\Media;
 
-use function rtrim;
+use function str_ends_with;
 
 /**
  * Utility helpers for working with the media index log.
@@ -43,10 +43,13 @@ final class IndexLogHelper
             return;
         }
 
-        // Avoid adding duplicate blank lines when the stored log already ends with a newline.
-        $normalizedExisting = rtrim($existing, "\n");
+        if (str_ends_with($existing, "\n")) {
+            $media->setIndexLog($existing . $line);
 
-        $media->setIndexLog($normalizedExisting . "\n" . $line);
+            return;
+        }
+
+        $media->setIndexLog($existing . "\n" . $line);
     }
 }
 

--- a/test/Unit/Support/IndexLogHelperTest.php
+++ b/test/Unit/Support/IndexLogHelperTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Support;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Support\IndexLogHelper;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+final class IndexLogHelperTest extends TestCase
+{
+    #[Test]
+    public function appendPreservesExplicitBlankLines(): void
+    {
+        $media = new Media('/pfad/zur/datei.jpg', 'checksum', 1024);
+        $media->setIndexLog("Erster Eintrag\n\n");
+
+        IndexLogHelper::append($media, 'Zweiter Eintrag');
+
+        self::assertSame("Erster Eintrag\n\nZweiter Eintrag", $media->getIndexLog());
+    }
+
+    #[Test]
+    public function appendRespectsExistingTrailingNewline(): void
+    {
+        $media = new Media('/pfad/zur/datei.jpg', 'checksum', 1024);
+        $media->setIndexLog("Erster Eintrag\r\n");
+
+        IndexLogHelper::append($media, 'Zweiter Eintrag');
+
+        self::assertSame("Erster Eintrag\r\nZweiter Eintrag", $media->getIndexLog());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the index log helper appends new entries without stripping existing blank lines
- add regression coverage for blank line preservation and Windows-style newlines

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: `bin/php` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29cd532ec8323af41172ffe37430c