### PR TITLE
Fix cluster helper aggregation and simplify thumbnail resolver

### DIFF
--- a/src/Clusterer/Support/ClusterBuildHelperTrait.php
+++ b/src/Clusterer/Support/ClusterBuildHelperTrait.php
@@ -33,7 +33,6 @@ use const PHP_INT_MAX;
  */
 trait ClusterBuildHelperTrait
 {
-    private ClusterPeopleAggregator $peopleAggregator;
 
     /**
      * @param list<Media> $members
@@ -247,10 +246,13 @@ trait ClusterBuildHelperTrait
      */
     private function buildPeopleParams(array $members): array
     {
-        if (!isset($this->peopleAggregator)) {
-            $this->peopleAggregator = new ClusterPeopleAggregator();
+        /** @var ClusterPeopleAggregator|null $peopleAggregator */
+        static $peopleAggregator = null;
+
+        if ($peopleAggregator === null) {
+            $peopleAggregator = new ClusterPeopleAggregator();
         }
 
-        return $this->peopleAggregator->buildParams($members);
+        return $peopleAggregator->buildParams($members);
     }
 }

--- a/src/Service/Feed/ThumbnailPathResolver.php
+++ b/src/Service/Feed/ThumbnailPathResolver.php
@@ -38,6 +38,7 @@ final class ThumbnailPathResolver
 
         /** @var array<int, string> $bySize */
         $bySize = [];
+        /** @var list<string> $fallbackPaths */
         $fallbackPaths = [];
 
         foreach ($thumbs as $key => $path) {
@@ -51,8 +52,9 @@ final class ThumbnailPathResolver
                 continue;
             }
 
-            if (is_string($key) && ctype_digit($key)) {
-                $bySize[(int) $key] = $path;
+            $keyString = (string) $key;
+            if (ctype_digit($keyString)) {
+                $bySize[(int) $keyString] = $path;
 
                 continue;
             }
@@ -79,7 +81,7 @@ final class ThumbnailPathResolver
             }
 
             $first = reset($bySize);
-            if (is_string($first) && is_file($first)) {
+            if ($first !== false && is_file($first)) {
                 return $first;
             }
 


### PR DESCRIPTION
## Summary
- reuse a static `ClusterPeopleAggregator` within `ClusterBuildHelperTrait` so readonly strategies no longer mutate uninitialised helper properties at runtime
- streamline `ThumbnailPathResolver` key handling and document fallback list typing to reduce redundant guards

## Testing
- composer ci:test:php:lint

------
https://chatgpt.com/codex/tasks/task_e_68e624434fa88323ab6ed7a859bf6783