### PR TITLE
Remove legacy algorithm version fallbacks

### DIFF
--- a/src/Service/Clusterer/ClusterPersistenceService.php
+++ b/src/Service/Clusterer/ClusterPersistenceService.php
@@ -464,23 +464,14 @@ final readonly class ClusterPersistenceService implements ClusterPersistenceInte
      */
     private function resolveAlgorithmVersion(array $params): ?string
     {
-        $candidates = [
-            $params['algorithm_version'] ?? null,
-            $params['algorithmVersion'] ?? null,
-            $params['version'] ?? null,
-        ];
+        $value = $params['algorithmVersion'] ?? null;
 
-        $candidate = array_find(
-            $candidates,
-            static fn ($value): bool => (is_string($value) && $value !== '') || is_int($value)
-        );
-
-        if (is_string($candidate)) {
-            return $candidate;
+        if (is_string($value) && $value !== '') {
+            return $value;
         }
 
-        if (is_int($candidate)) {
-            return (string) $candidate;
+        if (is_int($value)) {
+            return (string) $value;
         }
 
         return null;

--- a/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
+++ b/test/Unit/Service/Clusterer/ClusterPersistenceServiceTest.php
@@ -96,7 +96,7 @@ final class ClusterPersistenceServiceTest extends TestCase
         $draft = new ClusterDraft(
             algorithm: 'demo',
             params: [
-                'version'        => '2024.1',
+                'algorithmVersion' => '2024.1',
                 'member_quality' => ['ordered' => [2, 1, 3]],
                 'movement'       => [
                     'segment_count'                               => 4,


### PR DESCRIPTION
## Summary
- drop backward compatibility branches in `ClusterPersistenceService::resolveAlgorithmVersion()` so only `algorithmVersion` is supported
- adjust the persistence service unit test to pass the current parameter name

## Testing
- composer ci:test *(fails: phpstan reports pre-existing analysis violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e52d037f348323b1dda65777624240