### PR TITLE
Pin the action version comments to the exact released tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - name: Set up PHP version ${{ matrix.php }}
-              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2


### PR DESCRIPTION
zizmor `ref-version-mismatch` flagged the floating major-tag comments (e.g. `# v6`, `# v2`, `# v5`) on the hash-pinned actions. The SHAs are correct; only the comments pointed at moving major tags.

Repoint each comment at the exact release its SHA resolves to, so the comment stays in sync with the pin and Dependabot mirrors the exact version on future bumps. No behaviour change — comment-only.