### PR TITLE
docs: outline unused variable detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,12 @@ Die Vision-Pipeline speichert jetzt voraggregierte Qualitätsmetriken direkt am 
 Alle Score-Werte bewegen sich zwischen `0` und `1`, wobei `1` den bestmöglichen Zustand beschreibt. Die Cluster-Heuristiken greifen bevorzugt auf diese aggregierten Zahlen zu; fehlen sie, bleiben die Rohmetriken (Auflösung, Schärfe, ISO, Helligkeit usw.) als Fallback erhalten.
 
 Für die Berechnung der Qualitätsmetriken und Posterframes greift der Indexer standardmäßig auf die Binaries `ffmpeg` und `ffprobe` aus dem `PATH` zu. Solltest du abweichende Installationspfade verwenden, setzt du die Umgebungsvariablen `FFMPEG_PATH` bzw. `FFPROBE_PATH` oder überschreibst die zugehörigen Symfony-Parameter `memories.video.ffmpeg_path` und `memories.video.ffprobe_path` in deiner Konfiguration. Beide Parameter bringen nun ohne weitere Anpassungen lauffähige Standardwerte mit.
+
+## Statische Analyse & ungenutzte Variablen
+
+PHPStan meldet Variablen automatisch als ungenutzt, wenn ihr Inhalt im weiteren Kontrollfluss keine Rolle spielt. Das schließt zwei typische Situationen ein:
+
+* Der zugewiesene Wert taucht nirgendwo mehr auf oder wird direkt wieder überschrieben.
+* Eine per Referenz gespeicherte Variable wird nirgends gelesen oder gleich im Anschluss über eine neue Referenz ersetzt.
+
+Sorge in diesen Fällen für einen gezielten Einsatz oder entferne die unnötigen Zuweisungen, damit der Analyse-Lauf sauber durchläuft.


### PR DESCRIPTION
## Summary
- document how PHPStan flags unused variables in README so developers know when assignments trigger warnings

## Testing
- ./vendor/bin/phpstan analyze --configuration .build/phpstan.neon --memory-limit=-1 *(fails: existing 665 errors in baseline code)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a01ac934832392436a322beda409