### PR TITLE
Ensure deterministic vacation cluster ordering

### DIFF
--- a/docs/vacation-clusterer-review.md
+++ b/docs/vacation-clusterer-review.md
@@ -1,0 +1,24 @@
+# Bewertung der Vacation-Clusterer-Strategie
+
+## Zusammenfassung
+Die aktuelle `VacationClusterStrategy` ist gut modularisiert und delegiert jede Fachaufgabe an spezialisierte Kollaboratoren (Home-Ermittlung, Tagesstatistiken, Segment-Erkennung). Dadurch bleibt der Strategiekern schlank und leicht testbar. Die umfangreichen Unit-Tests simulieren komplexe Ferienreisen und stellen sicher, dass die Pipeline aus Heimaterkennung, Tageszusammenfassung und Segmentierung zusammenspielt.
+
+## Identifizierte Stärken
+- **Klare Verantwortlichkeiten:** Die Strategie kapselt nur den Kontrollfluss und verlässt sich auf wohl definierte Interfaces (`HomeLocatorInterface`, `DaySummaryBuilderInterface`, `VacationSegmentAssemblerInterface`).
+- **Robuste Filter:** Über das `MediaFilterTrait` werden unbrauchbare Medien (ohne Zeitstempel, Low-Quality, No-Show) früh entfernt, wodurch spätere Schritte weniger Sonderfälle behandeln müssen.
+- **Frühe Abbruchbedingungen:** Falls Zeitstempel fehlen, kein Zuhause ermittelt werden kann oder keine Tageszusammenfassungen entstehen, liefert die Strategie deterministisch ein leeres Ergebnis statt instabiler Cluster.
+- **Hohe Testabdeckung:** Die bestehende Testsuite deckt verschiedenste Urlaubsszenarien ab (internationale Reisen, GPS-Ausreißer, fehlende Heimatbasis) und dokumentiert die Erwartungen an Score-Parameter.
+
+## Verbesserungsmöglichkeiten
+- **Deterministische Sortierung:** `usort` ist nicht stabil. Bei identischen Zeitstempeln konnte die Reihenfolge variieren, was sich auf Tagesgruppen, Score-Berechnung und Cover-Auswahl auswirkte. Lösung: eine chronologische Sortier-Hilfsfunktion mit Pfad-Fallback, damit gleiche Zeitstempel reproduzierbar bleiben.
+- **Sichtbarkeit der Vorverarbeitung:** Ein dedizierter Sortier-Helper verbessert die Lesbarkeit und ermöglicht gezieltere Tests (siehe neue Unit-Tests).
+- **Testabdeckung für Randfälle:** Ein zusätzlicher Unit-Test prüft nun, dass sowohl der Day-Summary-Builder als auch der Segment-Assembler die deterministisch sortierte Medienliste erhalten. Damit werden Regressionsrisiken minimiert.
+- **Beobachtbarkeit (Ausblick):** Perspektivisch könnten strukturierte Debug-Logs oder Telemetriehaken helfen, fehlerhafte Segmentierungen schneller zu analysieren.
+- **Konfigurierbarkeit (Ausblick):** Einige Grenzwerte (z. B. Mindestanzahl an Tagen oder Medien pro Segment) könnten über Parameter extern steuerbar gemacht werden, um ohne Codeänderung auf unterschiedliche Bibliotheken reagieren zu können.
+
+## Ergebnis der Umsetzung
+- Neue Hilfsmethode `sortChronologically()` in `VacationClusterStrategy` sorgt für eine stabile, nachvollziehbare Reihenfolge der Medien und wird überall in der Pipeline verwendet.
+- Ein gezielter Unit-Test stellt sicher, dass die Reihenfolge in allen nachgelagerten Komponenten ankommt.
+- Diese Anpassungen reduzieren flüchtige Clusterergebnisse und unterstützen reproduzierbare Score-Berechnungen.
+
+Weitere Optimierungen (z. B. Logging, konfigurierbare Grenzwerte, Performance-Metriken) können schrittweise ergänzt werden, ohne die aktuelle Architektur aufzubrechen.


### PR DESCRIPTION
## Summary
- add a chronological sort helper with deterministic tie-breaking to `VacationClusterStrategy`
- extend the vacation cluster strategy test suite to cover the ordering behaviour
- document the current vacation clusterer implementation strengths and follow-up improvements

## Testing
- composer ci:test *(fails: phpstan currently reports existing type-check violations in unrelated services)*

------
https://chatgpt.com/codex/tasks/task_e_68e56f5df91c8323bff407b3d79348f0