### PR TITLE
Improve vacation cluster scoring and cohort handling

### DIFF
--- a/src/Clusterer/DaySummaryStage/AwayFlagStage.php
+++ b/src/Clusterer/DaySummaryStage/AwayFlagStage.php
@@ -47,13 +47,13 @@ final readonly class AwayFlagStage implements DaySummaryStageInterface
             $baseLocation               = $this->baseLocationResolver->resolve($summary, $nextSummary, $home, $timezone);
             $days[$key]['baseLocation'] = $baseLocation;
 
-            if ($baseLocation !== null && HomeBoundaryHelper::isBeyondHome($home, $baseLocation['lat'], $baseLocation['lon'])) {
+            if ($baseLocation !== null && HomeBoundaryHelper::isBeyondHome($home, $baseLocation['lat'], $baseLocation['lon'], true)) {
                 $days[$key]['baseAway'] = true;
             }
 
             if ($summary['gpsMembers'] !== [] && HomeBoundaryHelper::hasCoordinateSamples($summary['gpsMembers'])) {
                 $centroid     = MediaMath::centroid($summary['gpsMembers']);
-                $isBeyondHome = HomeBoundaryHelper::isBeyondHome($home, $centroid['lat'], $centroid['lon']);
+                $isBeyondHome = HomeBoundaryHelper::isBeyondHome($home, $centroid['lat'], $centroid['lon'], true);
 
                 if ($isBeyondHome) {
                     $days[$key]['awayByDistance'] = true;

--- a/src/Clusterer/Service/BaseLocationResolver.php
+++ b/src/Clusterer/Service/BaseLocationResolver.php
@@ -32,11 +32,11 @@ final class BaseLocationResolver implements BaseLocationResolverInterface
         $sleepProxy    = $this->computeSleepProxyLocation($summary, $nextSummary, $home);
 
         if ($staypointBase !== null) {
-            if (HomeBoundaryHelper::isBeyondHome($home, $staypointBase['lat'], $staypointBase['lon'])) {
+            if (HomeBoundaryHelper::isBeyondHome($home, $staypointBase['lat'], $staypointBase['lon'], false)) {
                 return $staypointBase;
             }
 
-            if ($sleepProxy !== null && HomeBoundaryHelper::isBeyondHome($home, $sleepProxy['lat'], $sleepProxy['lon'])) {
+            if ($sleepProxy !== null && HomeBoundaryHelper::isBeyondHome($home, $sleepProxy['lat'], $sleepProxy['lon'], false)) {
                 return $sleepProxy;
             }
 
@@ -44,7 +44,7 @@ final class BaseLocationResolver implements BaseLocationResolverInterface
         }
 
         if ($sleepProxy !== null) {
-            if (HomeBoundaryHelper::isBeyondHome($home, $sleepProxy['lat'], $sleepProxy['lon'])) {
+            if (HomeBoundaryHelper::isBeyondHome($home, $sleepProxy['lat'], $sleepProxy['lon'], false)) {
                 return $sleepProxy;
             }
 

--- a/src/Clusterer/Support/HomeBoundaryHelper.php
+++ b/src/Clusterer/Support/HomeBoundaryHelper.php
@@ -81,9 +81,23 @@ final class HomeBoundaryHelper
     /**
      * @param array{lat:float,lon:float,radius_km:float,centers?:list<array{lat:float,lon:float,radius_km:float}>} $home
      */
-    public static function isBeyondHome(array $home, float $lat, float $lon): bool
+    public static function isBeyondHome(array $home, float $lat, float $lon, bool $treatSecondaryCentersAsHome = false): bool
     {
         $nearest = self::nearestCenter($home, $lat, $lon);
+
+        if ($nearest['index'] > 0) {
+            if ($treatSecondaryCentersAsHome === false) {
+                return true;
+            }
+
+            $center       = $nearest['center'];
+            $memberCount  = (int) ($center['member_count'] ?? 0);
+            $dwellSeconds = (int) ($center['dwell_seconds'] ?? 0);
+
+            if ($memberCount > 0 || $dwellSeconds > 0) {
+                return true;
+            }
+        }
 
         return $nearest['distance_km'] > $nearest['radius_km'];
     }

--- a/src/Utility/DefaultLocationLabelResolver.php
+++ b/src/Utility/DefaultLocationLabelResolver.php
@@ -66,7 +66,7 @@ final readonly class DefaultLocationLabelResolver implements LocationLabelResolv
             $parts[] = 'county:' . $county;
         }
 
-        if ($state !== null) {
+        if ($state !== null && $city === null && $county === null) {
             $parts[] = 'state:' . $state;
         }
 


### PR DESCRIPTION
## Summary
- allow cohort presence stage to map alias person IDs onto canonical IDs and keep ratios as floats
- avoid adding redundant state information to locality keys
- distinguish manual secondary home centers from detected away clusters when checking home boundaries
- enhance vacation score calculation with adjacent weekend/holiday counting and propagate the new boundary handling

## Testing
- `vendor/bin/phpunit --configuration .build/phpunit.xml`
- `composer ci:test` *(fails: sh: 1: bin/php: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ece59a30832396ee75c003584d1e