### PR TITLE
refactor: expose structured metadata sections via properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ Mehrere Werte können wie bisher kommasepariert oder als wiederholte `--types`-O
 - Einzelne Schritte: `composer ci:test:php:lint`, `composer ci:test:php:phpstan`, `composer ci:test:php:unit` usw.
 - Frontend-E2E: `npm run test:e2e` bzw. `make web-test` startet Playwright.
 
+### Strukturierte Metadaten per Property-Chain
+
+- PHPUnit 12 verzichtet auf Getter-Aufrufe in Assertions. Strukturierte EXIF-Metadaten (Versionen 1.0–3.0) werden direkt über Property-Chains geprüft.
+- Tests und Snapshots behalten ihre bestehenden Fixtures bei; nur die Zugriffe wechseln auf `\$meta->…->…`.
+
+```php
+\$factory = new StructuredMetadataFactory();
+\$meta = \$factory->create(\$media);
+
+self::assertSame('Canon EOS R6', \$meta->camera->summary);
+self::assertSame('1/100 s', \$meta->exposure->exposure_text);
+self::assertSame('2024-10-05T12:34:56+00:00', \$meta->derived->taken_at);
+```
+
 ### Erinnerungs-Fixtures & Cluster-Integration
 
 - Unter `fixtures/memories/<dataset>/` liegen kuratierte Datensätze inklusive `metadata.json`, SVG-Vorschaubildern (`*.svg`, viewBox 64×64)

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,8 @@
+# Upgrade guide
+
+## PHPUnit 12 structured metadata assertions
+
+- **Breaking change:** `MagicSunday\\Memories\\Service\\Metadata\\StructuredMetadataSection::get()` has been removed. Sections expose their values as read-only properties to align with PHPUnit 12's property assertions.
+- Adjust custom tests and scripts to access values via property chains (e.g. `$meta->camera->summary`, `$meta->exposure->aperture_text`).
+- Snapshot and fixture suites for EXIF metadata versions 1.0 through 3.0 remain unchanged; only the access pattern within assertions shifts to the new property syntax (`$meta->…->…`).
+- When porting legacy assertions, verify that nullable keys still resolve to `null` and that list-valued keys return arrays identical to their stored snapshots.

--- a/src/Service/Metadata/StructuredMetadataSection.php
+++ b/src/Service/Metadata/StructuredMetadataSection.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MagicSunday\Memories\Service\Metadata;
 
+use function array_key_exists;
 use function is_array;
 use function is_bool;
 use function is_float;
@@ -65,9 +66,14 @@ final readonly class StructuredMetadataSection
     /**
      * @return SectionValue|null
      */
-    public function get(string $key): array|bool|float|int|string|null
+    public function __get(string $key): array|bool|float|int|string|null
     {
         return $this->values[$key] ?? null;
+    }
+
+    public function __isset(string $key): bool
+    {
+        return array_key_exists($key, $this->values);
     }
 
     /**

--- a/test/Unit/Service/Metadata/StructuredMetadataFactoryTest.php
+++ b/test/Unit/Service/Metadata/StructuredMetadataFactoryTest.php
@@ -69,19 +69,19 @@ final class StructuredMetadataFactoryTest extends TestCase
         $factory = new StructuredMetadataFactory();
         $metadata = $factory->create($media);
 
-        self::assertSame('Canon RF 24-70mm 24-70mm f/2.8L', $metadata->lens->get('summary'));
-        self::assertSame('Canon EOS R6', $metadata->camera->get('summary'));
-        self::assertSame('4000 × 3000', $metadata->image->get('dimensions'));
-        self::assertSame('90° gedreht', $metadata->image->get('orientation_label'));
-        self::assertSame('35 mm', $metadata->exposure->get('focal_length_text'));
-        self::assertSame('f/2.8', $metadata->exposure->get('aperture_text'));
-        self::assertSame('1/100 s', $metadata->exposure->get('exposure_text'));
-        self::assertSame('Blitz ausgelöst', $metadata->exposure->get('flash_text'));
-        self::assertSame('48.137154, 11.576124', $metadata->gps->get('coordinates'));
-        self::assertSame('abcdef1234567890abcdef1234567890', $metadata->preview->get('phash'));
-        self::assertSame('2024-10-05T12:34:56+00:00', $metadata->derived->get('taken_at'));
-        self::assertSame('Europe/Berlin', $metadata->derived->get('timezone'));
-        self::assertSame('photo', $metadata->derived->get('content_kind'));
-        self::assertSame(12.5, $metadata->derived->get('distance_km_from_home'));
+        self::assertSame('Canon RF 24-70mm 24-70mm f/2.8L', $metadata->lens->summary);
+        self::assertSame('Canon EOS R6', $metadata->camera->summary);
+        self::assertSame('4000 × 3000', $metadata->image->dimensions);
+        self::assertSame('90° gedreht', $metadata->image->orientation_label);
+        self::assertSame('35 mm', $metadata->exposure->focal_length_text);
+        self::assertSame('f/2.8', $metadata->exposure->aperture_text);
+        self::assertSame('1/100 s', $metadata->exposure->exposure_text);
+        self::assertSame('Blitz ausgelöst', $metadata->exposure->flash_text);
+        self::assertSame('48.137154, 11.576124', $metadata->gps->coordinates);
+        self::assertSame('abcdef1234567890abcdef1234567890', $metadata->preview->phash);
+        self::assertSame('2024-10-05T12:34:56+00:00', $metadata->derived->taken_at);
+        self::assertSame('Europe/Berlin', $metadata->derived->timezone);
+        self::assertSame('photo', $metadata->derived->content_kind);
+        self::assertSame(12.5, $metadata->derived->distance_km_from_home);
     }
 }

--- a/test/Unit/Service/Metadata/StructuredMetadataTest.php
+++ b/test/Unit/Service/Metadata/StructuredMetadataTest.php
@@ -35,10 +35,10 @@ final class StructuredMetadataTest extends TestCase
             'image' => 'not-an-array',
         ]);
 
-        self::assertSame('Canon', $metadata->lens->get('make'));
-        self::assertSame(123456, $metadata->lens->get('serial'));
-        self::assertSame([true, false, 42, 'value', null], $metadata->lens->get('flags'));
-        self::assertNull($metadata->lens->get('ignored'));
+        self::assertSame('Canon', $metadata->lens->make);
+        self::assertSame(123456, $metadata->lens->serial);
+        self::assertSame([true, false, 42, 'value', null], $metadata->lens->flags);
+        self::assertNull($metadata->lens->ignored);
 
         self::assertFalse($metadata->camera->isEmpty());
         self::assertSame(['owner' => null], $metadata->camera->toArray());


### PR DESCRIPTION
### Summary of property-chain migration
- expose `StructuredMetadataSection` values as read-only properties to support PHPUnit 12 property assertions
- update structured metadata unit coverage to rely on `$meta->…->…` chains while keeping existing fixtures intact
- document the property-based access pattern in the README and the new `docs/UPGRADE.md`

### Testing
- `php vendor/bin/phpunit --configuration .build/phpunit.xml --filter StructuredMetadata`

M# Sweep — Verify compliance for this milestone
- [ ] QA: Tests documented above
- [ ] QA: Coverage requirements satisfied


------
https://chatgpt.com/codex/tasks/task_e_69051a8b0f848323bfc7b19bbc0de8e5