### PR TITLE
BUGFIX: Ignore invalid POI distances

### DIFF
--- a/src/Utility/DefaultPoiContextAnalyzer.php
+++ b/src/Utility/DefaultPoiContextAnalyzer.php
@@ -18,6 +18,7 @@ use MagicSunday\Memories\Utility\Contract\PoiNormalizerInterface;
 use MagicSunday\Memories\Utility\Contract\PoiScoringStrategyInterface;
 
 use function is_array;
+use function is_finite;
 use function is_numeric;
 use function is_string;
 use function reset;
@@ -200,10 +201,16 @@ final readonly class DefaultPoiContextAnalyzer implements PoiContextAnalyzerInte
 
     private function distanceOrNull(mixed $value): ?float
     {
-        if (is_numeric($value)) {
-            return (float) $value;
+        if (!is_numeric($value)) {
+            return null;
         }
 
-        return null;
+        $distance = (float) $value;
+
+        if (!is_finite($distance) || $distance < 0.0) {
+            return null;
+        }
+
+        return $distance;
     }
 }

--- a/test/Unit/Utility/DefaultPoiContextAnalyzerTest.php
+++ b/test/Unit/Utility/DefaultPoiContextAnalyzerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Utility;
+
+use MagicSunday\Memories\Entity\Location;
+use MagicSunday\Memories\Test\TestCase;
+use MagicSunday\Memories\Utility\DefaultPoiContextAnalyzer;
+use MagicSunday\Memories\Utility\DefaultPoiLabelResolver;
+use MagicSunday\Memories\Utility\DefaultPoiNormalizer;
+use MagicSunday\Memories\Utility\DefaultPoiScorer;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DefaultPoiContextAnalyzerTest extends TestCase
+{
+    #[Test]
+    public function resolvePrimaryPoiIgnoresNegativeDistances(): void
+    {
+        $analyzer = new DefaultPoiContextAnalyzer(
+            new DefaultPoiNormalizer(),
+            new DefaultPoiScorer(),
+            new DefaultPoiLabelResolver(),
+        );
+
+        $location = $this->makeLocation(
+            providerPlaceId: 'poi-negative-distance',
+            displayName: 'Testort',
+            lat: 48.137154,
+            lon: 11.576124,
+            configure: static function (Location $loc): void {
+                $loc->setPois([
+                    [
+                        'id'    => 'node/1',
+                        'name'  => 'Ungültiger Eintrag',
+                        'names' => [
+                            'default'    => 'Ungültiger Eintrag',
+                            'localized'  => [],
+                            'alternates' => [],
+                        ],
+                        'categoryKey'    => 'tourism',
+                        'categoryValue'  => 'museum',
+                        'distanceMeters' => -5.0,
+                        'tags'           => [
+                            'tourism' => 'museum',
+                        ],
+                    ],
+                    [
+                        'id'    => 'node/2',
+                        'name'  => 'Gültiger Eintrag',
+                        'names' => [
+                            'default'    => 'Gültiger Eintrag',
+                            'localized'  => [],
+                            'alternates' => [],
+                        ],
+                        'categoryKey'    => 'tourism',
+                        'categoryValue'  => 'museum',
+                        'distanceMeters' => 10.0,
+                        'tags'           => [
+                            'tourism' => 'museum',
+                        ],
+                    ],
+                ]);
+            },
+        );
+
+        $primary = $analyzer->resolvePrimaryPoi($location);
+
+        self::assertNotNull($primary);
+        self::assertSame('Gültiger Eintrag', $primary['name']);
+    }
+}


### PR DESCRIPTION
## Summary
- treat non-finite and negative POI distances as unavailable during context analysis
- add regression test ensuring negative distances do not outrank valid POIs

## Testing
- php vendor/bin/phpunit --configuration .build/phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68e423d417ec8323997ef846ae8fd128