### PR TITLE
Add test report for failing phpstan run

### DIFF
--- a/docs/test-report.md
+++ b/docs/test-report.md
@@ -1,0 +1,13 @@
+# Test Report
+
+Date: 2025-10-06T20:57:03Z
+
+## Command
+
+```
+composer ci:test
+```
+
+## Result
+
+The test suite failed because PHPStan reported hundreds of type-safety violations while analysing the source directory. See the captured terminal output for the detailed list of errors.


### PR DESCRIPTION
## Summary
- add `docs/test-report.md` capturing the current `composer ci:test` failure details

## Testing
- composer ci:test *(fails: PHPStan reports hundreds of type-safety violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e429f7c8e4832393d9ef0f2048b9c7