### PR TITLE
Fix composite metadata MIME guessing when files are missing

### DIFF
--- a/src/Service/Metadata/CompositeMetadataExtractor.php
+++ b/src/Service/Metadata/CompositeMetadataExtractor.php
@@ -13,6 +13,10 @@ namespace MagicSunday\Memories\Service\Metadata;
 
 use MagicSunday\Memories\Entity\Media;
 
+use function is_file;
+use function is_string;
+use function mime_content_type;
+
 /**
  * Orchestrates a sequence of specialized extractors.
  * Keeps IndexCommand unchanged: it still depends on MetadataExtractorInterface.
@@ -47,9 +51,11 @@ final readonly class CompositeMetadataExtractor implements MetadataExtractorInte
     public function extract(string $filepath, Media $media): Media
     {
         // Ensure mime is present early (if not set yet, guess it)
-        if ($media->getMime() === null) {
-            $mime = mime_content_type($filepath) ?: null;
-            $media->setMime($mime);
+        if ($media->getMime() === null && is_file($filepath)) {
+            $mime = @mime_content_type($filepath);
+            if (is_string($mime) && $mime !== '') {
+                $media->setMime($mime);
+            }
         }
 
         foreach ($this->extractors as $extractor) {

--- a/test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php
+++ b/test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Test\Unit\Service\Metadata;
+
+use MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor;
+use MagicSunday\Memories\Test\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use function is_file;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_repeat;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const E_WARNING;
+
+final class CompositeMetadataExtractorTest extends TestCase
+{
+    #[Test]
+    public function skipsMimeGuessWhenFileDoesNotExist(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'missing_media_');
+        if ($tmp === false) {
+            self::fail('Unable to allocate temporary filename.');
+        }
+
+        if (is_file($tmp) && @unlink($tmp) === false) {
+            self::fail('Unable to remove temporary placeholder.');
+        }
+
+        $media = $this->makeMedia(
+            id: 101,
+            path: $tmp,
+            checksum: str_repeat('0', 64),
+            size: 512,
+        );
+
+        $composite = new CompositeMetadataExtractor([]);
+
+        $warnings = [];
+        $handler  = static function (int $severity, string $message) use (&$warnings): bool {
+            if ($severity === E_WARNING) {
+                $warnings[] = $message;
+            }
+
+            return true;
+        };
+
+        set_error_handler($handler);
+
+        try {
+            $composite->extract($tmp, $media);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame([], $warnings);
+        self::assertNull($media->getMime());
+    }
+}


### PR DESCRIPTION
## Summary
- guard the composite metadata extractor against guessing MIME types for missing files
- ensure MIME guessing only persists non-empty strings to the media entity
- add a unit test that verifies no PHP warnings occur when the media file is absent

## Testing
- composer ci:test *(fails: phpstan reports existing 734 errors unrelated to this change)*
- composer ci:test:php:unit
- bin/php vendor/bin/phpunit --configuration .build/phpunit.xml test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e42a138c38832385d110a754deae84