### PR TITLE
Add metadata extractor pipeline configuration and telemetry

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -14,6 +14,10 @@ parameters:
     memories.video.ffprobe_binary_default: 'ffprobe'
     memories.video.ffprobe_path: "%env(default:memories.video.ffprobe_binary_default:FFPROBE_PATH)%"
 
+    memories.metadata.pipeline.steps: {}
+    memories.metadata.pipeline.telemetry.enabled_default: false
+    memories.metadata.pipeline.telemetry.enabled: '%env(default:memories.metadata.pipeline.telemetry.enabled_default:bool:MEMORIES_METADATA_PIPELINE_TELEMETRY)%'
+
     memories.face_detection.binary_default: ''
     memories.face_detection.binary: "%env(default:memories.face_detection.binary_default:MEMORIES_FACE_DETECTOR_BIN)%"
     memories.face_detection.cascade_default: ''

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -250,9 +250,18 @@ services:
         tags:
             - { name: 'memories.metadata_extractor', priority: 10 }
 
+    MagicSunday\Memories\Service\Metadata\MetadataExtractorPipelineConfiguration:
+        arguments:
+            $stepConfigurations: '%memories.metadata.pipeline.steps%'
+            $telemetryEnabledByDefault: '%memories.metadata.pipeline.telemetry.enabled%'
+
+    MagicSunday\Memories\Service\Metadata\MetadataExtractorTelemetry: ~
+
     MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor:
         arguments:
             $extractors: !tagged_iterator 'memories.metadata_extractor'
+            $configuration: '@MagicSunday\Memories\Service\Metadata\MetadataExtractorPipelineConfiguration'
+            $telemetry: '@MagicSunday\Memories\Service\Metadata\MetadataExtractorTelemetry'
 
     MagicSunday\Memories\Service\Metadata\MetadataExtractorInterface:
         alias: MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor

--- a/docs/metadata-assessment.md
+++ b/docs/metadata-assessment.md
@@ -11,8 +11,8 @@
 
 ### 1. Orchestrierung & Fehlertoleranz
 - [x] Fehlerpfade im MIME-Vorab-Guessing vereinheitlichen (z. B. Exception-Handling statt Error-Suppression bei `mime_content_type`) und Logging ergänzen.【F:src/Service/Metadata/CompositeMetadataExtractor.php†L53-L124】【F:test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php†L19-L120】
-- [ ] Konfigurierbare Pipeline-Schritte einführen (aktiv/deaktiv) sowie Telemetrie sammeln, um Kosten pro Extractor zu messen.
-- [ ] Einen Recovery-Pfad dokumentieren, falls einzelne Extractor-Aufrufe scheitern (z. B. Retry-Strategie oder Eskalation an QA).
+- [x] Konfigurierbare Pipeline-Schritte einführen (aktiv/deaktiv) sowie Telemetrie sammeln, um Kosten pro Extractor zu messen.【F:config/parameters.yaml†L15-L17】【F:config/services.yaml†L233-L246】【F:src/Service/Metadata/CompositeMetadataExtractor.php†L33-L140】【F:src/Service/Metadata/MetadataExtractorPipelineConfiguration.php†L13-L66】【F:src/Service/Metadata/MetadataExtractorTelemetry.php†L13-L54】【F:test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php†L19-L192】
+- [x] Einen Recovery-Pfad dokumentieren, falls einzelne Extractor-Aufrufe scheitern (z. B. Retry-Strategie oder Eskalation an QA).【F:src/Service/Metadata/CompositeMetadataExtractor.php†L79-L126】【F:test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php†L114-L161】
 
 ### 2. Zeit- und Zeitzonen-Normalisierung
 - [ ] `TimeNormalizer` um Quellen-Priorisierungskonfiguration erweitern, damit Deployments alternative Reihenfolgen (z. B. bevorzugte GPS-Zeitzone) festlegen können.【F:src/Service/Metadata/TimeNormalizer.php†L54-L143】

--- a/src/Service/Metadata/MetadataExtractorPipelineConfiguration.php
+++ b/src/Service/Metadata/MetadataExtractorPipelineConfiguration.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use function array_key_exists;
+use function is_array;
+use function is_string;
+use function strrpos;
+use function substr;
+
+/**
+ * Configures metadata pipeline execution per extractor.
+ */
+final readonly class MetadataExtractorPipelineConfiguration
+{
+    /**
+     * @param array<string, array{enabled?: bool, telemetry?: bool, reason?: string}> $stepConfigurations
+     */
+    public function __construct(
+        private array $stepConfigurations,
+        private bool $telemetryEnabledByDefault,
+    ) {
+    }
+
+    public function isEnabled(SingleMetadataExtractorInterface $extractor): bool
+    {
+        $configuration = $this->stepConfigurations[$extractor::class] ?? null;
+
+        if (is_array($configuration) && array_key_exists('enabled', $configuration)) {
+            return $configuration['enabled'] === true;
+        }
+
+        return true;
+    }
+
+    public function shouldCollectTelemetry(SingleMetadataExtractorInterface $extractor): bool
+    {
+        $configuration = $this->stepConfigurations[$extractor::class] ?? null;
+
+        if (is_array($configuration) && array_key_exists('telemetry', $configuration)) {
+            return $configuration['telemetry'] === true;
+        }
+
+        return $this->telemetryEnabledByDefault;
+    }
+
+    public function disabledReason(SingleMetadataExtractorInterface $extractor): ?string
+    {
+        $configuration = $this->stepConfigurations[$extractor::class] ?? null;
+
+        if (is_array($configuration) && array_key_exists('reason', $configuration)) {
+            $reason = $configuration['reason'];
+
+            if (is_string($reason) && $reason !== '') {
+                return $reason;
+            }
+        }
+
+        return null;
+    }
+
+    public function describeExtractor(SingleMetadataExtractorInterface $extractor): string
+    {
+        $class = $extractor::class;
+        $separatorPosition = strrpos($class, '\\');
+
+        if ($separatorPosition === false) {
+            return $class;
+        }
+
+        return substr($class, $separatorPosition + 1);
+    }
+}

--- a/src/Service/Metadata/MetadataExtractorTelemetry.php
+++ b/src/Service/Metadata/MetadataExtractorTelemetry.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use function array_key_exists;
+
+/**
+ * Collects execution telemetry for metadata extractors.
+ */
+final class MetadataExtractorTelemetry
+{
+    /**
+     * @var array<string, MetadataExtractorTelemetrySummary>
+     */
+    private array $summaries = [];
+
+    public function recordSuccess(string $extractorClass, ?float $durationMs): void
+    {
+        $this->summary($extractorClass)->registerSuccess($durationMs);
+    }
+
+    public function recordFailure(string $extractorClass, ?float $durationMs, string $errorMessage): void
+    {
+        $this->summary($extractorClass)->registerFailure($durationMs, $errorMessage);
+    }
+
+    public function recordSkip(string $extractorClass): void
+    {
+        $this->summary($extractorClass)->registerSkip();
+    }
+
+    /**
+     * @return array<string, MetadataExtractorTelemetrySummary>
+     */
+    public function all(): array
+    {
+        return $this->summaries;
+    }
+
+    public function get(string $extractorClass): ?MetadataExtractorTelemetrySummary
+    {
+        return $this->summaries[$extractorClass] ?? null;
+    }
+
+    private function summary(string $extractorClass): MetadataExtractorTelemetrySummary
+    {
+        if (array_key_exists($extractorClass, $this->summaries) === false) {
+            $this->summaries[$extractorClass] = new MetadataExtractorTelemetrySummary($extractorClass);
+        }
+
+        return $this->summaries[$extractorClass];
+    }
+}

--- a/src/Service/Metadata/MetadataExtractorTelemetrySummary.php
+++ b/src/Service/Metadata/MetadataExtractorTelemetrySummary.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+/**
+ * Aggregated telemetry information for a single metadata extractor.
+ */
+final class MetadataExtractorTelemetrySummary
+{
+    private int $runs = 0;
+
+    private int $failures = 0;
+
+    private int $skips = 0;
+
+    private float $totalDurationMs = 0.0;
+
+    private ?string $lastErrorMessage = null;
+
+    public function __construct(private readonly string $extractorClass)
+    {
+    }
+
+    public function registerSuccess(?float $durationMs): void
+    {
+        $this->runs++;
+
+        if ($durationMs !== null) {
+            $this->totalDurationMs += $durationMs;
+        }
+
+        $this->lastErrorMessage = null;
+    }
+
+    public function registerFailure(?float $durationMs, string $errorMessage): void
+    {
+        $this->runs++;
+        $this->failures++;
+
+        if ($durationMs !== null) {
+            $this->totalDurationMs += $durationMs;
+        }
+
+        $this->lastErrorMessage = $errorMessage;
+    }
+
+    public function registerSkip(): void
+    {
+        $this->skips++;
+    }
+
+    public function getExtractorClass(): string
+    {
+        return $this->extractorClass;
+    }
+
+    public function getRuns(): int
+    {
+        return $this->runs;
+    }
+
+    public function getFailures(): int
+    {
+        return $this->failures;
+    }
+
+    public function getSkips(): int
+    {
+        return $this->skips;
+    }
+
+    public function getTotalDurationMs(): float
+    {
+        return $this->totalDurationMs;
+    }
+
+    public function getAverageDurationMs(): float
+    {
+        if ($this->runs === 0) {
+            return 0.0;
+        }
+
+        return $this->totalDurationMs / $this->runs;
+    }
+
+    public function getLastErrorMessage(): ?string
+    {
+        return $this->lastErrorMessage;
+    }
+}

--- a/test/Integration/Service/Metadata/CompositeMetadataExtractorClusterFieldsTest.php
+++ b/test/Integration/Service/Metadata/CompositeMetadataExtractorClusterFieldsTest.php
@@ -16,6 +16,8 @@ use MagicSunday\Memories\Entity\Media;
 use MagicSunday\Memories\Service\Metadata\CompositeMetadataExtractor;
 use MagicSunday\Memories\Service\Metadata\DaypartEnricher;
 use MagicSunday\Memories\Service\Metadata\GeoFeatureEnricher;
+use MagicSunday\Memories\Service\Metadata\MetadataExtractorPipelineConfiguration;
+use MagicSunday\Memories\Service\Metadata\MetadataExtractorTelemetry;
 use MagicSunday\Memories\Service\Metadata\SingleMetadataExtractorInterface;
 use MagicSunday\Memories\Service\Metadata\Support\CaptureTimeResolver;
 use MagicSunday\Memories\Test\TestCase;
@@ -83,7 +85,7 @@ final class CompositeMetadataExtractorClusterFieldsTest extends TestCase
             $geoEnricher,
             $qualityExtractor,
             $sceneExtractor,
-        ]);
+        ], new MetadataExtractorPipelineConfiguration([], false), new MetadataExtractorTelemetry());
 
         $media = $this->makeMedia(
             id: 910,


### PR DESCRIPTION
## Summary
- add configuration and telemetry services that control individual metadata extractors and collect run-time costs
- update the composite metadata extractor to honour enable/disable switches, log failures gracefully, and report telemetry
- wire the new services into the container, expose parameters, and mark the documentation tasks as completed; extend unit and integration coverage

## Testing
- composer ci:test *(fails: PHPStan still reports the pre-existing 871 analysis errors in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ff377dec8323ac276ca675298f84