### PR TITLE
Add quality and people aggregates to monthly highlights clusters

### DIFF
--- a/test/Unit/Clusterer/MonthlyHighlightsClusterStrategyTest.php
+++ b/test/Unit/Clusterer/MonthlyHighlightsClusterStrategyTest.php
@@ -56,6 +56,18 @@ final class MonthlyHighlightsClusterStrategyTest extends TestCase
         self::assertSame([1, 2, 3, 4], $cluster->getMembers());
         self::assertArrayHasKey('scene_tags', $params);
         self::assertArrayHasKey('keywords', $params);
+        self::assertArrayHasKey('quality_avg', $params);
+        self::assertIsFloat($params['quality_avg']);
+        self::assertArrayHasKey('people', $params);
+        self::assertArrayHasKey('people_count', $params);
+        self::assertArrayHasKey('people_unique', $params);
+        self::assertArrayHasKey('people_coverage', $params);
+        self::assertArrayHasKey('people_face_coverage', $params);
+        self::assertSame(0.0, $params['people']);
+        self::assertSame(0, $params['people_count']);
+        self::assertSame(0, $params['people_unique']);
+        self::assertSame(0.0, $params['people_coverage']);
+        self::assertSame(0.0, $params['people_face_coverage']);
         $sceneTags = $params['scene_tags'];
         self::assertCount(1, $sceneTags);
         self::assertSame('Stadt', $sceneTags[0]['label']);

--- a/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
+++ b/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
@@ -126,6 +126,25 @@ final class ClusterPersistenceServiceTest extends TestCase
         self::assertSame(1, $draft->getVideoCount());
         self::assertNotNull($draft->getConfigHash());
         self::assertSame(GeoCell::fromPoint(48.123456, 11.654321, 7), $draft->getCentroidCell7());
+
+        $params = $draft->getParams();
+        self::assertArrayHasKey('quality_avg', $params);
+        self::assertGreaterThan(0.0, $params['quality_avg']);
+        self::assertArrayHasKey('people', $params);
+        self::assertSame(0.0, $params['people']);
+        self::assertArrayHasKey('people_count', $params);
+        self::assertSame(0, $params['people_count']);
+        self::assertArrayHasKey('people_unique', $params);
+        self::assertSame(0, $params['people_unique']);
+        self::assertArrayHasKey('people_coverage', $params);
+        self::assertSame(0.0, $params['people_coverage']);
+        self::assertArrayHasKey('people_face_coverage', $params);
+        self::assertSame(0.0, $params['people_face_coverage']);
+
+        $persistedParams = $persisted->getParams();
+        self::assertArrayHasKey('quality_avg', $persistedParams);
+        self::assertArrayHasKey('people', $persistedParams);
+        self::assertArrayHasKey('people_count', $persistedParams);
     }
 
     /**


### PR DESCRIPTION
## Summary
- compute monthly highlight quality metrics via `ClusterQualityAggregator` and retain them on the draft
- refresh quality and people aggregates during persistence so stored parameters reflect the final member list
- extend unit coverage for monthly highlights and persistence to assert the new metadata fields

## Testing
- composer ci:test *(fails: phpstan reports existing type analysis issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e438746c1c832390ac62b2095a9d13