### PR TITLE
BUGFIX: Skip unnamed Overpass POIs

### DIFF
--- a/src/Service/Geocoding/DefaultOverpassResponseParser.php
+++ b/src/Service/Geocoding/DefaultOverpassResponseParser.php
@@ -74,6 +74,9 @@ final readonly class DefaultOverpassResponseParser implements OverpassResponsePa
 
             $names = $selection['names'];
             $name  = $this->poiNameExtractor->extract($names);
+            if ($name === null) {
+                continue;
+            }
 
             $pois[$id] = [
                 'id'             => $id,

--- a/test/Unit/Service/Geocoding/DefaultOverpassResponseParserTest.php
+++ b/test/Unit/Service/Geocoding/DefaultOverpassResponseParserTest.php
@@ -114,6 +114,7 @@ final class DefaultOverpassResponseParserTest extends TestCase
                     'lon'  => 3.21,
                     'tags' => [
                         'tourism' => 'attraction',
+                        'name'    => 'First Attraction',
                     ],
                 ],
                 [
@@ -123,12 +124,54 @@ final class DefaultOverpassResponseParserTest extends TestCase
                     'lon'  => 3.22,
                     'tags' => [
                         'tourism' => 'viewpoint',
+                        'name'    => 'Second Viewpoint',
                     ],
                 ],
             ],
         ];
 
         $pois = $parser->parse($payload, 1.23, 3.21, 1);
+
+        self::assertCount(1, $pois);
+        self::assertSame('node/1', $pois[0]['id']);
+    }
+
+    #[Test]
+    public function skipsElementsWithoutName(): void
+    {
+        $configuration = new OverpassTagConfiguration();
+        $parser        = new DefaultOverpassResponseParser(
+            new OverpassElementFilter(),
+            new OverpassTagSelector($configuration),
+            new OverpassPrimaryTagResolver($configuration),
+            new PoiNameExtractor(),
+        );
+
+        $payload = [
+            'elements' => [
+                [
+                    'type' => 'node',
+                    'id'   => 1,
+                    'lat'  => 1.23,
+                    'lon'  => 3.21,
+                    'tags' => [
+                        'tourism' => 'attraction',
+                        'name'    => 'Named Attraction',
+                    ],
+                ],
+                [
+                    'type' => 'node',
+                    'id'   => 2,
+                    'lat'  => 1.25,
+                    'lon'  => 3.25,
+                    'tags' => [
+                        'tourism' => 'museum',
+                    ],
+                ],
+            ],
+        ];
+
+        $pois = $parser->parse($payload, 1.23, 3.21, null);
 
         self::assertCount(1, $pois);
         self::assertSame('node/1', $pois[0]['id']);


### PR DESCRIPTION
## Summary
- skip unnamed Overpass elements when parsing POIs so nameless entries are excluded
- update the Overpass parser unit tests to keep named POIs and cover the nameless filtering behaviour

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml --filter DefaultOverpassResponseParserTest

------
https://chatgpt.com/codex/tasks/task_e_68e2c7faafc48323871d7ba2f4ff2e03