### PR TITLE
Add structured metadata QA inspection results

### DIFF
--- a/docs/metadata-assessment.md
+++ b/docs/metadata-assessment.md
@@ -36,7 +36,7 @@
 - [ ] Qualitätsmetriken aus `MediaQualityAggregator` mit Zeitbezug (z. B. ISO-Schwelle abhängig vom Aufnahmedatum) versehen und Logging weiter strukturieren.【F:src/Service/Metadata/Quality/MediaQualityAggregator.php†L13-L132】
 
 ### 6. QA & Beobachtbarkeit
-- [ ] `MetadataQaInspector` um strukturierte Ergebnisse erweitern (statt Log-Zeilen), damit der Indexprozess maschinell reagieren kann.【F:src/Service/Metadata/MetadataQaInspector.php†L32-L55】
+- [x] `MetadataQaInspector` um strukturierte Ergebnisse erweitern (statt Log-Zeilen), damit der Indexprozess maschinell reagieren kann.【F:src/Service/Metadata/MetadataQaInspector.php†L24-L78】【F:src/Service/Metadata/MetadataQaInspectionResult.php†L13-L69】【F:src/Service/Indexing/Contract/MediaIngestionContext.php†L19-L214】【F:src/Service/Indexing/Stage/TimeStage.php†L19-L87】
 - [ ] Einheitliches Index-Log-Schema definieren und in allen Extractoren anwenden (aktuell schreiben nur ausgewählte Klassen aggregierte Meldungen).
 - [ ] Dashboards/Reports für fehlende oder widersprüchliche Metadaten erstellen (z. B. Tageszeit ohne Zeitzone, Golden Hour ohne GPS).
 

--- a/src/Service/Indexing/Contract/MediaIngestionContext.php
+++ b/src/Service/Indexing/Contract/MediaIngestionContext.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MagicSunday\Memories\Service\Indexing\Contract;
 
 use MagicSunday\Memories\Entity\Media;
+use MagicSunday\Memories\Service\Metadata\MetadataQaInspectionResult;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -35,6 +36,8 @@ final readonly class MediaIngestionContext
         private bool $reindexRequired,
         private bool $skipped,
         private ?string $skipMessage,
+        /** @var list<MetadataQaInspectionResult> */
+        private array $qaFindings,
     ) {
     }
 
@@ -62,6 +65,7 @@ final readonly class MediaIngestionContext
             false,
             false,
             null,
+            [],
         );
     }
 
@@ -140,6 +144,14 @@ final readonly class MediaIngestionContext
         return $this->skipMessage;
     }
 
+    /**
+     * @return list<MetadataQaInspectionResult>
+     */
+    public function getQaFindings(): array
+    {
+        return $this->qaFindings;
+    }
+
     public function withDetectedMime(
         string $detectedMime,
         bool $isRaw = false,
@@ -162,6 +174,7 @@ final readonly class MediaIngestionContext
             $this->reindexRequired,
             $this->skipped,
             $this->skipMessage,
+            $this->qaFindings,
         );
     }
 
@@ -183,6 +196,7 @@ final readonly class MediaIngestionContext
             $this->reindexRequired,
             $this->skipped,
             $this->skipMessage,
+            $this->qaFindings,
         );
     }
 
@@ -204,6 +218,7 @@ final readonly class MediaIngestionContext
             $this->reindexRequired,
             $this->skipped,
             $this->skipMessage,
+            $this->qaFindings,
         );
     }
 
@@ -225,6 +240,7 @@ final readonly class MediaIngestionContext
             $reindexRequired,
             $this->skipped,
             $this->skipMessage,
+            $this->qaFindings,
         );
     }
 
@@ -246,6 +262,32 @@ final readonly class MediaIngestionContext
             $this->reindexRequired,
             true,
             $message,
+            $this->qaFindings,
+        );
+    }
+
+    public function withQaFinding(MetadataQaInspectionResult $finding): self
+    {
+        $qaFindings = $this->qaFindings;
+        $qaFindings[] = $finding;
+
+        return new self(
+            $this->filePath,
+            $this->force,
+            $this->dryRun,
+            $this->withThumbnails,
+            $this->strictMime,
+            $this->output,
+            $this->media,
+            $this->detectedMime,
+            $this->detectedRaw,
+            $this->detectedHeic,
+            $this->detectedHevc,
+            $this->checksum,
+            $this->reindexRequired,
+            $this->skipped,
+            $this->skipMessage,
+            $qaFindings,
         );
     }
 }

--- a/src/Service/Metadata/MetadataQaInspectionResult.php
+++ b/src/Service/Metadata/MetadataQaInspectionResult.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/photo-memories.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Memories\Service\Metadata;
+
+use function array_unique;
+use function array_values;
+use function implode;
+
+/**
+ * Value object describing the outcome of metadata QA checks.
+ */
+final readonly class MetadataQaInspectionResult
+{
+    /**
+     * @param list<string> $missingFeatures
+     * @param list<string> $suggestions
+     */
+    private function __construct(
+        private array $missingFeatures,
+        private array $suggestions,
+    ) {
+    }
+
+    public static function none(): self
+    {
+        return new self([], []);
+    }
+
+    /**
+     * @param list<string> $missingFeatures
+     * @param list<string> $suggestions
+     */
+    public static function withIssues(array $missingFeatures, array $suggestions): self
+    {
+        return new self(array_values(array_unique($missingFeatures)), array_values(array_unique($suggestions)));
+    }
+
+    public function hasIssues(): bool
+    {
+        return $this->missingFeatures !== [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getMissingFeatures(): array
+    {
+        return $this->missingFeatures;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSuggestions(): array
+    {
+        return $this->suggestions;
+    }
+
+    public function toLogMessage(): ?string
+    {
+        if (!$this->hasIssues()) {
+            return null;
+        }
+
+        $message = 'Warnung: fehlende Zeit-Features (' . implode(', ', $this->missingFeatures) . ').';
+        if ($this->suggestions !== []) {
+            $message .= ' Empfehlung: ' . implode('; ', $this->suggestions) . '.';
+        }
+
+        return $message;
+    }
+}

--- a/src/Service/Metadata/MetadataQaInspector.php
+++ b/src/Service/Metadata/MetadataQaInspector.php
@@ -13,12 +13,8 @@ namespace MagicSunday\Memories\Service\Metadata;
 
 use DateTimeImmutable;
 use MagicSunday\Memories\Entity\Media;
-use MagicSunday\Memories\Support\IndexLogHelper;
-
+use MagicSunday\Memories\Service\Metadata\MetadataQaInspectionResult;
 use function array_key_exists;
-use function array_unique;
-use function implode;
-use function sprintf;
 
 /**
  * Validates that mandatory time related metadata has been enriched.
@@ -32,7 +28,7 @@ final readonly class MetadataQaInspector
     ) {
     }
 
-    public function inspect(string $filepath, Media $media): void
+    public function inspect(string $filepath, Media $media): MetadataQaInspectionResult
     {
         $features = $media->getFeatures() ?? [];
         $missing  = [];
@@ -65,14 +61,9 @@ final readonly class MetadataQaInspector
         }
 
         if ($missing === []) {
-            return;
+            return MetadataQaInspectionResult::none();
         }
 
-        $message = sprintf('Warnung: fehlende Zeit-Features (%s).', implode(', ', array_unique($missing)));
-        if ($suggestions !== []) {
-            $message .= ' Empfehlung: ' . implode('; ', array_unique($suggestions)) . '.';
-        }
-
-        IndexLogHelper::append($media, $message);
+        return MetadataQaInspectionResult::withIssues($missing, $suggestions);
     }
 }


### PR DESCRIPTION
## Summary
- add a value object that exposes metadata QA inspection findings in a structured way
- store QA findings on the media ingestion context and log them from the time stage
- refresh the inspector unit tests and mark the documentation checklist item as completed

## Testing
- composer ci:test *(fails: existing PHPStan baseline violations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e5048a9ee08323a231658cf004425a