### PR TITLE
Improve geocoding type safety for phpstan

### DIFF
--- a/src/Service/Geocoding/DefaultLocationRefreshProcessor.php
+++ b/src/Service/Geocoding/DefaultLocationRefreshProcessor.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function count;
 use function function_exists;
 use function is_array;
+use function is_string;
 use function iterator_to_array;
 use function mb_strimwidth;
 use function preg_replace;
@@ -163,7 +164,10 @@ final readonly class DefaultLocationRefreshProcessor implements LocationRefreshP
 
     private function formatProgressLabel(string $label): string
     {
-        $normalized = preg_replace('/\s+/u', ' ', trim($label)) ?? $label;
+        $normalized = preg_replace('/\s+/u', ' ', trim($label));
+        if (!is_string($normalized) || $normalized === '') {
+            $normalized = $label;
+        }
 
         if (function_exists('mb_strimwidth')) {
             return mb_strimwidth($normalized, 0, 70, '…', 'UTF-8');

--- a/src/Service/Geocoding/DefaultPoiUpdateProcessor.php
+++ b/src/Service/Geocoding/DefaultPoiUpdateProcessor.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function count;
 use function function_exists;
 use function is_array;
+use function is_string;
 use function iterator_to_array;
 use function mb_strimwidth;
 use function preg_replace;
@@ -106,7 +107,10 @@ final readonly class DefaultPoiUpdateProcessor implements PoiUpdateProcessorInte
 
     private function formatProgressLabel(string $label): string
     {
-        $normalized = preg_replace('/\s+/u', ' ', trim($label)) ?? $label;
+        $normalized = preg_replace('/\s+/u', ' ', trim($label));
+        if (!is_string($normalized) || $normalized === '') {
+            $normalized = $label;
+        }
 
         if (function_exists('mb_strimwidth')) {
             return mb_strimwidth($normalized, 0, 70, '…', 'UTF-8');

--- a/src/Service/Geocoding/LocationCellIndex.php
+++ b/src/Service/Geocoding/LocationCellIndex.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use MagicSunday\Memories\Entity\Location;
 
+use function is_int;
+use function is_string;
+
 /**
  * Lightweight cell -> Location index backed by the DB.
  * Speeds up reverse-geocoding by reusing known Locations for a cell.
@@ -49,11 +52,23 @@ final class LocationCellIndex
 
         $n = 0;
         foreach ($it as $row) {
-            $cell = (string) $row['cell'];
-            if ($cell !== '' && !isset($this->cellToId[$cell])) {
-                $this->cellToId[$cell] = (int) $row['id'];
-                ++$n;
+            $cell = $row['cell'] ?? null;
+            $id   = $row['id'] ?? null;
+
+            if (!is_string($cell) || $cell === '' || isset($this->cellToId[$cell])) {
+                continue;
             }
+
+            if (!is_int($id)) {
+                continue;
+            }
+
+            if ($id <= 0) {
+                continue;
+            }
+
+            $this->cellToId[$cell] = $id;
+            ++$n;
         }
 
         return $n;

--- a/src/Service/Geocoding/LocationRefreshProcessorInterface.php
+++ b/src/Service/Geocoding/LocationRefreshProcessorInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Geocoding;
 
+use MagicSunday\Memories\Entity\Location;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -18,5 +19,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 interface LocationRefreshProcessorInterface
 {
+    /**
+     * @param iterable<Location> $locations
+     */
     public function process(iterable $locations, bool $refreshPois, bool $dryRun, OutputInterface $output): LocationRefreshSummary;
 }

--- a/src/Service/Geocoding/LocationResolver.php
+++ b/src/Service/Geocoding/LocationResolver.php
@@ -283,7 +283,7 @@ final class LocationResolver implements PoiEnsurerInterface
         $location->setStale(false);
     }
 
-    private function resolveRefreshedAt(GeocodeResult $geocode): ?DateTimeImmutable
+    private function resolveRefreshedAt(GeocodeResult $geocode): DateTimeImmutable
     {
         if ($geocode->refreshedAt instanceof DateTimeImmutable) {
             return $geocode->refreshedAt;

--- a/src/Service/Geocoding/MediaGeocodingProcessorInterface.php
+++ b/src/Service/Geocoding/MediaGeocodingProcessorInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Geocoding;
 
+use MagicSunday\Memories\Entity\Media;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -18,6 +19,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 interface MediaGeocodingProcessorInterface
 {
+    /**
+     * @param iterable<Media> $media
+     */
     public function process(
         iterable $media,
         bool $refreshPois,

--- a/src/Service/Geocoding/MediaLocationLinker.php
+++ b/src/Service/Geocoding/MediaLocationLinker.php
@@ -14,6 +14,8 @@ namespace MagicSunday\Memories\Service\Geocoding;
 use MagicSunday\Memories\Entity\Location;
 use MagicSunday\Memories\Entity\Media;
 
+use function array_filter;
+use function array_values;
 use function count;
 use function explode;
 use function floor;
@@ -153,8 +155,11 @@ final class MediaLocationLinker implements MediaLocationLinkerInterface
 
         $normalized = str_replace('_', '-', $trimmed);
         $normalized = explode('.', $normalized, 2)[0];
-        $parts      = explode('-', $normalized);
-        $count      = count($parts);
+        $parts = array_values(array_filter(
+            explode('-', $normalized),
+            static fn (string $part): bool => $part !== ''
+        ));
+        $count = count($parts);
 
         if ($count === 0) {
             return 'de';
@@ -167,11 +172,6 @@ final class MediaLocationLinker implements MediaLocationLinkerInterface
         }
 
         $header = implode('-', $parts);
-
-        if ($header === '') {
-            return 'de';
-        }
-
         return $header;
     }
 }

--- a/src/Service/Geocoding/NominatimReverseGeocoder.php
+++ b/src/Service/Geocoding/NominatimReverseGeocoder.php
@@ -160,7 +160,7 @@ final readonly class NominatimReverseGeocoder implements ReverseGeocoderInterfac
             MediaMath::haversineDistanceInMeters($lat, $lon, $lat, $west),
         ];
 
-        $radius = (float) max($distances);
+        $radius = max($distances);
 
         return $radius > 0.0 ? $radius : null;
     }

--- a/src/Service/Geocoding/OverpassElementFilter.php
+++ b/src/Service/Geocoding/OverpassElementFilter.php
@@ -22,6 +22,11 @@ use function is_string;
  */
 final class OverpassElementFilter implements OverpassElementFilterInterface
 {
+    /**
+     * @param array<string, mixed> $element
+     *
+     * @return array{id: string, lat: float, lon: float, tags: array<string, mixed>}|null
+     */
     public function filter(array $element): ?array
     {
         $id = $this->elementId($element);
@@ -47,6 +52,9 @@ final class OverpassElementFilter implements OverpassElementFilterInterface
         ];
     }
 
+    /**
+     * @param array<string, mixed> $element
+     */
     private function elementId(array $element): ?string
     {
         $type = $element['type'] ?? null;

--- a/src/Utility/DefaultPoiLabelResolver.php
+++ b/src/Utility/DefaultPoiLabelResolver.php
@@ -62,12 +62,16 @@ final class DefaultPoiLabelResolver implements PoiLabelResolverInterface
     }
 
     /**
-     * @param array{default:string|null,localized:array<string,string>,alternates:list<string>} $names
+     * @param array{default:string|null,localized?:array<string,string>|null,alternates?:list<string>|null} $names
      */
     private function labelFromNames(array $names): ?string
     {
         $localized = $names['localized'] ?? [];
-        if (is_array($localized) && $localized !== []) {
+        if (!is_array($localized)) {
+            $localized = [];
+        }
+
+        if ($localized !== []) {
             $preferredLocaleValue = null;
             $preferredLocaleKey   = array_find(
                 $this->preferredLocaleKeys,
@@ -94,27 +98,27 @@ final class DefaultPoiLabelResolver implements PoiLabelResolverInterface
             return $default;
         }
 
-        if (is_array($localized)) {
-            $firstLocalized = array_find(
-                $localized,
-                static fn ($value): bool => is_string($value) && $value !== ''
-            );
+        $firstLocalized = array_find(
+            $localized,
+            static fn (string $value): bool => $value !== ''
+        );
 
-            if (is_string($firstLocalized)) {
-                return $firstLocalized;
-            }
+        if (is_string($firstLocalized)) {
+            return $firstLocalized;
         }
 
         $alternates = $names['alternates'] ?? [];
-        if (is_array($alternates)) {
-            $firstAlternate = array_find(
-                $alternates,
-                static fn ($alternate): bool => is_string($alternate) && $alternate !== ''
-            );
+        if (!is_array($alternates)) {
+            $alternates = [];
+        }
 
-            if (is_string($firstAlternate)) {
-                return $firstAlternate;
-            }
+        $firstAlternate = array_find(
+            $alternates,
+            static fn (string $alternate): bool => $alternate !== ''
+        );
+
+        if (is_string($firstAlternate)) {
+            return $firstAlternate;
         }
 
         return null;

--- a/src/Utility/DefaultPoiNormalizer.php
+++ b/src/Utility/DefaultPoiNormalizer.php
@@ -66,7 +66,7 @@ final class DefaultPoiNormalizer implements PoiNormalizerInterface
     }
 
     /**
-     * @param array{default:string|null,localized:array<string,string>,alternates:list<string>}|null $raw
+     * @param array{default:string|null,localized?:array<string,string>|null,alternates?:list<string>|null}|null $raw
      *
      * @return array{default:string|null,localized:array<string,string>,alternates:list<string>}
      */
@@ -83,39 +83,43 @@ final class DefaultPoiNormalizer implements PoiNormalizerInterface
             }
 
             $rawLocalized = $raw['localized'] ?? [];
-            if (is_array($rawLocalized)) {
-                foreach ($rawLocalized as $locale => $value) {
-                    if (!is_string($locale)) {
-                        continue;
-                    }
+            if (!is_array($rawLocalized)) {
+                $rawLocalized = [];
+            }
 
-                    $locale = strtolower(str_replace(' ', '_', $locale));
-                    if ($locale === '') {
-                        continue;
-                    }
-
-                    if (!is_string($value) || $value === '') {
-                        continue;
-                    }
-
-                    $localized[$locale] = $value;
+            foreach ($rawLocalized as $locale => $value) {
+                if (!is_string($locale)) {
+                    continue;
                 }
+
+                $locale = strtolower(str_replace(' ', '_', $locale));
+                if ($locale === '') {
+                    continue;
+                }
+
+                if (!is_string($value) || $value === '') {
+                    continue;
+                }
+
+                $localized[$locale] = $value;
             }
 
             $rawAlternates = $raw['alternates'] ?? [];
-            if (is_array($rawAlternates)) {
-                foreach ($rawAlternates as $alternate) {
-                    if (!is_string($alternate)) {
-                        continue;
-                    }
+            if (!is_array($rawAlternates)) {
+                $rawAlternates = [];
+            }
 
-                    $trimmed = trim($alternate);
-                    if ($trimmed === '') {
-                        continue;
-                    }
-
-                    $alternates[$trimmed] = true;
+            foreach ($rawAlternates as $alternate) {
+                if (!is_string($alternate)) {
+                    continue;
                 }
+
+                $trimmed = trim($alternate);
+                if ($trimmed === '') {
+                    continue;
+                }
+
+                $alternates[$trimmed] = true;
             }
         }
 
@@ -145,7 +149,7 @@ final class DefaultPoiNormalizer implements PoiNormalizerInterface
 
         $localized = array_find(
             $names['localized'],
-            static fn ($value): bool => is_string($value) && $value !== ''
+            static fn (string $value): bool => $value !== ''
         );
         if (is_string($localized)) {
             return $localized;
@@ -153,7 +157,7 @@ final class DefaultPoiNormalizer implements PoiNormalizerInterface
 
         $alternate = array_find(
             $names['alternates'],
-            static fn ($value): bool => is_string($value) && $value !== ''
+            static fn (string $value): bool => $value !== ''
         );
         if (is_string($alternate)) {
             return $alternate;

--- a/src/Utility/DefaultPoiScorer.php
+++ b/src/Utility/DefaultPoiScorer.php
@@ -14,7 +14,6 @@ namespace MagicSunday\Memories\Utility;
 use MagicSunday\Memories\Utility\Contract\PoiScoringStrategyInterface;
 
 use function floor;
-use function is_string;
 
 /**
  * Applies the default POI weighting heuristics.
@@ -81,10 +80,6 @@ final class DefaultPoiScorer implements PoiScoringStrategyInterface
         }
 
         foreach ($poi['tags'] as $tagKey => $tagValue) {
-            if (!is_string($tagValue)) {
-                continue;
-            }
-
             $score += self::POI_TAG_WEIGHTS[$tagKey] ?? 0;
             $score += self::POI_TAG_VALUE_BONUS[$tagKey . ':' . $tagValue] ?? 0;
         }


### PR DESCRIPTION
## Summary
- tighten iterable documentation for the geocoding processors and normalize progress label formatting
- harden location cell indexing and POI enrichment by validating numeric data before reuse
- clean up POI helper utilities to rely on typed arrays instead of redundant guards

## Testing
- `composer ci:test` *(fails: phpstan still reports existing high-volume level-9 findings)*

------
https://chatgpt.com/codex/tasks/task_e_68e5325858e083238740f1f2aa769c21