### PR TITLE
Fix vacation spot count parameter and ensure countries always provided

### DIFF
--- a/config/templates/titles.yaml
+++ b/config/templates/titles.yaml
@@ -89,7 +89,7 @@ de:
     #   - {{ move_days }}: Tage mit signifikanter Bewegung
     #   - {{ photo_density_z }}: Standardisierte Fotodichte (z-Wert)
     #   - {{ airport_transfer }}: Flag für Flughafen- oder Bahnhofs-Transfers
-    #   - {{ spot_clusters_total }}: Anzahl der Spot-Cluster
+    #   - {{ spot_count }}: Anzahl der Spot-Cluster
     #   - {{ spot_cluster_days }}: Tage mit Spot-Clustern
     #   - {{ spot_dwell_hours }}: Aufenthaltsstunden in Spot-Clustern
     #   - {{ spot_exploration_bonus }}: Explorationsbonus (Score)
@@ -101,7 +101,7 @@ de:
     #   - {{ place_country }} (optional): Dominantes Land; Templates können bei Uneindeutigkeit auf {{ countries }} zurückgreifen
     #   - {{ primaryStaypointCity }} (optional): Stadt des längsten Aufenthalts
     #   - {{ primaryStaypointLocation }} (optional): Formatierter Aufenthaltsort des Haupt-Staypoints
-    #   - {{ countries }} (optional): Liste eindeutiger ISO-Ländercodes für Multi-Country-Reisen
+    #   - {{ countries }}: Liste eindeutiger ISO-Ländercodes (kann leer sein)
     vacation:
         title: "{{ classification_label }} – {{ place_country }}"
         subtitle: "{{ start_date }} – {{ end_date }}"

--- a/src/Clusterer/Service/VacationScoreCalculator.php
+++ b/src/Clusterer/Service/VacationScoreCalculator.php
@@ -484,7 +484,7 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
             'max_speed_kmh'            => $maxSpeedKmh,
             'avg_speed_kmh'            => $avgSpeedKmh,
             'high_speed_transit'       => $highSpeedTransit,
-            'spot_clusters_total'      => $spotClusterCount,
+            'spot_count'               => $spotClusterCount,
             'spot_cluster_days'        => $multiSpotDays,
             'spot_dwell_hours'         => round($spotDwellHours, 2),
             'spot_exploration_bonus'   => round($explorationBonus, 2),
@@ -496,6 +496,7 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
             'work_day_penalty_days'    => $workDayPenalty,
             'work_day_penalty_score'   => round($penalty, 2),
             'timezones'                => $timezones,
+            'countries'                => $countries,
         ];
 
         if ($placeComponents !== []) {
@@ -564,10 +565,6 @@ final class VacationScoreCalculator implements VacationScoreCalculatorInterface
 
         if ($primaryStaypointLocationParts !== []) {
             $params['primaryStaypointLocationParts'] = $primaryStaypointLocationParts;
-        }
-
-        if (count($countries) > 1) {
-            $params['countries'] = $countries;
         }
 
         $placeCityMissing = !isset($params['place_city']) || $params['place_city'] === '';

--- a/test/Unit/Clusterer/DefaultVacationSegmentAssemblerTest.php
+++ b/test/Unit/Clusterer/DefaultVacationSegmentAssemblerTest.php
@@ -118,6 +118,7 @@ final class DefaultVacationSegmentAssemblerTest extends TestCase
         self::assertSame('vacation', $params['classification']);
         self::assertSame(6, $params['away_days']);
         self::assertEqualsCanonicalizing([0, 60], $params['timezones']);
-        self::assertArrayNotHasKey('countries', $params);
+        self::assertArrayHasKey('countries', $params);
+        self::assertSame(['pt'], $params['countries']);
     }
 }

--- a/test/Unit/Clusterer/VacationClusterStrategyTest.php
+++ b/test/Unit/Clusterer/VacationClusterStrategyTest.php
@@ -205,13 +205,14 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertTrue($params['country_change']);
         self::assertTrue($params['timezone_change']);
         self::assertIsBool($params['airport_transfer']);
-        self::assertArrayHasKey('spot_clusters_total', $params);
+        self::assertArrayHasKey('spot_count', $params);
         self::assertArrayHasKey('spot_cluster_days', $params);
         self::assertArrayHasKey('spot_dwell_hours', $params);
         self::assertArrayHasKey('spot_exploration_bonus', $params);
         self::assertSame(5, $params['work_day_penalty_days']);
         self::assertSame(2.0, $params['work_day_penalty_score']);
-        self::assertArrayNotHasKey('countries', $params);
+        self::assertArrayHasKey('countries', $params);
+        self::assertSame(['it'], $params['countries']);
         self::assertSame([120], $params['timezones']);
         self::assertSame('Roma', $params['place_city']);
         self::assertSame('Lazio', $params['place_region']);
@@ -606,7 +607,7 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertSame('vacation', $cluster->getAlgorithm());
         self::assertSame('vacation', $params['classification']);
         self::assertGreaterThanOrEqual(8.0, $params['score']);
-        self::assertArrayHasKey('spot_clusters_total', $params);
+        self::assertArrayHasKey('spot_count', $params);
         self::assertArrayHasKey('spot_cluster_days', $params);
         self::assertArrayHasKey('spot_dwell_hours', $params);
         self::assertArrayHasKey('spot_exploration_bonus', $params);
@@ -614,7 +615,8 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertGreaterThan(0.0, $params['weekend_holiday_bonus']);
         self::assertLessThanOrEqual(2, $params['work_day_penalty_days']);
         self::assertLessThanOrEqual(0.8, $params['work_day_penalty_score']);
-        self::assertArrayNotHasKey('countries', $params);
+        self::assertArrayHasKey('countries', $params);
+        self::assertSame(['de'], $params['countries']);
         self::assertSame([120], $params['timezones']);
         self::assertArrayNotHasKey('place_city', $params);
         self::assertSame('Schleswig-Holstein', $params['place_region']);
@@ -731,7 +733,8 @@ final class VacationClusterStrategyTest extends TestCase
         self::assertGreaterThanOrEqual(8.0, $params['score']);
         self::assertLessThanOrEqual(2, $params['work_day_penalty_days']);
         self::assertLessThanOrEqual(0.8, $params['work_day_penalty_score']);
-        self::assertArrayNotHasKey('countries', $params);
+        self::assertArrayHasKey('countries', $params);
+        self::assertSame(['de'], $params['countries']);
         self::assertSame([60], $params['timezones']);
     }
 
@@ -1165,7 +1168,7 @@ final class VacationClusterStrategyTest extends TestCase
         $params = $cluster->getParams();
         self::assertSame('vacation', $params['classification']);
         self::assertGreaterThanOrEqual(8.0, $params['score']);
-        self::assertSame(4, $params['spot_clusters_total']);
+        self::assertSame(4, $params['spot_count']);
         self::assertSame(2, $params['spot_cluster_days']);
         self::assertGreaterThan(0.0, $params['spot_exploration_bonus']);
         self::assertGreaterThan(0.0, $params['spot_dwell_hours']);

--- a/test/Unit/Clusterer/VacationScoreCalculatorTest.php
+++ b/test/Unit/Clusterer/VacationScoreCalculatorTest.php
@@ -138,7 +138,8 @@ final class VacationScoreCalculatorTest extends TestCase
             $params['primaryStaypointLocationParts'],
         );
         self::assertSame('Lisbon, Lisbon District, Portugal', $params['primaryStaypointLocation']);
-        self::assertArrayNotHasKey('countries', $params);
+        self::assertArrayHasKey('countries', $params);
+        self::assertSame(['es'], $params['countries']);
         self::assertGreaterThan(8.0, $params['score']);
         self::assertSame(3, $params['spot_cluster_days']);
         self::assertSame(3, $params['total_days']);
@@ -301,7 +302,8 @@ final class VacationScoreCalculatorTest extends TestCase
         self::assertSame('Staypoint City, Spain', $params['primaryStaypointLocation']);
         self::assertSame(['Staypoint City', 'Spain'], $params['primaryStaypointLocationParts']);
         self::assertArrayNotHasKey('primaryStaypointRegion', $params);
-        self::assertArrayNotHasKey('countries', $params);
+        self::assertArrayHasKey('countries', $params);
+        self::assertSame(['es'], $params['countries']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- replace the vacation spot_clusters_total metric with spot_count and always expose the countries list
- adjust feed templates and clustering tests to read the updated parameter names and expectations

## Testing
- composer ci:test *(fails: bin/php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d148fe80832392570aa65e5256ab