### PR TITLE
Refine day summary types and container instantiation

### DIFF
--- a/src/Clusterer/DaySummaryStage/AwayFlagStage.php
+++ b/src/Clusterer/DaySummaryStage/AwayFlagStage.php
@@ -37,26 +37,22 @@ final readonly class AwayFlagStage implements DaySummaryStageInterface
 
         $keys = array_keys($days);
         foreach ($keys as $index => $key) {
-            $summary     = &$days[$key];
             $nextKey     = $keys[$index + 1] ?? null;
+            $summary     = $days[$key];
             $nextSummary = $nextKey !== null ? $days[$nextKey] : null;
 
             $timezone = $this->timezoneResolver->resolveSummaryTimezone($summary, $home);
             $baseLocation = $this->baseLocationResolver->resolve($summary, $nextSummary, $home, $timezone);
-            $summary['baseLocation'] = $baseLocation;
+            $days[$key]['baseLocation'] = $baseLocation;
 
             if ($baseLocation !== null && $baseLocation['distance_km'] > $home['radius_km']) {
-                $summary['baseAway'] = true;
+                $days[$key]['baseAway'] = true;
             }
 
             if ($summary['avgDistanceKm'] > $home['radius_km']) {
-                $summary['awayByDistance'] = true;
+                $days[$key]['awayByDistance'] = true;
             }
-
-            unset($summary);
         }
-
-        unset($summary);
 
         $baseFlags     = [];
         $distanceFlags = [];

--- a/src/Clusterer/DaySummaryStage/InitializationStage.php
+++ b/src/Clusterer/DaySummaryStage/InitializationStage.php
@@ -32,6 +32,46 @@ use function strtolower;
 use const SORT_STRING;
 
 /**
+ * @phpstan-type Staypoint array{lat:float,lon:float,start:int,end:int,dwell:int}
+ * @phpstan-type BaseLocation array{lat:float,lon:float,distance_km:float,source:string}
+ * @phpstan-type DaySummary array{
+ *     date: string,
+ *     members: list<Media>,
+ *     gpsMembers: list<Media>,
+ *     maxDistanceKm: float,
+ *     distanceSum: float,
+ *     distanceCount: int,
+ *     avgDistanceKm: float,
+ *     travelKm: float,
+ *     countryCodes: array<string, true>,
+ *     timezoneOffsets: array<int, int>,
+ *     localTimezoneIdentifier: string,
+ *     localTimezoneOffset: int|null,
+ *     tourismHits: int,
+ *     poiSamples: int,
+ *     tourismRatio: float,
+ *     hasAirportPoi: bool,
+ *     weekday: int,
+ *     photoCount: int,
+ *     densityZ: float,
+ *     isAwayCandidate: bool,
+ *     sufficientSamples: bool,
+ *     spotClusters: list<list<Media>>,
+ *     spotNoise: list<Media>,
+ *     spotCount: int,
+ *     spotNoiseSamples: int,
+ *     spotDwellSeconds: int,
+ *     staypoints: list<Staypoint>,
+ *     baseLocation: BaseLocation|null,
+ *     baseAway: bool,
+ *     awayByDistance: bool,
+ *     firstGpsMedia: Media|null,
+ *     lastGpsMedia: Media|null,
+ *     timezoneIdentifierVotes?: array<string, int>,
+ *     isSynthetic: bool,
+ * }
+ */
+/**
  * Initialises per-day summaries from media items.
  */
 final readonly class InitializationStage implements DaySummaryStageInterface
@@ -49,6 +89,12 @@ final readonly class InitializationStage implements DaySummaryStageInterface
         }
     }
 
+    /**
+     * @param array<string, DaySummary> $days
+     * @param array{lat:float,lon:float,radius_km:float,country:?string,timezone_offset:?int} $home
+     *
+     * @return array<string, DaySummary>
+     */
     public function process(array $days, array $home): array
     {
         if ($days === []) {
@@ -179,9 +225,9 @@ final readonly class InitializationStage implements DaySummaryStageInterface
     }
 
     /**
-     * @param array<string, array{date:string,isSynthetic:bool}> $days
+     * @param array<string, DaySummary> $days
      *
-     * @return array<string, array{date:string,isSynthetic:bool}>
+     * @return array<string, DaySummary>
      * @throws DateInvalidTimeZoneException
      * @throws DateMalformedStringException
      */
@@ -219,9 +265,7 @@ final readonly class InitializationStage implements DaySummaryStageInterface
     }
 
     /**
-     * @param string $date
-     *
-     * @return array{date:string,members:list<Media>,gpsMembers:list<Media>,maxDistanceKm:float,distanceSum:float,distanceCount:int,avgDistanceKm:float,travelKm:float,countryCodes:array<string,true>,timezoneOffsets:array<int,int>,localTimezoneIdentifier:string,localTimezoneOffset:int|null,tourismHits:int,poiSamples:int,tourismRatio:float,hasAirportPoi:bool,weekday:int,photoCount:int,densityZ:float,isAwayCandidate:bool,sufficientSamples:bool,spotClusters:list<list<Media>>,spotNoise:list<Media>,spotCount:int,spotNoiseSamples:int,spotDwellSeconds:int,staypoints:list<array{lat:float,lon:float,start:int,end:int,dwell:int}>,baseLocation:array{lat:float,lon:float,distance_km:float,source:string}|null,baseAway:bool,awayByDistance:bool,firstGpsMedia:Media|null,lastGpsMedia:Media|null,isSynthetic:bool,timezoneIdentifierVotes:array<string,int>}
+     * @return DaySummary
      * @throws DateInvalidTimeZoneException
      * @throws DateMalformedStringException
      */


### PR DESCRIPTION
## Summary
- add explicit phpstan array shape aliases for day summary data and mark timezoneIdentifierVotes as optional
- remove reference juggling in AwayFlagStage to silence undefined-variable clean-up warnings
- instantiate the cached container class dynamically with runtime validation to satisfy static analysis

## Testing
- bin/php vendor/bin/phpstan analyse src/Clusterer/DaySummaryStage --error-format=raw --memory-limit=1G
- bin/php vendor/bin/phpstan analyse src/DependencyContainerFactory.php --error-format=raw --memory-limit=1G

------
https://chatgpt.com/codex/tasks/task_e_68e29f0a146c8323a39a2d067c2301e7