### PR TITLE
Enhance device similarity clusters with dominant tags

### DIFF
--- a/src/Clusterer/DeviceSimilarityStrategy.php
+++ b/src/Clusterer/DeviceSimilarityStrategy.php
@@ -119,6 +119,11 @@ final readonly class DeviceSimilarityStrategy implements ClusterStrategyInterfac
             $peopleParams = $this->buildPeopleParams($group);
             $params       = [...$params, ...$peopleParams];
 
+            $tagMetadata = $this->collectDominantTags($group);
+            if ($tagMetadata !== []) {
+                $params = [...$params, ...$tagMetadata];
+            }
+
             $drafts[] = new ClusterDraft(
                 algorithm: $this->name(),
                 params: $params,


### PR DESCRIPTION
## Summary
- merge dominant scene tags and keywords into device similarity cluster parameters to expose recurring motifs

## Testing
- `composer ci:test` *(fails: phpstan reports existing baseline issues about strict docblock type assumptions)*

------
https://chatgpt.com/codex/tasks/task_e_68e437ff2cbc8323994f59a23de2f1dc