### PR TITLE
Enrich person-centric cluster metadata

### DIFF
--- a/src/Clusterer/NightlifeEventClusterStrategy.php
+++ b/src/Clusterer/NightlifeEventClusterStrategy.php
@@ -13,6 +13,7 @@ namespace MagicSunday\Memories\Clusterer;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use MagicSunday\Memories\Clusterer\Support\ClusterBuildHelperTrait;
 use MagicSunday\Memories\Clusterer\Support\LocalTimeHelper;
 use MagicSunday\Memories\Clusterer\Support\MediaFilterTrait;
 use MagicSunday\Memories\Entity\Media;
@@ -20,7 +21,6 @@ use MagicSunday\Memories\Utility\LocationHelper;
 use MagicSunday\Memories\Utility\MediaMath;
 
 use function array_any;
-use function array_map;
 use function array_values;
 use function assert;
 use function count;
@@ -38,6 +38,7 @@ use function usort;
 final readonly class NightlifeEventClusterStrategy implements ClusterStrategyInterface
 {
     use MediaFilterTrait;
+    use ClusterBuildHelperTrait;
 
     public function __construct(
         private LocalTimeHelper $localTimeHelper,
@@ -156,6 +157,9 @@ final readonly class NightlifeEventClusterStrategy implements ClusterStrategyInt
                 'time_range' => $time,
             ];
 
+            $peopleParams = $this->buildPeopleParams($run);
+            $params       = [...$params, ...$peopleParams];
+
             if ($hasNight === true) {
                 $params['feature_daypart'] = 'night';
             }
@@ -184,7 +188,7 @@ final readonly class NightlifeEventClusterStrategy implements ClusterStrategyInt
                 algorithm: 'nightlife_event',
                 params: $params,
                 centroid: ['lat' => $centroid['lat'], 'lon' => $centroid['lon']],
-                members: array_map(static fn (Media $m): int => $m->getId(), $run)
+                members: $this->toMemberIds($run)
             );
         }
 

--- a/src/Clusterer/Support/ClusterLocationMetadataTrait.php
+++ b/src/Clusterer/Support/ClusterLocationMetadataTrait.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Clusterer\Support;
 
+use MagicSunday\Memories\Clusterer\ClusterDraft;
 use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Utility\LocationHelper;
 
@@ -114,6 +115,20 @@ trait ClusterLocationMetadataTrait
         }
 
         return $params;
+    }
+
+    /**
+     * Applies location metadata to a cluster draft.
+     *
+     * @param list<Media> $members
+     */
+    private function applyLocationMetadata(ClusterDraft $draft, array $members): void
+    {
+        $params = $this->appendLocationMetadata($members, $draft->getParams());
+
+        foreach ($params as $key => $value) {
+            $draft->setParam($key, $value);
+        }
     }
 
     private function normalizeLocationComponent(string $value): string

--- a/src/Service/Clusterer/Scoring/PeopleClusterScoreHeuristic.php
+++ b/src/Service/Clusterer/Scoring/PeopleClusterScoreHeuristic.php
@@ -39,6 +39,7 @@ final class PeopleClusterScoreHeuristic extends AbstractClusterScoreHeuristic
         $cluster->setParam('people_count', $peopleMetrics['mentions']);
         $cluster->setParam('people_unique', $peopleMetrics['unique']);
         $cluster->setParam('people_coverage', $peopleMetrics['coverage']);
+        $cluster->setParam('people_face_coverage', $peopleMetrics['faceCoverage']);
     }
 
     public function score(ClusterDraft $cluster): float
@@ -58,7 +59,7 @@ final class PeopleClusterScoreHeuristic extends AbstractClusterScoreHeuristic
      * @param int                 $members
      * @param array<string,mixed> $params
      *
-     * @return array{score:float,unique:int,mentions:int,coverage:float}
+     * @return array{score:float,unique:int,mentions:int,coverage:float,faceCoverage:float}
      */
     private function computePeopleMetrics(array $mediaItems, int $members, array $params): array
     {
@@ -69,12 +70,14 @@ final class PeopleClusterScoreHeuristic extends AbstractClusterScoreHeuristic
             $mentions = (int) ($params['people_count'] ?? 0);
             $unique   = (int) ($params['people_unique'] ?? 0);
             $coverage = $this->clamp01($this->floatOrNull($params['people_coverage'] ?? null));
+            $face     = $this->clamp01($this->floatOrNull($params['people_face_coverage'] ?? null));
 
             return [
                 'score'    => $score,
                 'unique'   => $unique,
                 'mentions' => $mentions,
                 'coverage' => $coverage,
+                'faceCoverage' => $face,
             ];
         }
 
@@ -86,6 +89,7 @@ final class PeopleClusterScoreHeuristic extends AbstractClusterScoreHeuristic
             'unique'   => $peopleParams['people_unique'],
             'mentions' => $peopleParams['people_count'],
             'coverage' => $peopleParams['people_coverage'],
+            'faceCoverage' => $peopleParams['people_face_coverage'],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- integrate the shared people metric aggregator into the nightlife clustering strategy
- extend person cohort drafts with dominant tag collection and location metadata helpers
- expose the location metadata helper on cluster drafts and persist face coverage in the people heuristic

## Testing
- composer ci:test *(fails: phpstan reports 787 pre-existing analysis errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bb35cbac8323b43c2d07f6bb2c5c