### PR TITLE
Harden CI checkout with persist-credentials: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+                with:
+                    persist-credentials: false
 
             -   name: Set up PHP version ${{ matrix.php }}
                 uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2


### PR DESCRIPTION
Addresses magicsunday/.github#1 (zizmor `artipacked`).

Sets `persist-credentials: false` on the `actions/checkout` step in `ci.yml`. This workflow has no downstream step that needs the job token (no `git push`, no private-VCS `composer install`), so dropping the persisted credential is safe.

Verified: YAML parses, `actionlint` adds no new finding, only `ci.yml` changes.