### PR TITLE
Implement configurable time normalization and solar caching

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -59,6 +59,9 @@ parameters:
 
     memories.timezone.default: 'UTC'
     memories.cluster.timezone.default: 'Europe/Berlin'
+    memories.time.normalizer.source_priority: ['filename','file_mtime']
+    memories.time.normalizer.max_offset_minutes_default: 720
+    memories.time.normalizer.max_offset_minutes: '%env(default:memories.time.normalizer.max_offset_minutes_default:int:MEMORIES_TIME_NORMALIZER_MAX_OFFSET_MINUTES)%'
 
     memories.cluster.transport_speed.min_leg_duration_minutes_default: 5.0
     memories.cluster.transport_speed.min_leg_distance_km_default: 10.0

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -162,6 +162,8 @@ services:
     MagicSunday\Memories\Service\Metadata\TimeNormalizer:
         arguments:
             $defaultTimezone: '%memories.timezone.default%'
+            $sourcePriority: '%memories.time.normalizer.source_priority%'
+            $plausibilityThresholdMinutes: '%memories.time.normalizer.max_offset_minutes%'
         tags:
             - { name: 'memories.metadata_extractor', priority: 100 }
 

--- a/docs/metadata-assessment.md
+++ b/docs/metadata-assessment.md
@@ -15,10 +15,10 @@
 - [x] Einen Recovery-Pfad dokumentieren, falls einzelne Extractor-Aufrufe scheitern (z. B. Retry-Strategie oder Eskalation an QA).【F:src/Service/Metadata/CompositeMetadataExtractor.php†L79-L126】【F:test/Unit/Service/Metadata/CompositeMetadataExtractorTest.php†L114-L161】
 
 ### 2. Zeit- und Zeitzonen-Normalisierung
-- [ ] `TimeNormalizer` um Quellen-Priorisierungskonfiguration erweitern, damit Deployments alternative Reihenfolgen (z. B. bevorzugte GPS-Zeitzone) festlegen können.【F:src/Service/Metadata/TimeNormalizer.php†L54-L143】
-- [ ] Zusätzliche Plausibilitätsprüfungen implementieren (z. B. Abgleich zwischen `takenAt` und Dateisystemzeit zur Erkennung verdächtiger Abweichungen) inklusive Index-Log-Einträgen.
-- [ ] `SolarEnricher` mit Caching für wiederkehrende Koordinaten und verbesserter Behandlung polarer Tage/Nächte ergänzen, um unnötige Neuberechnungen zu vermeiden.【F:src/Service/Metadata/SolarEnricher.php†L35-L158】
-- [ ] QA-Checks erweitern (z. B. Prüfung auf `timezoneOffsetMin`, `tzConfidence`) und automatisch Korrekturmaßnahmen vorschlagen.【F:src/Service/Metadata/MetadataQaInspector.php†L21-L55】
+- [x] `TimeNormalizer` um Quellen-Priorisierungskonfiguration erweitern, damit Deployments alternative Reihenfolgen (z. B. bevorzugte GPS-Zeitzone) festlegen können.【F:src/Service/Metadata/TimeNormalizer.php†L33-L205】
+- [x] Zusätzliche Plausibilitätsprüfungen implementieren (z. B. Abgleich zwischen `takenAt` und Dateisystemzeit zur Erkennung verdächtiger Abweichungen) inklusive Index-Log-Einträgen.【F:src/Service/Metadata/TimeNormalizer.php†L153-L205】
+- [x] `SolarEnricher` mit Caching für wiederkehrende Koordinaten und verbesserter Behandlung polarer Tage/Nächte ergänzen, um unnötige Neuberechnungen zu vermeiden.【F:src/Service/Metadata/SolarEnricher.php†L18-L200】【F:src/Service/Metadata/Support/SolarEventCache.php†L13-L32】【F:src/Service/Metadata/Support/SolarEventResult.php†L13-L33】
+- [x] QA-Checks erweitern (z. B. Prüfung auf `timezoneOffsetMin`, `tzConfidence`) und automatisch Korrekturmaßnahmen vorschlagen.【F:src/Service/Metadata/MetadataQaInspector.php†L15-L82】
 
 ### 3. Feature-Taxonomie & Datenmodell
 - [ ] Das freie `features`-Array durch einen typisierten Value-Object-Ansatz ersetzen oder zumindest Namespaces/Hydration-Helper definieren, um Key-Kollisionen zu verhindern.【F:src/Service/Metadata/DaypartEnricher.php†L49-L51】【F:src/Service/Metadata/CalendarFeatureEnricher.php†L46-L62】

--- a/src/Service/Metadata/Support/SolarEventCache.php
+++ b/src/Service/Metadata/Support/SolarEventCache.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+/**
+ * In-memory cache for solar event calculations.
+ */
+final class SolarEventCache
+{
+    /**
+     * @var array<string, SolarEventResult>
+     */
+    private array $store = [];
+
+    public function get(string $key): ?SolarEventResult
+    {
+        return $this->store[$key] ?? null;
+    }
+
+    public function set(string $key, SolarEventResult $value): void
+    {
+        $this->store[$key] = $value;
+    }
+}

--- a/src/Service/Metadata/Support/SolarEventResult.php
+++ b/src/Service/Metadata/Support/SolarEventResult.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata\Support;
+
+/**
+ * Represents cached sunrise and sunset information for a coordinate/day pair.
+ */
+final class SolarEventResult
+{
+    public function __construct(
+        public readonly ?int $sunriseUtc,
+        public readonly ?int $sunsetUtc,
+        public readonly bool $isPolarDay,
+        public readonly bool $isPolarNight,
+    ) {
+    }
+
+    public function isRegularDay(): bool
+    {
+        return !$this->isPolarDay && !$this->isPolarNight;
+    }
+}


### PR DESCRIPTION
## Summary
- make the time normaliser configurable for fallback priorities and emit filesystem plausibility warnings
- cache solar computations, expose polar day/night flags and extend QA checks with timezone guidance
- cover the new behaviour with unit tests and mark the related documentation tasks as completed

## Testing
- composer ci:test *(fails: phpstan reports pre-existing issues across the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68e501d147b88323a461fb39d119a75b