### PR TITLE
Fix phpstan issues in console commands

### DIFF
--- a/src/Command/FeedPreviewCommand.php
+++ b/src/Command/FeedPreviewCommand.php
@@ -171,7 +171,7 @@ final class FeedPreviewCommand extends Command
     }
 
     /**
-     * @param array|bool|float|int|string|null $value
+     * @param array<int, array<string, mixed>|bool|float|int|string|null>|bool|float|int|string|null $value
      */
     private function formatSceneTags(array|bool|float|int|string|null $value): string
     {

--- a/src/Command/SlideshowGenerateCommand.php
+++ b/src/Command/SlideshowGenerateCommand.php
@@ -90,9 +90,14 @@ final class SlideshowGenerateCommand extends Command
 
     private function writeError(SlideshowJob $job, Throwable $throwable): void
     {
+        $message = $throwable->getMessage();
+        if ($message === '') {
+            $message = 'Unbekannter Fehler bei der Videoerstellung.';
+        }
+
         file_put_contents(
             $job->errorPath(),
-            $throwable->getMessage() ?: 'Unbekannter Fehler bei der Videoerstellung.',
+            $message,
             LOCK_EX
         );
 


### PR DESCRIPTION
## Summary
- narrow the scene tag helper signature in `FeedPreviewCommand` so phpstan understands the accepted payload shape
- replace the short ternary in `SlideshowGenerateCommand::writeError()` with an explicit fallback assignment to satisfy strict rules

## Testing
- `vendor/bin/phpstan analyze src/Command --configuration .build/phpstan.neon --memory-limit=-1`
- `composer ci:test:php:unit`
- `composer ci:test` *(fails: phpstan reports pre-existing violations outside the command namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68e429e52fac83239ca0d3aebc802f59