### PR TITLE
Adjust location labels to prefer locality information

### DIFF
--- a/test/Unit/Utility/LocationHelperTest.php
+++ b/test/Unit/Utility/LocationHelperTest.php
@@ -210,4 +210,43 @@ final class LocationHelperTest extends TestCase
 
         self::assertSame('Altes Rathaus', $helper->displayLabel($location));
     }
+
+    #[Test]
+    public function fallsBackToCityWhenPoiHasOnlyCategory(): void
+    {
+        $helper = LocationHelper::createDefault();
+
+        $location = $this->makeLocation(
+            providerPlaceId: 'poi-monument-1',
+            displayName: 'Monument Square',
+            lat: 50.9795,
+            lon: 11.3235,
+            city: 'Weimar',
+            configure: static function (Location $loc): void {
+                $loc->setPois([
+                    [
+                        'id'    => 'node/301',
+                        'name'  => null,
+                        'names' => [
+                            'default'    => null,
+                            'localized'  => [],
+                            'alternates' => [],
+                        ],
+                        'categoryKey'    => 'historic',
+                        'categoryValue'  => 'monument',
+                        'distanceMeters' => 25.0,
+                        'tags'           => [
+                            'historic' => 'monument',
+                        ],
+                    ],
+                ]);
+            },
+        );
+
+        self::assertSame('Weimar', $helper->displayLabel($location));
+
+        $media = $this->makeMedia(1, '/monument.jpg', location: $location);
+
+        self::assertSame('Weimar', $helper->majorityLabel([$media]));
+    }
 }


### PR DESCRIPTION
## Summary
- prefer locality components over POI category names when resolving display labels
- ignore majority POI contexts whose label duplicates their category before falling back to media labels
- cover monument-only POIs with a regression test ensuring display and majority labels fall back to the city

## Testing
- `composer ci:test:php:unit` *(fails: missing bin/php wrapper in this environment)*
- `php vendor/bin/phpunit --configuration .build/phpunit.xml` *(fails: existing vacation clustering tests fail in this environment)*
- `php vendor/bin/phpunit --configuration .build/phpunit.xml --filter LocationHelperTest`


------
https://chatgpt.com/codex/tasks/task_e_68e2c5261bbc8323b9262e7d5366bf12