### PR TITLE
Remove redundant array_values call in MediaFilterTrait

### DIFF
--- a/src/Clusterer/Support/MediaFilterTrait.php
+++ b/src/Clusterer/Support/MediaFilterTrait.php
@@ -267,6 +267,6 @@ trait MediaFilterTrait
             return $items;
         }
 
-        return array_values($result);
+        return $result;
     }
 }


### PR DESCRIPTION
## Summary
- remove the redundant array_values call when returning filtered media

## Testing
- composer ci:test *(fails: `bin/php` wrapper is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a46a17648323978c7dbeb26ed258