### PR TITLE
Mark immutable promoted test doubles as readonly

### DIFF
--- a/test/Integration/Service/Geocoding/OverpassClientTest.php
+++ b/test/Integration/Service/Geocoding/OverpassClientTest.php
@@ -95,7 +95,7 @@ final class RecordingHttpClient implements HttpClientInterface
 {
     public string $lastQuery = '';
 
-    public function __construct(private ResponseInterface $response)
+    public function __construct(private readonly ResponseInterface $response)
     {
     }
 

--- a/test/Unit/Clusterer/VacationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VacationClusterStrategyTest.php
@@ -335,7 +335,7 @@ final class VacationClusterStrategyTest extends TestCase
             /**
              * @param array<int, Media> $map
              */
-            public function __construct(private array $map)
+            public function __construct(private readonly array $map)
             {
             }
 

--- a/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
+++ b/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
@@ -36,7 +36,7 @@ final class ClusterPersistenceServiceTest extends TestCase
         $media = $this->buildMediaSet();
         $lookup = new class($media) implements MemberMediaLookupInterface {
             /** @param array<int, Media> $media */
-            public function __construct(private array $media) {}
+            public function __construct(private readonly array $media) {}
 
             public function findByIds(array $ids, bool $onlyVideos = false): array
             {

--- a/test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php
+++ b/test/Unit/Service/Clusterer/Pipeline/MemberQualityRankingStageTest.php
@@ -373,7 +373,7 @@ final class InMemoryMediaLookup implements MemberMediaLookupInterface
     /**
      * @param array<int, Media> $map
      */
-    public function __construct(private array $map)
+    public function __construct(private readonly array $map)
     {
     }
 

--- a/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
+++ b/test/Unit/Service/Thumbnail/ThumbnailServiceTest.php
@@ -204,7 +204,7 @@ final class ThumbnailServiceTest extends TestCase
         $imagick->expects(self::exactly(2))->method('destroy');
 
         $service = new class ($thumbnailDir, [200], $imagick) extends ThumbnailService {
-            public function __construct(string $thumbnailDir, array $sizes, private Imagick $imagick)
+            public function __construct(string $thumbnailDir, array $sizes, private readonly Imagick $imagick)
             {
                 parent::__construct($thumbnailDir, $sizes);
             }
@@ -383,7 +383,7 @@ final class ThumbnailServiceTest extends TestCase
         $imagick->expects(self::once())->method('destroy');
 
         $service = new class ($thumbnailDir, [320], $imagick) extends ThumbnailService {
-            public function __construct(string $thumbnailDir, array $sizes, private Imagick $imagick)
+            public function __construct(string $thumbnailDir, array $sizes, private readonly Imagick $imagick)
             {
                 parent::__construct($thumbnailDir, $sizes);
             }


### PR DESCRIPTION
## Summary
- mark private promoted constructor properties in test doubles as readonly to better express immutability

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29d246a8483239e192de44fe882e5