### PR TITLE
Add staypoint-aware vacation metadata defaults

### DIFF
--- a/config/templates/titles.yaml
+++ b/config/templates/titles.yaml
@@ -98,7 +98,10 @@ de:
     #   - {{ place }} (optional): Dominanter Aufnahmeort
     #   - {{ place_city }} (optional): Dominante Stadt im Cluster
     #   - {{ place_region }} (optional): Dominante Region/Bundesland
-    #   - {{ place_country }} (optional): Dominantes Land
+    #   - {{ place_country }} (optional): Dominantes Land; Templates können bei Uneindeutigkeit auf {{ countries }} zurückgreifen
+    #   - {{ primaryStaypointCity }} (optional): Stadt des längsten Aufenthalts
+    #   - {{ primaryStaypointLocation }} (optional): Formatierter Aufenthaltsort des Haupt-Staypoints
+    #   - {{ countries }} (optional): Liste eindeutiger ISO-Ländercodes für Multi-Country-Reisen
     vacation:
         title: "{{ classification_label }} – {{ place_country }}"
         subtitle: "{{ start_date }} – {{ end_date }}"

--- a/test/Unit/Clusterer/DefaultVacationSegmentAssemblerTest.php
+++ b/test/Unit/Clusterer/DefaultVacationSegmentAssemblerTest.php
@@ -118,6 +118,6 @@ final class DefaultVacationSegmentAssemblerTest extends TestCase
         self::assertSame('vacation', $params['classification']);
         self::assertSame(6, $params['away_days']);
         self::assertEqualsCanonicalizing([0, 60], $params['timezones']);
-        self::assertSame(['pt'], $params['countries']);
+        self::assertArrayNotHasKey('countries', $params);
     }
 }

--- a/test/Unit/Clusterer/VacationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VacationClusterStrategyTest.php
@@ -211,7 +211,7 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertArrayHasKey('spot_exploration_bonus', $params);
         self::assertSame(5, $params['work_day_penalty_days']);
         self::assertSame(2.0, $params['work_day_penalty_score']);
-        self::assertSame(['it'], $params['countries']);
+        self::assertArrayNotHasKey('countries', $params);
         self::assertSame([120], $params['timezones']);
         self::assertSame('Roma', $params['place_city']);
         self::assertSame('Lazio', $params['place_region']);
@@ -614,7 +614,7 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertGreaterThan(0.0, $params['weekend_holiday_bonus']);
         self::assertLessThanOrEqual(2, $params['work_day_penalty_days']);
         self::assertLessThanOrEqual(0.8, $params['work_day_penalty_score']);
-        self::assertSame(['de'], $params['countries']);
+        self::assertArrayNotHasKey('countries', $params);
         self::assertSame([120], $params['timezones']);
         self::assertArrayNotHasKey('place_city', $params);
         self::assertSame('Schleswig-Holstein', $params['place_region']);
@@ -731,7 +731,7 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertGreaterThanOrEqual(8.0, $params['score']);
         self::assertLessThanOrEqual(2, $params['work_day_penalty_days']);
         self::assertLessThanOrEqual(0.8, $params['work_day_penalty_score']);
-        self::assertSame(['de'], $params['countries']);
+        self::assertArrayNotHasKey('countries', $params);
         self::assertSame([60], $params['timezones']);
     }
 


### PR DESCRIPTION
## Summary
- select the longest-dwell staypoint when building vacation drafts and persist detailed helper metadata
- fall back to staypoint-derived city and location strings when majority labels are missing and expose multi-country lists only when needed
- extend unit coverage and template documentation for the new staypoint fields and `countries` fallback guidance

## Testing
- `composer ci:test` *(fails: sh: 1: bin/php: not found)*
- `vendor/bin/phpunit test/Unit/Clusterer/VacationScoreCalculatorTest.php`
- `vendor/bin/phpunit test/Unit/Clusterer/DefaultVacationSegmentAssemblerTest.php`
- `vendor/bin/phpunit test/Unit/Clusterer/VacationClusterStrategyTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68e2bcacedf88323bea69164cc85c558