### PR TITLE
Prioritise vacation classifications during dominance selection

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -101,6 +101,11 @@ parameters:
         - 'device_similarity'
         - 'phash_similarity'
         - 'burst'
+    memories.cluster.consolidate.classification_priority:
+        vacation:
+            - 'vacation'
+            - 'short_trip'
+            - 'day_trip'
     memories.cluster.consolidate.default_group: 'default'
     memories.cluster.consolidate.groups:
         time_similarity: 'time_and_basics'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -859,6 +859,7 @@ services:
             $overlapMergeThreshold: '%memories.cluster.consolidate.overlap_merge_threshold%'
             $overlapDropThreshold: '%memories.cluster.consolidate.overlap_drop_threshold%'
             $keepOrder: '%memories.cluster.consolidate.keep_order%'
+            $classificationPriority: '%memories.cluster.consolidate.classification_priority%'
         tags:
             - { name: 'memories.cluster_consolidation.stage', priority: 300 }
 

--- a/test/Unit/Service/Clusterer/Pipeline/DominanceSelectionStageTest.php
+++ b/test/Unit/Service/Clusterer/Pipeline/DominanceSelectionStageTest.php
@@ -25,6 +25,7 @@ final class DominanceSelectionStageTest extends TestCase
             overlapMergeThreshold: 0.5,
             overlapDropThreshold: 0.9,
             keepOrder: ['primary', 'secondary'],
+            classificationPriority: [],
         );
 
         $primaryWinner    = $this->createDraft('primary', 0.8, [1, 2, 3]);
@@ -46,14 +47,51 @@ final class DominanceSelectionStageTest extends TestCase
         ], $result);
     }
 
+    #[Test]
+    public function prefersVacationClassificationBeforeSize(): void
+    {
+        $stage = new DominanceSelectionStage(
+            overlapMergeThreshold: 0.5,
+            overlapDropThreshold: 0.9,
+            keepOrder: ['vacation'],
+            classificationPriority: [
+                'vacation' => ['vacation', 'short_trip', 'day_trip'],
+            ],
+        );
+
+        $vacation    = $this->createDraft('vacation', 0.8, [1, 2], 'vacation');
+        $shortTrip   = $this->createDraft('vacation', 0.8, [10, 11, 12, 13], 'short_trip');
+        $dayTrip     = $this->createDraft('vacation', 0.8, [20, 21, 22, 23, 24], 'day_trip');
+        $unclassified = $this->createDraft('vacation', 0.8, [30, 31, 32]);
+
+        $result = $stage->process([
+            $shortTrip,
+            $vacation,
+            $dayTrip,
+            $unclassified,
+        ]);
+
+        self::assertSame([
+            $vacation,
+            $shortTrip,
+            $dayTrip,
+            $unclassified,
+        ], $result);
+    }
+
     /**
      * @param list<int> $members
      */
-    private function createDraft(string $algorithm, float $score, array $members): ClusterDraft
+    private function createDraft(string $algorithm, float $score, array $members, ?string $classification = null): ClusterDraft
     {
+        $params = ['score' => $score];
+        if ($classification !== null) {
+            $params['classification'] = $classification;
+        }
+
         return new ClusterDraft(
             algorithm: $algorithm,
-            params: ['score' => $score],
+            params: $params,
             centroid: ['lat' => 0.0, 'lon' => 0.0],
             members: $members,
         );

--- a/test/Unit/Service/Clusterer/Pipeline/PipelineClusterConsolidatorTest.php
+++ b/test/Unit/Service/Clusterer/Pipeline/PipelineClusterConsolidatorTest.php
@@ -38,6 +38,7 @@ final class PipelineClusterConsolidatorTest extends TestCase
                 overlapMergeThreshold: 0.5,
                 overlapDropThreshold: 0.9,
                 keepOrder: ['primary', 'secondary'],
+                classificationPriority: [],
             ),
             new AnnotationPruningStage(['annot'], ['annot' => 0.4]),
             new PerMediaCapStage(


### PR DESCRIPTION
## Summary
- add classification-aware tie-breaking to the dominance selection stage so vacation clusters outrank shorter trips
- expose default vacation classification order through configuration and inject it via the service container
- expand unit coverage for the stage and pipeline to exercise the new constructor signature and vacation ordering

## Testing
- composer ci:test *(fails: bin/php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aefcd374832386a75841ffddc5a1