### PR TITLE
Ensure geocoding uses German accept language

### DIFF
--- a/test/Unit/Service/Geocoding/MediaLocationLinkerTest.php
+++ b/test/Unit/Service/Geocoding/MediaLocationLinkerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Geocoding;
+
+use MagicSunday\Memories\Service\Geocoding\MediaLocationLinker;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+final class MediaLocationLinkerTest extends TestCase
+{
+    public function testNormalizeAcceptLanguage(): void
+    {
+        $refClass = new ReflectionClass(MediaLocationLinker::class);
+        $linker   = $refClass->newInstanceWithoutConstructor();
+
+        $method = new ReflectionMethod(MediaLocationLinker::class, 'normalizeAcceptLanguage');
+        $method->setAccessible(true);
+
+        self::assertSame('de-DE', $method->invoke($linker, 'de_DE'));
+        self::assertSame('de', $method->invoke($linker, ''));
+        self::assertSame('fr', $method->invoke($linker, ' fr '));
+        self::assertSame('de-DE', $method->invoke($linker, 'DE_de'));
+        self::assertSame('de-DE', $method->invoke($linker, 'de_DE.UTF-8'));
+        self::assertSame('de,en;q=0.7', $method->invoke($linker, 'de,en;q=0.7'));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize the Accept-Language header before triggering reverse geocoding so that German locales stay in effect
- add a unit test that covers common locale formats and verifies the sanitisation logic

## Testing
- composer ci:test *(fails: bin/php not found in container image)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter MediaLocationLinkerTest


------
https://chatgpt.com/codex/tasks/task_e_68e2bdb1608083238d77a195628d1597