### PR TITLE
Refactor accuracy radius calculation

### DIFF
--- a/src/Service/Geocoding/NominatimReverseGeocoder.php
+++ b/src/Service/Geocoding/NominatimReverseGeocoder.php
@@ -153,16 +153,11 @@ final readonly class NominatimReverseGeocoder implements ReverseGeocoderInterfac
 
         [$south, $north, $west, $east] = $bbox;
 
-        $northFloat = (float) $north;
-        $southFloat = (float) $south;
-        $eastFloat  = (float) $east;
-        $westFloat  = (float) $west;
-
         $distances = [
-            MediaMath::haversineDistanceInMeters($lat, $lon, $northFloat, $lon),
-            MediaMath::haversineDistanceInMeters($lat, $lon, $southFloat, $lon),
-            MediaMath::haversineDistanceInMeters($lat, $lon, $lat, $eastFloat),
-            MediaMath::haversineDistanceInMeters($lat, $lon, $lat, $westFloat),
+            MediaMath::haversineDistanceInMeters($lat, $lon, $north, $lon),
+            MediaMath::haversineDistanceInMeters($lat, $lon, $south, $lon),
+            MediaMath::haversineDistanceInMeters($lat, $lon, $lat, $east),
+            MediaMath::haversineDistanceInMeters($lat, $lon, $lat, $west),
         ];
 
         $radius = (float) max($distances);


### PR DESCRIPTION
## Summary
- remove redundant temporary variables when calculating accuracy radius using bounding box coordinates

## Testing
- composer ci:test *(fails: sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a47ecab483239f8daf44bb8158c5