### PR TITLE
Improve feed pagination metadata and update documentation

### DIFF
--- a/docs/test-report.md
+++ b/docs/test-report.md
@@ -1,6 +1,6 @@
 # Test Report
 
-Date: 2025-10-06T20:57:03Z
+Date: 2025-10-07T15:26:08Z
 
 ## Command
 
@@ -10,4 +10,4 @@ composer ci:test
 
 ## Result
 
-The test suite failed because PHPStan reported hundreds of type-safety violations while analysing the source directory. See the captured terminal output for the detailed list of errors.
+The aggregate CI run still fails because PHPStan aborts with 897 type-safety violations across multiple cluster and geocoding classes. The error log highlights uninitialised readonly properties as well as redundant type checks reported by level 9 rules.【20521e†L1-L88】【20521e†L214-L232】

--- a/test/Unit/Http/Controller/FeedControllerTest.php
+++ b/test/Unit/Http/Controller/FeedControllerTest.php
@@ -161,9 +161,12 @@ final class FeedControllerTest extends TestCase
 
         self::assertArrayHasKey('meta', $payload);
         $meta = $payload['meta'];
-        self::assertSame(2, $meta['gesamtVerfuegbar']);
+        self::assertSame(1, $meta['gesamtVerfuegbar']);
         self::assertSame(1, $meta['anzahlGeliefert']);
-        self::assertEqualsCanonicalizing(['holiday_event', 'hike_adventure'], $meta['verfuegbareStrategien']);
+        self::assertEqualsCanonicalizing(['holiday_event'], $meta['verfuegbareStrategien']);
+        self::assertArrayHasKey('pagination', $meta);
+        self::assertFalse($meta['pagination']['hatWeitere']);
+        self::assertNull($meta['pagination']['nextCursor']);
     }
 
     public function testFeedFormatsTakenAtWithExifOffset(): void


### PR DESCRIPTION
## Summary
- ensure the feed meta data reports counts, pagination cursors, and available strategies based on the filtered result set
- extend the feed controller unit test to cover the new pagination metadata contract
- refresh the feed controller UX report and the CI test report to document the new behaviour and current phpstan status

## Testing
- composer ci:test *(fails: phpstan reports existing baseline issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e53005c4a083239599b2d3d245c88d