### PR TITLE
Adjust cluster order normalisation id casting

### DIFF
--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -642,7 +642,7 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
         /** @var array<int,int> $originalCounts */
         $originalCounts = [];
         foreach ($original as $id) {
-            $intId = (int) $id;
+            $intId = $id;
             $originalCounts[$intId] = ($originalCounts[$intId] ?? 0) + 1;
         }
 
@@ -680,7 +680,7 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
         }
 
         foreach ($original as $id) {
-            $intId   = (int) $id;
+            $intId   = $id;
             $expected = $originalCounts[$intId] ?? 0;
             $current  = $orderedCounts[$intId] ?? 0;
             if ($current >= $expected) {


### PR DESCRIPTION
## Summary
- keep the original identifier values in normaliseOrderList without casting to int

## Testing
- composer ci:test *(fails: bin/php not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a481df7083238b534a00a5e15331