### PR TITLE
Add slideshow storyboard metadata and configurable audio

### DIFF
--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -311,3 +311,12 @@ parameters:
     memories.slideshow.ffmpeg_path: 'ffmpeg'
     memories.slideshow.php_binary_default: 'php'
     memories.slideshow.php_binary: "%env(default:memories.slideshow.php_binary_default:MEMORIES_PHP_BINARY)%"
+    memories.slideshow.transitions:
+        - 'fade'
+        - 'wipeleft'
+        - 'wiperight'
+        - 'circleopen'
+        - 'circleclose'
+        - 'pixelize'
+    memories.slideshow.music_path_default: ''
+    memories.slideshow.music_path: "%env(default:memories.slideshow.music_path_default:MEMORIES_SLIDESHOW_MUSIC)%"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -91,6 +91,8 @@ services:
             $transitionDuration: '%memories.slideshow.transition_duration_s%'
             $width: '%memories.slideshow.video_width%'
             $height: '%memories.slideshow.video_height%'
+            $transitions: '%memories.slideshow.transitions%'
+            $audioTrack: '%memories.slideshow.music_path%'
 
     MagicSunday\Memories\Service\Slideshow\SlideshowVideoGeneratorInterface:
         alias: MagicSunday\Memories\Service\Slideshow\SlideshowVideoGenerator
@@ -102,7 +104,10 @@ services:
             $videoDirectory: '%memories.slideshow.video_dir%'
             $projectDirectory: '%kernel.project_dir%'
             $slideDuration: '%memories.slideshow.image_duration_s%'
+            $transitionDuration: '%memories.slideshow.transition_duration_s%'
             $phpBinary: '%memories.slideshow.php_binary%'
+            $transitions: '%memories.slideshow.transitions%'
+            $musicTrack: '%memories.slideshow.music_path%'
 
     MagicSunday\Memories\Service\Slideshow\SlideshowVideoManagerInterface:
         alias: MagicSunday\Memories\Service\Slideshow\SlideshowVideoManager
@@ -1100,6 +1105,10 @@ services:
             $defaultCoverWidth: '%memories.http.feed.cover_width%'
             $defaultMemberWidth: '%memories.http.feed.member_width%'
             $maxThumbnailWidth: '%memories.http.feed.max_thumbnail_width%'
+            $slideshowImageDuration: '%memories.slideshow.image_duration_s%'
+            $slideshowTransitionDuration: '%memories.slideshow.transition_duration_s%'
+            $slideshowTransitions: '%memories.slideshow.transitions%'
+            $slideshowMusic: '%memories.slideshow.music_path%'
             $thumbnailService: '@MagicSunday\Memories\Service\Thumbnail\ThumbnailServiceInterface'
             $entityManager: '@Doctrine\ORM\EntityManagerInterface'
             $profileProvider: '@MagicSunday\Memories\Service\Feed\FeedPersonalizationProfileProvider'

--- a/docs/ios-google-like-rueckblicke-aufgaben.md
+++ b/docs/ios-google-like-rueckblicke-aufgaben.md
@@ -6,8 +6,8 @@
 - [x] Parameter für personalisierte Schwellenwerte in `config/parameters.yaml` vorbereiten: Gewichtungen, Score-Schwellen und Profilkatalog sind zentral konfigurierbar und werden vom `FeedPersonalizationProfileProvider` an den Feed übergeben.【F:config/parameters.yaml†L233-L282】【F:config/services.yaml†L1044-L1075】【F:src/Service/Feed/FeedPersonalizationProfileProvider.php†L17-L86】
 
 ## 2. Storytelling-Erlebnis aufwerten
-- Storyboards aus dem JSON-Feed ableiten und in Slideshow-Generierung sowie UI integrieren.
-- Konfigurierbare Musik-, Übergangs- und Dauerparameter definieren.
+- [x] Storyboards aus dem JSON-Feed ableiten und in Slideshow-Generierung sowie UI integrieren: `FeedController` liefert jetzt einen `storyboard`-Block mit Folieninformationen, Übergängen, Dauer- und Kontextangaben, während `SlideshowVideoManager` und `SlideshowVideoGenerator` dieselben Daten für die Videoerstellung nutzen.【F:src/Http/Controller/FeedController.php†L312-L392】【F:src/Service/Slideshow/SlideshowVideoManager.php†L41-L139】【F:src/Service/Slideshow/SlideshowVideoGenerator.php†L39-L269】
+- [x] Konfigurierbare Musik-, Übergangs- und Dauerparameter definieren: Sämtliche Werte werden nun über `config/parameters.yaml` gesteuert und in Services injiziert; FFMPEG greift optional auf eine konfigurierte Audiodatei zu.【F:config/parameters.yaml†L306-L316】【F:config/services.yaml†L90-L118】【F:src/Service/Slideshow/SlideshowVideoGenerator.php†L39-L269】
 - Automatische Titel- und Beschreibungsgenerierung mit POI- und Personeninformationen implementieren.
 - Lokalisierung für generierte Texte vorbereiten.
 


### PR DESCRIPTION
## Summary
- expose slideshow timing, transition and audio configuration via new parameters and service wiring
- enrich feed responses with storyboard metadata and persist the same information for slideshow jobs including optional music
- update ffmpeg generator to honour per-slide durations/transitions and include audio, plus add coverage for the new job serialization
- document the completed storyboard backlog items for the Rückblicke feature

## Testing
- `composer ci:test` *(fails: phpstan still reports pre-existing 800+ level-9 issues; see output)*

------
https://chatgpt.com/codex/tasks/task_e_68e550f595808323b3da6ac5ca9353fe