### PR TITLE
Fix default parameter fallbacks for optional environment overrides

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -29,6 +29,9 @@ parameters:
     memories.hash.phash_prefix_length: 16
 
     # Home configuration
+    memories.home.lat_default: 0.0
+    memories.home.lon_default: 0.0
+    memories.home.radius_km_default: 15.0
     env(MEMORIES_HOME_VERSION_HASH): 'home_config_v1'
     memories.home.version_hash: '%env(string:MEMORIES_HOME_VERSION_HASH)%'
 
@@ -44,14 +47,16 @@ parameters:
     memories.geocoding.overpass.max_pois: 15
     memories.geocoding.overpass.fetch_limit_multiplier: 3.0
     memories.geocoding.overpass.allowed_pois: []
-    memories.localization.preferred_locale: '%env(default::string:MEMORIES_PREFERRED_LOCALE)%'
+    memories.localization.preferred_locale_default: 'de'
+    memories.localization.preferred_locale: '%env(default:memories.localization.preferred_locale_default:string:MEMORIES_PREFERRED_LOCALE)%'
 
     memories.timezone.default: 'UTC'
     memories.cluster.timezone.default: 'Europe/Berlin'
 
     # Thumbnail-Größen (px)
     memories.thumbnail_sizes: [320, 1024]
-    memories.thumbnail.apply_orientation: '%env(default::bool:MEMORIES_THUMBNAIL_APPLY_ORIENTATION)%'
+    memories.thumbnail.apply_orientation_default: false
+    memories.thumbnail.apply_orientation: '%env(default:memories.thumbnail.apply_orientation_default:bool:MEMORIES_THUMBNAIL_APPLY_ORIENTATION)%'
 
     # Consolidation Defaults
     memories.cluster.consolidate.min_score: 0.30

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -151,7 +151,7 @@ services:
         arguments:
             $homeLat: '%env(float:MEMORIES_HOME_LAT)%'
             $homeLon: '%env(float:MEMORIES_HOME_LON)%'
-            $homeRadiusKm: '%env(default::float:MEMORIES_HOME_RADIUS_KM)%'
+            $homeRadiusKm: '%env(default:memories.home.radius_km_default:float:MEMORIES_HOME_RADIUS_KM)%'
             $homeVersionHash: '%memories.home.version_hash%'
             $cellDegrees: 0.01
         tags:
@@ -624,9 +624,9 @@ services:
         arguments:
             $timezone: 'Europe/Berlin'
             $defaultHomeRadiusKm: 15.0
-            $homeLat: '%env(default::float:MEMORIES_HOME_LAT)%'
-            $homeLon: '%env(default::float:MEMORIES_HOME_LON)%'
-            $homeRadiusKm: '%env(default::float:MEMORIES_HOME_RADIUS_KM)%'
+            $homeLat: '%env(default:memories.home.lat_default:float:MEMORIES_HOME_LAT)%'
+            $homeLon: '%env(default:memories.home.lon_default:float:MEMORIES_HOME_LON)%'
+            $homeRadiusKm: '%env(default:memories.home.radius_km_default:float:MEMORIES_HOME_RADIUS_KM)%'
 
     MagicSunday\Memories\Clusterer\Contract\HomeLocatorInterface:
         alias: MagicSunday\Memories\Clusterer\DefaultHomeLocator


### PR DESCRIPTION
## Summary
- add explicit default parameters for locale, thumbnail orientation, and home coordinates used when related environment variables are missing
- update service definitions to reference the new defaults so Symfony injects typed fallback values instead of `null`

## Testing
- `composer ci:test` *(fails: bin/php not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29f1666cc8323b1410fe14a7a9577