### PR TITLE
Enhance first visit place clustering metadata

### DIFF
--- a/src/Clusterer/FirstVisitPlaceClusterStrategy.php
+++ b/src/Clusterer/FirstVisitPlaceClusterStrategy.php
@@ -16,6 +16,7 @@ use DateMalformedStringException;
 use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
+use MagicSunday\Memories\Clusterer\Support\ClusterLocationMetadataTrait;
 use MagicSunday\Memories\Clusterer\Support\ConsecutiveDaysTrait;
 use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Media;
@@ -39,11 +40,12 @@ use const SORT_STRING;
  */
 final readonly class FirstVisitPlaceClusterStrategy implements ClusterStrategyInterface
 {
+    use ClusterLocationMetadataTrait;
     use ConsecutiveDaysTrait;
     use MediaFilterTrait;
 
     public function __construct(
-        private LocationHelper $locHelper,
+        private LocationHelper $locationHelper,
         private float $gridDegrees = 0.01, // ~1.1 km in lat
         private string $timezone = 'Europe/Berlin',
         private int $minItemsPerDay = 4,
@@ -168,11 +170,8 @@ final readonly class FirstVisitPlaceClusterStrategy implements ClusterStrategyIn
                     'time_range' => $time,
                 ];
 
-                $label = $this->locHelper->majorityLabel($members);
-
-                if ($label !== null) {
-                    $params['place'] = $label;
-                }
+                $label  = $this->locationHelper->majorityLabel($members);
+                $params = $this->appendLocationMetadata($members, $params);
 
                 $draft = new ClusterDraft(
                     algorithm: 'first_visit_place',

--- a/test/Unit/Clusterer/FirstVisitPlaceClusterStrategyTest.php
+++ b/test/Unit/Clusterer/FirstVisitPlaceClusterStrategyTest.php
@@ -28,7 +28,7 @@ final class FirstVisitPlaceClusterStrategyTest extends TestCase
     {
         $helper   = LocationHelper::createDefault();
         $strategy = new FirstVisitPlaceClusterStrategy(
-            locHelper: $helper,
+            locationHelper: $helper,
             gridDegrees: 0.01,
             timezone: 'Europe/Berlin',
             minItemsPerDay: 4,
@@ -72,7 +72,17 @@ final class FirstVisitPlaceClusterStrategyTest extends TestCase
         $cluster = $clusters[0];
 
         self::assertSame('first_visit_place', $cluster->getAlgorithm());
-        self::assertSame('Innsbruck', $cluster->getParams()['place']);
+        $params = $cluster->getParams();
+
+        self::assertArrayHasKey('place', $params);
+        self::assertArrayHasKey('place_city', $params);
+        self::assertArrayHasKey('place_country', $params);
+        self::assertArrayHasKey('place_location', $params);
+
+        self::assertSame('Innsbruck', $params['place']);
+        self::assertSame('innsbruck', $params['place_city']);
+        self::assertSame('austria', $params['place_country']);
+        self::assertSame('innsbruck, austria', $params['place_location']);
         self::assertSame(
             [1200, 1201, 1202, 1203, 1210, 1211, 1212, 1213],
             $cluster->getMembers()
@@ -84,7 +94,7 @@ final class FirstVisitPlaceClusterStrategyTest extends TestCase
     {
         $helper   = LocationHelper::createDefault();
         $strategy = new FirstVisitPlaceClusterStrategy(
-            locHelper: $helper,
+            locationHelper: $helper,
             gridDegrees: 0.01,
             timezone: 'Europe/Berlin',
             minItemsPerDay: 4,


### PR DESCRIPTION
## Summary
- reuse ClusterLocationMetadataTrait inside FirstVisitPlaceClusterStrategy to populate location details on cluster params
- rename the injected LocationHelper property to align with the trait and delegate metadata enrichment to it
- extend FirstVisitPlaceClusterStrategyTest to verify the emitted place metadata keys on produced clusters

## Testing
- vendor/bin/phpunit -c .build/phpunit.xml --filter FirstVisitPlaceClusterStrategyTest

------
https://chatgpt.com/codex/tasks/task_e_68e2cfbc72a48323b28080468d11f8d7