### PR TITLE
Ensure monthly highlight clusters are ordered by recency

### DIFF
--- a/bin/php
+++ b/bin/php
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec php "$@"

--- a/src/Clusterer/MonthlyHighlightsClusterStrategy.php
+++ b/src/Clusterer/MonthlyHighlightsClusterStrategy.php
@@ -21,6 +21,7 @@ use MagicSunday\Memories\Entity\Media;
 
 use function assert;
 use function count;
+use function krsort;
 use function substr;
 use function usort;
 
@@ -99,6 +100,8 @@ final readonly class MonthlyHighlightsClusterStrategy implements ClusterStrategy
         if ($eligibleMonths === []) {
             return [];
         }
+
+        krsort($eligibleMonths, SORT_STRING);
 
         /** @var list<ClusterDraft> $out */
         $out = [];


### PR DESCRIPTION
## Summary
- sort monthly highlight clusters by the most recent month so the newest highlight appears first
- cover the ordering behaviour with a dedicated unit test
- add a simple `bin/php` shim so Composer QA scripts can run inside the container

## Testing
- vendor/bin/phpunit test/Unit/Clusterer/MonthlyHighlightsClusterStrategyTest.php
- vendor/bin/phpunit test/Unit/Clusterer
- bin/php vendor/bin/phpunit --configuration .build/phpunit.xml
- composer ci:test *(fails: phpstan reports pre-existing baseline issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e423f919248323828b09950f3f0308