### PR TITLE
Enhance home detection with adaptive centers

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -32,6 +32,8 @@ parameters:
     memories.home.lat_default: 0.0
     memories.home.lon_default: 0.0
     memories.home.radius_km_default: 15.0
+    memories.home.max_centers_default: 2
+    memories.home.fallback_radius_scale_default: 1.75
     env(MEMORIES_HOME_VERSION_HASH): 'home_config_v1'
     memories.home.version_hash: '%env(string:MEMORIES_HOME_VERSION_HASH)%'
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -627,6 +627,8 @@ services:
             $homeLat: '%env(default:memories.home.lat_default:float:MEMORIES_HOME_LAT)%'
             $homeLon: '%env(default:memories.home.lon_default:float:MEMORIES_HOME_LON)%'
             $homeRadiusKm: '%env(default:memories.home.radius_km_default:float:MEMORIES_HOME_RADIUS_KM)%'
+            $maxHomeCenters: '%env(default:memories.home.max_centers_default:int:MEMORIES_HOME_MAX_CENTERS)%'
+            $fallbackRadiusScale: '%env(default:memories.home.fallback_radius_scale_default:float:MEMORIES_HOME_FALLBACK_RADIUS_SCALE)%'
 
     MagicSunday\Memories\Clusterer\Contract\HomeLocatorInterface:
         alias: MagicSunday\Memories\Clusterer\DefaultHomeLocator

--- a/src/Clusterer/Contract/BaseLocationResolverInterface.php
+++ b/src/Clusterer/Contract/BaseLocationResolverInterface.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer\Contract;
 
 use DateTimeZone;
+use MagicSunday\Memories\Clusterer\Contract\DaySummaryStageInterface;
 use MagicSunday\Memories\Entity\Media;
 
 /**
@@ -20,11 +21,13 @@ use MagicSunday\Memories\Entity\Media;
 interface BaseLocationResolverInterface
 {
     /**
+     * @phpstan-import-type HomeDescriptor from DaySummaryStageInterface
+     *
      * Determines the most plausible base location for the provided day summary.
      *
      * @param array{date:string,staypoints:list<array{lat:float,lon:float,start:int,end:int,dwell:int}>,firstGpsMedia:Media|null,lastGpsMedia:Media|null,gpsMembers:list<Media>} $summary
      * @param array{date:string,staypoints:list<array{lat:float,lon:float,start:int,end:int,dwell:int}>,firstGpsMedia:Media|null}|null                                           $nextSummary
-     * @param array{lat:float,lon:float,radius_km:float,country:string|null,timezone_offset:int|null}                                                                            $home
+     * @param HomeDescriptor                                                                                                                          $home
      *
      * @return array{lat:float,lon:float,distance_km:float,source:string}|null
      */

--- a/src/Clusterer/Contract/DaySummaryStageInterface.php
+++ b/src/Clusterer/Contract/DaySummaryStageInterface.php
@@ -12,13 +12,24 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Clusterer\Contract;
 
 /**
+ * @phpstan-type HomeDescriptor array{
+ *     lat:float,
+ *     lon:float,
+ *     radius_km:float,
+ *     country:string|null,
+ *     timezone_offset:int|null,
+ *     centers?:list<array{lat:float,lon:float,radius_km:float,member_count?:int,dwell_seconds?:int}>
+ * }
+ */
+
+/**
  * Contract for incremental day summary pipeline stages.
  */
 interface DaySummaryStageInterface
 {
     /**
      * @param array<string, mixed>|list<mixed>                                                        $days
-     * @param array{lat:float,lon:float,radius_km:float,country:string|null,timezone_offset:int|null} $home
+     * @param HomeDescriptor                                                                          $home
      *
      * @return array<string, mixed>
      */

--- a/src/Clusterer/Support/HomeBoundaryHelper.php
+++ b/src/Clusterer/Support/HomeBoundaryHelper.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Clusterer\Support;
+
+use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Utility\MediaMath;
+
+use function is_array;
+
+/**
+ * Utility helpers for evaluating proximity to configured home centers.
+ */
+final class HomeBoundaryHelper
+{
+    /**
+     * @param array{lat:float,lon:float,radius_km:float,centers?:list<array{lat:float,lon:float,radius_km:float,country?:string|null,timezone_offset?:int|null,member_count?:int,dwell_seconds?:int}>} $home
+     *
+     * @return list<array{lat:float,lon:float,radius_km:float,country?:string|null,timezone_offset?:int|null,member_count?:int,dwell_seconds?:int}>
+     */
+    public static function centers(array $home): array
+    {
+        $centers = $home['centers'] ?? null;
+
+        if (is_array($centers) && $centers !== []) {
+            return $centers;
+        }
+
+        return [[
+            'lat'             => $home['lat'],
+            'lon'             => $home['lon'],
+            'radius_km'       => $home['radius_km'],
+            'country'         => $home['country'] ?? null,
+            'timezone_offset' => $home['timezone_offset'] ?? null,
+        ]];
+    }
+
+    /**
+     * @param array{lat:float,lon:float,radius_km:float,centers?:list<array{lat:float,lon:float,radius_km:float,country?:string|null,timezone_offset?:int|null,member_count?:int,dwell_seconds?:int}>} $home
+     *
+     * @return array{distance_km:float,radius_km:float,center:array{lat:float,lon:float,radius_km:float,country?:string|null,timezone_offset?:int|null,member_count?:int,dwell_seconds?:int},index:int}
+     */
+    public static function nearestCenter(array $home, float $lat, float $lon): array
+    {
+        $centers    = self::centers($home);
+        $bestIndex  = 0;
+        $bestCenter = $centers[0];
+        $bestDist   = PHP_FLOAT_MAX;
+
+        foreach ($centers as $index => $center) {
+            $distance = MediaMath::haversineDistanceInMeters(
+                $lat,
+                $lon,
+                (float) $center['lat'],
+                (float) $center['lon'],
+            ) / 1000.0;
+
+            if ($distance < $bestDist) {
+                $bestDist   = $distance;
+                $bestCenter = $center;
+                $bestIndex  = $index;
+            }
+        }
+
+        return [
+            'distance_km' => $bestDist,
+            'radius_km'   => (float) $bestCenter['radius_km'],
+            'center'      => $bestCenter,
+            'index'       => $bestIndex,
+        ];
+    }
+
+    /**
+     * @param array{lat:float,lon:float,radius_km:float,centers?:list<array{lat:float,lon:float,radius_km:float}>} $home
+     */
+    public static function isBeyondHome(array $home, float $lat, float $lon): bool
+    {
+        $nearest = self::nearestCenter($home, $lat, $lon);
+
+        return $nearest['distance_km'] > $nearest['radius_km'];
+    }
+
+    /**
+     * @param array{lat:float,lon:float,radius_km:float,centers?:list<array{lat:float,lon:float,radius_km:float}>} $home
+     */
+    public static function primaryRadius(array $home): float
+    {
+        $centers = self::centers($home);
+
+        return (float) $centers[0]['radius_km'];
+    }
+
+    /**
+     * @param list<Media> $members
+     */
+    public static function hasCoordinateSamples(array $members): bool
+    {
+        foreach ($members as $media) {
+            if ($media->getGpsLat() !== null && $media->getGpsLon() !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor DefaultHomeLocator to emit adaptive multi-center home descriptors and expose tuning knobs
- introduce a shared HomeBoundaryHelper and update away detection services to honor all configured home centers
- expand configuration defaults and test coverage for multi-center home handling

## Testing
- `composer ci:test` *(fails: sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bff541388323940d309cb09cd43d