### PR TITLE
Add persistence coverage for new cluster parameters

### DIFF
--- a/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
+++ b/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
@@ -97,6 +97,11 @@ final class ClusterPersistenceServiceTest extends TestCase
             params: [
                 'version'        => '2024.1',
                 'member_quality' => ['ordered' => [2, 1, 3]],
+                'movement'       => [
+                    'segment_count'      => 4,
+                    'fast_segment_ratio' => 0.5,
+                    'avg_speed_mps'      => 12.3,
+                ],
             ],
             centroid: ['lat' => 48.123456, 'lon' => 11.654321],
             members: [1, 2, 3],
@@ -130,6 +135,8 @@ final class ClusterPersistenceServiceTest extends TestCase
         $params = $draft->getParams();
         self::assertArrayHasKey('quality_avg', $params);
         self::assertGreaterThan(0.0, $params['quality_avg']);
+        self::assertArrayHasKey('quality_resolution', $params);
+        self::assertGreaterThan(0.0, $params['quality_resolution']);
         self::assertArrayHasKey('people', $params);
         self::assertSame(0.0, $params['people']);
         self::assertArrayHasKey('people_count', $params);
@@ -140,11 +147,24 @@ final class ClusterPersistenceServiceTest extends TestCase
         self::assertSame(0.0, $params['people_coverage']);
         self::assertArrayHasKey('people_face_coverage', $params);
         self::assertSame(0.0, $params['people_face_coverage']);
+        self::assertArrayHasKey('movement', $params);
+        self::assertSame([
+            'segment_count'      => 4,
+            'fast_segment_ratio' => 0.5,
+            'avg_speed_mps'      => 12.3,
+        ], $params['movement']);
 
         $persistedParams = $persisted->getParams();
         self::assertArrayHasKey('quality_avg', $persistedParams);
+        self::assertArrayHasKey('quality_resolution', $persistedParams);
         self::assertArrayHasKey('people', $persistedParams);
         self::assertArrayHasKey('people_count', $persistedParams);
+        self::assertArrayHasKey('movement', $persistedParams);
+        self::assertSame([
+            'segment_count'      => 4,
+            'fast_segment_ratio' => 0.5,
+            'avg_speed_mps'      => 12.3,
+        ], $persistedParams['movement']);
     }
 
     /**

--- a/test/Unit/Support/ClusterEntityToDraftMapperTest.php
+++ b/test/Unit/Support/ClusterEntityToDraftMapperTest.php
@@ -54,4 +54,51 @@ final class ClusterEntityToDraftMapperTest extends TestCase
 
         self::assertSame('custom_group', $drafts[0]->getParams()['group']);
     }
+
+    #[Test]
+    public function mapManyPreservesExtendedParameters(): void
+    {
+        $movement = [
+            'segment_count'      => 5,
+            'fast_segment_ratio' => 0.4,
+            'avg_speed_mps'      => 8.1,
+        ];
+
+        $params = [
+            'score'                => 0.95,
+            'group'                => 'travel_and_places',
+            'quality_avg'          => 0.82,
+            'quality_resolution'   => 0.91,
+            'people'               => 0.5,
+            'people_count'         => 6,
+            'people_unique'        => 3,
+            'people_coverage'      => 0.75,
+            'people_face_coverage' => 0.5,
+            'movement'             => $movement,
+        ];
+
+        $entity = new Cluster(
+            algorithm: 'vacation',
+            params: $params,
+            centroid: ['lat' => 1.0, 'lon' => 2.0],
+            members: [3, 1, 2],
+        );
+
+        $mapper = new ClusterEntityToDraftMapper(['vacation' => 'travel_and_places']);
+
+        $drafts = $mapper->mapMany([$entity]);
+
+        self::assertCount(1, $drafts);
+
+        $draftParams = $drafts[0]->getParams();
+
+        self::assertSame(0.82, $draftParams['quality_avg']);
+        self::assertSame(0.91, $draftParams['quality_resolution']);
+        self::assertSame(0.5, $draftParams['people']);
+        self::assertSame(6, $draftParams['people_count']);
+        self::assertSame(3, $draftParams['people_unique']);
+        self::assertSame(0.75, $draftParams['people_coverage']);
+        self::assertSame(0.5, $draftParams['people_face_coverage']);
+        self::assertSame($movement, $draftParams['movement']);
+    }
 }


### PR DESCRIPTION
## Summary
- extend ClusterPersistenceServiceTest to assert quality, people, and movement parameters are persisted alongside metadata
- cover ClusterEntityToDraftMapper to ensure extended parameters survive rehydration for downstream heuristics

## Testing
- composer ci:test *(fails: phpstan reports existing baseline violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e43a8b99b48323962e22ae0f68cd15