### PR TITLE
Refactor metadata MIME support checks

### DIFF
--- a/src/Service/Metadata/AppleHeuristicsExtractor.php
+++ b/src/Service/Metadata/AppleHeuristicsExtractor.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Metadata;
 
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Support\ImageOrVideoSupportTrait;
 
 use function array_values;
 use function basename;
@@ -28,7 +29,6 @@ use function preg_match;
 use function scandir;
 use function sha1;
 use function sort;
-use function str_starts_with;
 use function strtolower;
 
 use const PATHINFO_EXTENSION;
@@ -39,11 +39,11 @@ use const PATHINFO_FILENAME;
  */
 final class AppleHeuristicsExtractor implements SingleMetadataExtractorInterface
 {
+    use ImageOrVideoSupportTrait;
+
     public function supports(string $filepath, Media $media): bool
     {
-        $mime = $media->getMime();
-
-        return $mime !== null && (str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/'));
+        return $this->supportsImageOrVideoMime($media);
     }
 
     public function extract(string $filepath, Media $media): Media

--- a/src/Service/Metadata/BurstDetector.php
+++ b/src/Service/Metadata/BurstDetector.php
@@ -18,14 +18,13 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Metadata\Support\ImageOrVideoSupportTrait;
 
 use function abs;
 use function array_map;
 use function count;
 use function implode;
-use function is_string;
 use function sha1;
-use function str_starts_with;
 use function strcmp;
 use function substr;
 use function trim;
@@ -36,15 +35,15 @@ use function usort;
  */
 final readonly class BurstDetector implements SingleMetadataExtractorInterface
 {
+    use ImageOrVideoSupportTrait;
+
     public function __construct(private MediaRepository $mediaRepository)
     {
     }
 
     public function supports(string $filepath, Media $media): bool
     {
-        $mime = $media->getMime();
-
-        return is_string($mime) && (str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/'));
+        return $this->supportsImageOrVideoMime($media);
     }
 
     public function extract(string $filepath, Media $media): Media

--- a/src/Service/Metadata/BurstIndexExtractor.php
+++ b/src/Service/Metadata/BurstIndexExtractor.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Metadata;
 
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\Support\ImageOrVideoSupportTrait;
 
 use function is_string;
 use function ltrim;
 use function pathinfo;
 use function preg_match;
 use function preg_replace;
-use function str_starts_with;
 
 use const PATHINFO_FILENAME;
 
@@ -27,11 +27,11 @@ use const PATHINFO_FILENAME;
  */
 final class BurstIndexExtractor implements SingleMetadataExtractorInterface
 {
+    use ImageOrVideoSupportTrait;
+
     public function supports(string $filepath, Media $media): bool
     {
-        $mime = $media->getMime();
-
-        return is_string($mime) && (str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/'));
+        return $this->supportsImageOrVideoMime($media);
     }
 
     public function extract(string $filepath, Media $media): Media

--- a/src/Service/Metadata/LivePairLinker.php
+++ b/src/Service/Metadata/LivePairLinker.php
@@ -14,13 +14,12 @@ namespace MagicSunday\Memories\Service\Metadata;
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Repository\MediaRepository;
+use MagicSunday\Memories\Service\Metadata\Support\ImageOrVideoSupportTrait;
 
 use function abs;
 use function array_map;
 use function implode;
-use function is_string;
 use function sha1;
-use function str_starts_with;
 use function trim;
 use function usort;
 
@@ -29,15 +28,15 @@ use function usort;
  */
 final readonly class LivePairLinker implements SingleMetadataExtractorInterface
 {
+    use ImageOrVideoSupportTrait;
+
     public function __construct(private MediaRepository $mediaRepository)
     {
     }
 
     public function supports(string $filepath, Media $media): bool
     {
-        $mime = $media->getMime();
-
-        return is_string($mime) && (str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/'));
+        return $this->supportsImageOrVideoMime($media);
     }
 
     public function extract(string $filepath, Media $media): Media

--- a/src/Service/Metadata/Support/ImageOrVideoSupportTrait.php
+++ b/src/Service/Metadata/Support/ImageOrVideoSupportTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+use MagicSunday\Memories\Entity\Media;
+
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Provides a shared implementation to detect image or video media by MIME type.
+ */
+trait ImageOrVideoSupportTrait
+{
+    private function supportsImageOrVideoMime(Media $media): bool
+    {
+        $mime = $media->getMime();
+
+        if (!is_string($mime)) {
+            return false;
+        }
+
+        return str_starts_with($mime, 'image/') || str_starts_with($mime, 'video/');
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared ImageOrVideoSupportTrait to centralize MIME guards for metadata extractors
- reuse the trait in AppleHeuristicsExtractor, BurstDetector, BurstIndexExtractor, and LivePairLinker to remove duplicate code

## Testing
- composer ci:test *(fails: phpstan reports existing baseline issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e435afec8483238ae07d78cd90f171