### PR TITLE
Add forced location refresh support to geocoding workflow

### DIFF
--- a/src/Service/Geocoding/DefaultGeocodingWorkflow.php
+++ b/src/Service/Geocoding/DefaultGeocodingWorkflow.php
@@ -100,7 +100,13 @@ final readonly class DefaultGeocodingWorkflow
             return;
         }
 
-        $summary = $this->mediaProcessor->process($medias, $options->refreshPois(), $options->isDryRun(), $output);
+        $summary = $this->mediaProcessor->process(
+            $medias,
+            $options->refreshPois(),
+            $options->refreshLocations(),
+            $options->isDryRun(),
+            $output,
+        );
         $summary->render($io);
 
         $locationsForPoi = $summary->getLocationsForPoiUpdate();

--- a/src/Service/Geocoding/DefaultMediaGeocodingProcessor.php
+++ b/src/Service/Geocoding/DefaultMediaGeocodingProcessor.php
@@ -40,7 +40,13 @@ final readonly class DefaultMediaGeocodingProcessor implements MediaGeocodingPro
     ) {
     }
 
-    public function process(iterable $media, bool $refreshPois, bool $dryRun, OutputInterface $output): GeocodingResultSummary
+    public function process(
+        iterable $media,
+        bool $refreshPois,
+        bool $forceRefreshLocations,
+        bool $dryRun,
+        OutputInterface $output,
+    ): GeocodingResultSummary
     {
         $medias = $this->normalizeIterable($media);
         $count  = count($medias);
@@ -58,7 +64,7 @@ final readonly class DefaultMediaGeocodingProcessor implements MediaGeocodingPro
 
         foreach ($medias as $item) {
             $progressBar->setMessage('Rückwärtssuche');
-            $location = $this->linker->link($item, $this->locale, $refreshPois);
+            $location = $this->linker->link($item, $this->locale, $forceRefreshLocations, $refreshPois);
 
             if ($location instanceof Location) {
                 ++$linked;

--- a/src/Service/Geocoding/MediaGeocodingProcessorInterface.php
+++ b/src/Service/Geocoding/MediaGeocodingProcessorInterface.php
@@ -18,5 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 interface MediaGeocodingProcessorInterface
 {
-    public function process(iterable $media, bool $refreshPois, bool $dryRun, OutputInterface $output): GeocodingResultSummary;
+    public function process(
+        iterable $media,
+        bool $refreshPois,
+        bool $forceRefreshLocations,
+        bool $dryRun,
+        OutputInterface $output,
+    ): GeocodingResultSummary;
 }

--- a/src/Service/Geocoding/MediaLocationLinkerInterface.php
+++ b/src/Service/Geocoding/MediaLocationLinkerInterface.php
@@ -19,7 +19,12 @@ use MagicSunday\Memories\Entity\Media;
  */
 interface MediaLocationLinkerInterface
 {
-    public function link(Media $media, string $acceptLanguage = 'de', bool $forceRefreshPois = false): ?Location;
+    public function link(
+        Media $media,
+        string $acceptLanguage = 'de',
+        bool $forceRefreshLocations = false,
+        bool $forceRefreshPois = false,
+    ): ?Location;
 
     public function consumeLastNetworkCalls(): int;
 }


### PR DESCRIPTION
## Summary
- propagate the forced location refresh flag from the workflow to the media geocoding processor
- update the media location linker to bypass its caches when a refresh is requested while still updating the cell index
- extend the media geocoding processor unit tests to cover the new refresh flag and forced reverse-geocoding behaviour

## Testing
- composer ci:test *(fails: `bin/php` missing in container)*
- ./vendor/bin/phpunit -c .build/phpunit.xml --filter DefaultMediaGeocodingProcessorTest


------
https://chatgpt.com/codex/tasks/task_e_68e2ca9b673483239dbb988bbb883ee8